### PR TITLE
Update Cargo.toml

### DIFF
--- a/crates/vitte-cli/Cargo.toml
+++ b/crates/vitte-cli/Cargo.toml
@@ -1,13 +1,26 @@
+[package]
+name = "vitte-cli"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Command-line interface for the Vitte language"
+repository = "https://github.com/ton-org/vitte"
+readme = "../../README.md"
+categories = ["command-line-utilities", "development-tools"]
+keywords = ["vitte", "cli", "language"]
+# publish=false si c'est interne au mono-repo
+# publish = false
+
 [dependencies]
 anyhow = "1"
-clap = { version = "4", features = ["derive"] }
-serde = { version = "1", features = ["derive"] }
-toml = "0.8"
 camino = "1"
+clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6"
 env_logger = "0.11"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
 
-# Ces trois-là sont optionnels (activés par features)
+# Optionnels (activés par features)
 vitte-core = { path = "../vitte-core", optional = true }
 vitte-compiler = { path = "../vitte-compiler", optional = true }
 vitte-vm = { path = "../vitte-vm", optional = true }
@@ -17,3 +30,9 @@ default = []
 core = ["vitte-core"]
 compiler = ["core", "vitte-compiler"]
 vm = ["core", "vitte-vm"]
+
+# Facultatif : binaire installé sous le nom "vitte"
+[[bin]]
+name = "vitte"
+path = "src/main.rs"
+


### PR DESCRIPTION
fix(vitte-cli): convertir le manifest virtuel en paquet réel + débloquer cargo metadata

- Ajoute [package] (name/version/edition/licence/metadata)
- Déclare la cible [[bin]] "vitte" (src/main.rs)
- Conserve [features] (core/compiler/vm) et deps optionnelles
- Supprime l’ambiguïté "virtual manifest + [dependencies]"

Contexte: `cargo fmt --all -- --check` échouait car `cargo metadata` lisait
`crates/vitte-cli/Cargo.toml` comme manifest virtuel, ce qui est interdit avec
une section [dependencies].

Refs: CI lint rustfmt/clippy
