### PR TITLE
Update rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,4 @@
-# .rustfmt.toml — Style maison : net, cohérent, CI-friendly
-# 👉 100 colonnes, imports rangés, commentaires wrap, et commas traînantes (diffs propres)
+# .rustfmt.toml — Stable-safe (Rust 1.80)
 
 # ——— Base ———
 edition = "2021"
@@ -7,12 +6,12 @@ max_width = 100
 hard_tabs = false
 tab_spaces = 4
 newline_style = "Unix"
-use_small_heuristics = "Max"   # place le plus possible sur une ligne (sans casser la lisibilité)
+use_small_heuristics = "Max"
 
 # ——— Imports & modules ———
 reorder_imports = true
-imports_granularity = "Crate"      # "Module" si tu veux regrouper par module, "Item" pour le plus fin
-group_imports = "StdExternalCrate" # std | extern | crate/local
+imports_granularity = "Crate"      # "Module" ou "Item" au besoin
+group_imports = "StdExternalCrate" # groupe: std | extern | crate/local
 reorder_modules = true
 
 # ——— Commentaires & docs ———
@@ -23,13 +22,11 @@ normalize_doc_attributes = true
 
 # ——— Macros ———
 format_macro_bodies = true
-format_macro_matchers = true
+# (format_macro_matchers retiré: parfois instable selon versions)
 
-# ——— Virgules, pipes & opérateurs ———
-trailing_comma = "Vertical"      # moins de diffs quand on ajoute des éléments
-match_block_trailing_comma = true
-match_arm_leading_pipes = "Always"
-binop_separator = "Front"        # opérateurs en début de ligne sur les expressions longues
+# ——— Virgules & opérateurs ———
+trailing_comma = "Vertical"
+# (match_block_trailing_comma / match_arm_leading_pipes / binop_separator retirés pour compat stable)
 
 # ——— Blancs ———
 blank_lines_upper_bound = 2
@@ -39,11 +36,11 @@ blank_lines_lower_bound = 0
 hex_literal_case = "Lower"
 spaces_around_ranges = false
 
-# ——— Alignements (garder sobre) ———
+# ——— Alignements ———
 struct_field_align_threshold = 0
 enum_discrim_align_threshold = 0
 
-# ——— Largeurs fines (aide rustfmt pour les découpes) ———
+# ——— Largeurs fines ———
 array_width = 80
 attr_fn_like_width = 70
 chain_width = 80
@@ -54,5 +51,5 @@ struct_lit_width = 40
 struct_variant_width = 40
 
 # ——— Choix assumés ———
-# On évite d'aplatir de force : lisibilité > “tout sur une ligne”
 fn_single_line = false
+


### PR DESCRIPTION
chore(rustfmt): stabiliser .rustfmt.toml (compatible Rustfmt stable)

- Conserve le style souhaité (max_width=100, wrap_comments, imports rangés)
- Retire les options instables : match_block_trailing_comma, match_arm_leading_pipes, binop_separator, format_macro_matchers
- Assure la compatibilité Rust 1.80+ et un passage clean en CI

Refs: lint rustfmt