### PR TITLE
chore(packaging): add release-readiness gate before Debian build

### DIFF
--- a/.github/workflows/debian-crash-regressions.yml
+++ b/.github/workflows/debian-crash-regressions.yml
@@ -1,0 +1,44 @@
+name: debian-crash-regressions
+
+on:
+  pull_request:
+    paths:
+      - 'src/compiler/driver/**'
+      - 'src/compiler/backends/**'
+      - 'toolchain/scripts/install/install-debian-vitte-2.1.1.sh'
+      - 'toolchain/scripts/install/debian-deps.sh'
+      - 'toolchain/scripts/package/make-debian-deb.sh'
+      - 'tools/ci_debian_crash_regressions.sh'
+      - 'tools/crash_report_snapshots.sh'
+      - '.github/workflows/debian-crash-regressions.yml'
+      - 'tests/**'
+      - 'examples/**'
+      - 'Makefile'
+  push:
+    branches:
+      - main
+
+jobs:
+  crash-regressions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          source toolchain/scripts/install/debian-deps.sh
+          sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+
+      - name: Build
+        run: make build
+
+      - name: Release readiness gate
+        run: make -s release-readiness
+
+      - name: Debian crash regressions
+        run: tools/ci_debian_crash_regressions.sh
+
+      - name: Crash report snapshots
+        run: make crash-report-snapshots

--- a/Makefile
+++ b/Makefile
@@ -446,6 +446,10 @@ modules-contract-snapshots:
 modules-contract-snapshots-update:
 	@tools/modules_contract_snapshots.sh --update
 
+.PHONY: export-policy-lint
+export-policy-lint:
+	@tools/modules_contract_snapshots.sh
+
 .PHONY: module-tree-lint
 module-tree-lint:
 	@tools/lint_module_tree.py
@@ -461,6 +465,1399 @@ packages-governance-lint:
 .PHONY: critical-runtime-matrix-lint
 critical-runtime-matrix-lint:
 	@tools/lint_critical_runtime_matrix.py
+
+.PHONY: array-export-snapshot-lint
+array-export-snapshot-lint:
+	@tools/lint_array_export_snapshot.py
+
+.PHONY: ast-export-snapshot-lint
+ast-export-snapshot-lint:
+	@tools/lint_ast_export_snapshot.py
+
+.PHONY: core-mod-lint
+core-mod-lint:
+	@tools/lint_core_mod_contracts.py
+
+.PHONY: core-no-internal-exports-lint
+core-no-internal-exports-lint:
+	@python3 tools/lint_core_no_internal_exports.py
+
+.PHONY: core-no-entry-lint
+core-no-entry-lint:
+	@python3 tools/lint_core_no_entry.py
+
+.PHONY: core-export-naming-lint
+core-export-naming-lint:
+	@python3 tools/lint_core_export_naming.py
+
+.PHONY: core-sensitive-imports-lint
+core-sensitive-imports-lint:
+	@python3 tools/lint_core_sensitive_imports.py
+
+.PHONY: core-alias-pkg-lint
+core-alias-pkg-lint:
+	@python3 tools/lint_core_alias_pkg.py
+
+.PHONY: modules-use-as-strict-lint
+modules-use-as-strict-lint:
+	@python3 tools/lint_modules_use_as_strict.py
+
+.PHONY: core-compat-contracts-lint
+core-compat-contracts-lint:
+	@python3 tools/lint_core_compat_contracts.py
+
+.PHONY: core-contract-snapshots
+core-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=core
+	@tools/core_contract_snapshots.sh
+
+.PHONY: core-contract-snapshots-update
+core-contract-snapshots-update:
+	@tools/core_contract_snapshots.sh --update
+
+.PHONY: core-facade-snapshot
+core-facade-snapshot:
+	@tools/core_facade_snapshot.sh
+
+.PHONY: core-facade-snapshot-update
+core-facade-snapshot-update:
+	@tools/core_facade_snapshot.sh --update
+
+.PHONY: core-smoke
+core-smoke:
+	@tools/core_smoke.sh
+
+.PHONY: core-no-side-effects-test
+core-no-side-effects-test:
+	@tools/core_smoke.sh SRC=tests/core/vitte_core_no_side_effects.vit
+
+.PHONY: core-profile-strict-test
+core-profile-strict-test:
+	@tools/core_smoke.sh SRC=tests/core/core_profile_strict.vit
+
+.PHONY: core-analyze-json
+core-analyze-json:
+	@tools/analyze_core_json.sh
+
+.PHONY: core-contract-diff
+core-contract-diff:
+	@tools/core_contract_diff.sh
+
+.PHONY: core-bench
+core-bench:
+	@tools/core_bench.sh
+
+.PHONY: core-fuzz
+core-fuzz:
+	@tools/core_fuzz.sh
+
+.PHONY: core-gtk-e2e
+core-gtk-e2e:
+	@tools/gtk_core_quickfix_e2e.sh
+
+.PHONY: core-only-ci
+core-only-ci: core-mod-lint core-no-internal-exports-lint core-no-entry-lint core-export-naming-lint core-sensitive-imports-lint core-contract-snapshots core-facade-snapshot core-smoke core-no-side-effects-test core-profile-strict-test core-analyze-json core-compat-contracts-lint
+
+.PHONY: core-strict-ci
+core-strict-ci: core-only-ci core-alias-pkg-lint modules-use-as-strict-lint core-contract-diff core-bench core-fuzz core-gtk-e2e
+
+.PHONY: std-mod-lint
+std-mod-lint:
+	@python3 tools/lint_std_mod_contracts.py
+
+.PHONY: std-no-internal-exports-lint
+std-no-internal-exports-lint:
+	@python3 tools/lint_std_no_internal_exports.py
+
+.PHONY: std-graph-lint
+std-graph-lint:
+	@python3 tools/lint_std_graph.py
+
+.PHONY: std-no-side-effects-lint
+std-no-side-effects-lint:
+	@python3 tools/lint_std_no_side_effects.py
+
+.PHONY: std-alias-pkg-lint
+std-alias-pkg-lint:
+	@python3 tools/lint_std_alias_pkg.py
+
+.PHONY: std-sensitive-imports-lint
+std-sensitive-imports-lint:
+	@python3 tools/lint_std_sensitive_imports.py
+
+.PHONY: std-export-naming-lint
+std-export-naming-lint:
+	@python3 tools/lint_std_export_naming.py
+
+.PHONY: std-compat-contracts-lint
+std-compat-contracts-lint:
+	@python3 tools/lint_std_compat_contracts.py
+
+.PHONY: std-contract-snapshots
+std-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=std
+	@tools/std_contract_snapshots.sh
+
+.PHONY: std-contract-snapshots-update
+std-contract-snapshots-update:
+	@tools/std_contract_snapshots.sh --update
+
+.PHONY: std-facade-snapshot
+std-facade-snapshot:
+	@tools/std_facade_snapshot.sh
+
+.PHONY: std-facade-snapshot-update
+std-facade-snapshot-update:
+	@tools/std_facade_snapshot.sh --update
+
+.PHONY: std-smoke
+std-smoke:
+	@tools/std_smoke.sh
+
+.PHONY: std-no-side-effects-test
+std-no-side-effects-test:
+	@SRC=tests/std/vitte_std_no_side_effects.vit tools/std_smoke.sh
+
+.PHONY: std-profile-strict-test
+std-profile-strict-test:
+	@SRC=tests/std/std_profile_strict.vit tools/std_smoke.sh
+
+.PHONY: std-analyze-json
+std-analyze-json:
+	@tools/analyze_std_json.sh
+
+.PHONY: std-contract-diff
+std-contract-diff:
+	@tools/std_contract_diff.sh
+
+.PHONY: std-bench
+std-bench:
+	@tools/std_bench.sh
+	@tools/std_import_latency_bench.sh
+
+.PHONY: std-fuzz
+std-fuzz:
+	@tools/std_fuzz.sh
+
+.PHONY: std-docsgen
+std-docsgen:
+	@tools/std_docsgen.sh
+
+.PHONY: std-symbol-index
+std-symbol-index:
+	@python3 tools/std_symbol_search.py --index --repo .
+
+.PHONY: std-symbol-search
+std-symbol-search:
+	@python3 tools/std_symbol_search.py --repo . --query "$(Q)"
+
+.PHONY: std-profile-matrix
+std-profile-matrix:
+	@tools/std_profile_matrix.sh
+
+.PHONY: std-ci-report
+std-ci-report:
+	@tools/std_ci_report.sh
+
+.PHONY: std-only-ci
+std-only-ci: std-mod-lint std-no-internal-exports-lint std-graph-lint std-no-side-effects-lint std-sensitive-imports-lint std-export-naming-lint std-contract-snapshots std-facade-snapshot std-smoke std-no-side-effects-test std-profile-strict-test std-analyze-json std-compat-contracts-lint std-profile-matrix std-ci-report
+
+.PHONY: std-strict-ci
+std-strict-ci: std-only-ci std-alias-pkg-lint std-contract-diff std-bench std-fuzz std-docsgen std-symbol-index
+
+.PHONY: log-mod-lint
+log-mod-lint:
+	@python3 tools/lint_log_mod_contracts.py
+
+.PHONY: log-no-internal-exports-lint
+log-no-internal-exports-lint:
+	@python3 tools/lint_log_no_internal_exports.py
+
+.PHONY: log-no-side-effects-lint
+log-no-side-effects-lint:
+	@python3 tools/lint_log_no_side_effects.py
+
+.PHONY: log-alias-pkg-lint
+log-alias-pkg-lint:
+	@python3 tools/lint_log_alias_pkg.py
+
+.PHONY: log-sensitive-imports-lint
+log-sensitive-imports-lint:
+	@python3 tools/lint_log_sensitive_imports.py
+
+.PHONY: log-export-naming-lint
+log-export-naming-lint:
+	@python3 tools/lint_log_export_naming.py
+
+.PHONY: log-compat-contracts-lint
+log-compat-contracts-lint:
+	@python3 tools/lint_log_compat_contracts.py
+
+.PHONY: log-contract-snapshots
+log-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=log
+	@tools/log_contract_snapshots.sh
+
+.PHONY: log-contract-snapshots-update
+log-contract-snapshots-update:
+	@tools/log_contract_snapshots.sh --update
+
+.PHONY: log-facade-snapshot
+log-facade-snapshot:
+	@tools/log_facade_snapshot.sh
+
+.PHONY: log-facade-snapshot-update
+log-facade-snapshot-update:
+	@tools/log_facade_snapshot.sh --update
+
+.PHONY: log-smoke
+log-smoke:
+	@tools/log_smoke.sh
+
+.PHONY: log-no-side-effects-test
+log-no-side-effects-test:
+	@SRC=tests/log/vitte_log_no_side_effects.vit tools/log_smoke.sh
+
+.PHONY: log-profile-strict-test
+log-profile-strict-test:
+	@SRC=tests/log/log_profile_strict.vit tools/log_smoke.sh
+
+.PHONY: log-analyze-json
+log-analyze-json:
+	@tools/analyze_log_json.sh
+
+.PHONY: log-contract-diff
+log-contract-diff:
+	@tools/log_contract_diff.sh
+
+.PHONY: log-bench
+log-bench:
+	@tools/log_bench.sh
+	@tools/log_macro_bench.sh
+
+.PHONY: log-fuzz
+log-fuzz:
+	@tools/log_fuzz.sh
+
+.PHONY: log-docsgen
+log-docsgen:
+	@tools/log_docsgen.sh
+
+.PHONY: log-profile-matrix
+log-profile-matrix:
+	@tools/log_profile_matrix.sh
+
+.PHONY: log-ci-report
+log-ci-report:
+	@tools/log_ci_report.sh
+
+.PHONY: log-only-ci
+log-only-ci: log-mod-lint log-no-internal-exports-lint log-no-side-effects-lint log-sensitive-imports-lint log-export-naming-lint log-contract-snapshots log-facade-snapshot log-smoke log-no-side-effects-test log-profile-strict-test log-analyze-json log-compat-contracts-lint log-profile-matrix log-ci-report
+
+.PHONY: log-strict-ci
+log-strict-ci: log-only-ci log-alias-pkg-lint log-contract-diff log-bench log-fuzz log-docsgen
+
+.PHONY: fs-mod-lint
+fs-mod-lint:
+	@python3 tools/lint_fs_mod_contracts.py
+
+.PHONY: fs-no-internal-exports-lint
+fs-no-internal-exports-lint:
+	@python3 tools/lint_fs_no_internal_exports.py
+
+.PHONY: fs-no-side-effects-lint
+fs-no-side-effects-lint:
+	@python3 tools/lint_fs_no_side_effects.py
+
+.PHONY: fs-alias-pkg-lint
+fs-alias-pkg-lint:
+	@python3 tools/lint_fs_alias_pkg.py
+
+.PHONY: fs-sensitive-imports-lint
+fs-sensitive-imports-lint:
+	@python3 tools/lint_fs_sensitive_imports.py
+
+.PHONY: fs-export-naming-lint
+fs-export-naming-lint:
+	@python3 tools/lint_fs_export_naming.py
+
+.PHONY: fs-compat-contracts-lint
+fs-compat-contracts-lint:
+	@python3 tools/lint_fs_compat_contracts.py
+
+.PHONY: fs-contract-snapshots
+fs-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=fs
+	@tools/fs_contract_snapshots.sh
+
+.PHONY: fs-contract-snapshots-update
+fs-contract-snapshots-update:
+	@tools/fs_contract_snapshots.sh --update
+
+.PHONY: fs-facade-snapshot
+fs-facade-snapshot:
+	@tools/fs_facade_snapshot.sh
+
+.PHONY: fs-facade-snapshot-update
+fs-facade-snapshot-update:
+	@tools/fs_facade_snapshot.sh --update
+
+.PHONY: fs-smoke
+fs-smoke:
+	@tools/fs_smoke.sh
+
+.PHONY: fs-no-side-effects-test
+fs-no-side-effects-test:
+	@SRC=tests/fs/vitte_fs_no_side_effects.vit tools/fs_smoke.sh
+
+.PHONY: fs-profile-strict-test
+fs-profile-strict-test:
+	@SRC=tests/fs/fs_profile_strict.vit tools/fs_smoke.sh
+
+.PHONY: fs-analyze-json
+fs-analyze-json:
+	@tools/analyze_fs_json.sh
+
+.PHONY: fs-contract-diff
+fs-contract-diff:
+	@tools/fs_contract_diff.sh
+
+.PHONY: fs-bench
+fs-bench:
+	@tools/fs_bench.sh
+	@tools/fs_macro_bench.sh
+
+.PHONY: fs-fuzz
+fs-fuzz:
+	@tools/fs_fuzz.sh
+
+.PHONY: fs-docsgen
+fs-docsgen:
+	@tools/fs_docsgen.sh
+
+.PHONY: fs-profile-matrix
+fs-profile-matrix:
+	@tools/fs_profile_matrix.sh
+
+.PHONY: fs-ci-report
+fs-ci-report:
+	@tools/fs_ci_report.sh
+
+.PHONY: fs-only-ci
+fs-only-ci: fs-mod-lint fs-no-internal-exports-lint fs-no-side-effects-lint fs-sensitive-imports-lint fs-export-naming-lint fs-contract-snapshots fs-facade-snapshot fs-smoke fs-no-side-effects-test fs-profile-strict-test fs-analyze-json fs-compat-contracts-lint fs-profile-matrix fs-ci-report
+
+.PHONY: fs-strict-ci
+fs-strict-ci: fs-only-ci fs-alias-pkg-lint fs-contract-diff fs-bench fs-fuzz fs-docsgen
+
+.PHONY: db-mod-lint
+db-mod-lint:
+	@python3 tools/lint_db_mod_contracts.py
+
+.PHONY: db-no-internal-exports-lint
+db-no-internal-exports-lint:
+	@python3 tools/lint_db_no_internal_exports.py
+
+.PHONY: db-no-side-effects-lint
+db-no-side-effects-lint:
+	@python3 tools/lint_db_no_side_effects.py
+
+.PHONY: db-alias-pkg-lint
+db-alias-pkg-lint:
+	@python3 tools/lint_db_alias_pkg.py
+
+.PHONY: db-sensitive-imports-lint
+db-sensitive-imports-lint:
+	@python3 tools/lint_db_sensitive_imports.py
+
+.PHONY: db-export-naming-lint
+db-export-naming-lint:
+	@python3 tools/lint_db_export_naming.py
+
+.PHONY: db-compat-contracts-lint
+db-compat-contracts-lint:
+	@python3 tools/lint_db_compat_contracts.py
+
+.PHONY: db-sql-injection-lint
+db-sql-injection-lint:
+	@python3 tools/lint_db_sql_injection.py
+
+.PHONY: db-migration-compat-lint
+db-migration-compat-lint:
+	@python3 tools/lint_db_migration_compat.py
+
+.PHONY: db-contract-snapshots
+db-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=db
+	@tools/db_contract_snapshots.sh
+
+.PHONY: db-contract-snapshots-update
+db-contract-snapshots-update:
+	@tools/db_contract_snapshots.sh --update
+
+.PHONY: db-facade-snapshot
+db-facade-snapshot:
+	@tools/db_facade_snapshot.sh
+
+.PHONY: db-facade-snapshot-update
+db-facade-snapshot-update:
+	@tools/db_facade_snapshot.sh --update
+
+.PHONY: db-smoke
+db-smoke:
+	@tools/db_smoke.sh
+
+.PHONY: db-no-side-effects-test
+db-no-side-effects-test:
+	@SRC=tests/db/vitte_db_no_side_effects.vit tools/db_smoke.sh
+
+.PHONY: db-profile-strict-test
+db-profile-strict-test:
+	@SRC=tests/db/db_profile_strict.vit tools/db_smoke.sh
+
+.PHONY: db-analyze-json
+db-analyze-json:
+	@tools/analyze_db_json.sh
+
+.PHONY: db-contract-diff
+db-contract-diff:
+	@tools/db_contract_diff.sh
+
+.PHONY: db-bench
+db-bench:
+	@tools/db_bench.sh
+	@tools/db_macro_bench.sh
+
+.PHONY: db-fuzz
+db-fuzz:
+	@tools/db_fuzz.sh
+
+.PHONY: db-docsgen
+db-docsgen:
+	@tools/db_docsgen.sh
+
+.PHONY: db-profile-matrix
+db-profile-matrix:
+	@tools/db_profile_matrix.sh
+
+.PHONY: db-ci-report
+db-ci-report:
+	@tools/db_ci_report.sh
+
+.PHONY: db-only-ci
+db-only-ci: db-mod-lint db-no-internal-exports-lint db-no-side-effects-lint db-sensitive-imports-lint db-export-naming-lint db-sql-injection-lint db-contract-snapshots db-facade-snapshot db-smoke db-no-side-effects-test db-profile-strict-test db-analyze-json db-compat-contracts-lint db-profile-matrix db-ci-report
+
+.PHONY: db-strict-ci
+db-strict-ci: db-only-ci db-alias-pkg-lint db-contract-diff db-migration-compat-lint db-bench db-fuzz db-docsgen
+
+.PHONY: http-mod-lint
+http-mod-lint:
+	@python3 tools/lint_http_mod_contracts.py
+
+.PHONY: http-client-mod-lint
+http-client-mod-lint:
+	@python3 tools/lint_http_client_mod_contracts.py
+
+.PHONY: http-no-internal-exports-lint
+http-no-internal-exports-lint:
+	@python3 tools/lint_http_no_internal_exports.py
+
+.PHONY: http-no-side-effects-lint
+http-no-side-effects-lint:
+	@python3 tools/lint_http_no_side_effects.py
+
+.PHONY: http-alias-pkg-lint
+http-alias-pkg-lint:
+	@python3 tools/lint_http_alias_pkg.py
+
+.PHONY: http-sensitive-imports-lint
+http-sensitive-imports-lint:
+	@python3 tools/lint_http_sensitive_imports.py
+
+.PHONY: http-export-naming-lint
+http-export-naming-lint:
+	@python3 tools/lint_http_export_naming.py
+
+.PHONY: http-compat-contracts-lint
+http-compat-contracts-lint:
+	@python3 tools/lint_http_compat_contracts.py
+
+.PHONY: http-security-lint
+http-security-lint:
+	@python3 tools/lint_http_security.py
+
+.PHONY: http-contract-snapshots
+http-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=http
+	@tools/http_contract_snapshots.sh
+
+.PHONY: http-contract-snapshots-update
+http-contract-snapshots-update:
+	@tools/http_contract_snapshots.sh --update
+
+.PHONY: http-facade-snapshot
+http-facade-snapshot:
+	@tools/http_facade_snapshot.sh
+
+.PHONY: http-facade-snapshot-update
+http-facade-snapshot-update:
+	@tools/http_facade_snapshot.sh --update
+
+.PHONY: http-client-contract-snapshots
+http-client-contract-snapshots:
+	@tools/http_client_contract_snapshots.sh
+
+.PHONY: http-client-contract-snapshots-update
+http-client-contract-snapshots-update:
+	@tools/http_client_contract_snapshots.sh --update
+
+.PHONY: http-client-facade-snapshot
+http-client-facade-snapshot:
+	@tools/http_client_facade_snapshot.sh
+
+.PHONY: http-client-facade-snapshot-update
+http-client-facade-snapshot-update:
+	@tools/http_client_facade_snapshot.sh --update
+
+.PHONY: http-smoke
+http-smoke:
+	@tools/http_smoke.sh
+
+.PHONY: http-client-smoke
+http-client-smoke:
+	@tools/http_client_smoke.sh
+
+.PHONY: http-no-side-effects-test
+http-no-side-effects-test:
+	@SRC=tests/http/vitte_http_no_side_effects.vit tools/http_smoke.sh
+
+.PHONY: http-client-no-side-effects-test
+http-client-no-side-effects-test:
+	@SRC=tests/http_client/vitte_http_client_no_side_effects.vit tools/http_client_smoke.sh
+
+.PHONY: http-profile-strict-test
+http-profile-strict-test:
+	@SRC=tests/http/http_profile_strict.vit tools/http_smoke.sh
+
+.PHONY: http-client-profile-strict-test
+http-client-profile-strict-test:
+	@SRC=tests/http_client/http_client_profile_strict.vit tools/http_client_smoke.sh
+
+.PHONY: http-analyze-json
+http-analyze-json:
+	@tools/analyze_http_json.sh
+
+.PHONY: http-client-analyze-json
+http-client-analyze-json:
+	@tools/analyze_http_client_json.sh
+
+.PHONY: http-contract-diff
+http-contract-diff:
+	@tools/http_contract_diff.sh
+
+.PHONY: http-bench
+http-bench:
+	@tools/http_bench.sh
+	@tools/http_macro_bench.sh
+
+.PHONY: http-client-bench
+http-client-bench:
+	@tools/http_client_bench.sh
+	@tools/http_client_macro_bench.sh
+
+.PHONY: http-fuzz
+http-fuzz:
+	@tools/http_fuzz.sh
+
+.PHONY: http-client-fuzz
+http-client-fuzz:
+	@tools/http_client_fuzz.sh
+
+.PHONY: http-docsgen
+http-docsgen:
+	@tools/http_docsgen.sh
+
+.PHONY: http-client-docsgen
+http-client-docsgen:
+	@tools/http_client_docsgen.sh
+
+.PHONY: http-profile-matrix
+http-profile-matrix:
+	@tools/http_profile_matrix.sh
+
+.PHONY: http-client-profile-matrix
+http-client-profile-matrix:
+	@tools/http_client_profile_matrix.sh
+
+.PHONY: http-ci-report
+http-ci-report:
+	@tools/http_ci_report.sh
+
+.PHONY: http-client-ci-report
+http-client-ci-report:
+	@tools/http_client_ci_report.sh
+
+.PHONY: http-only-ci
+http-only-ci: http-mod-lint http-no-internal-exports-lint http-no-side-effects-lint http-sensitive-imports-lint http-export-naming-lint http-security-lint http-contract-snapshots http-facade-snapshot http-smoke http-no-side-effects-test http-profile-strict-test http-analyze-json http-compat-contracts-lint http-profile-matrix http-ci-report
+
+.PHONY: http-strict-ci
+http-strict-ci: http-only-ci http-alias-pkg-lint http-contract-diff http-bench http-fuzz http-docsgen
+
+.PHONY: http-client-only-ci
+http-client-only-ci: http-client-mod-lint http-no-internal-exports-lint http-no-side-effects-lint http-sensitive-imports-lint http-export-naming-lint http-security-lint http-client-contract-snapshots http-client-facade-snapshot http-client-smoke http-client-no-side-effects-test http-client-profile-strict-test http-client-analyze-json http-compat-contracts-lint http-client-profile-matrix http-client-ci-report
+
+.PHONY: http-client-strict-ci
+http-client-strict-ci: http-client-only-ci http-alias-pkg-lint http-contract-diff http-client-bench http-client-fuzz http-client-docsgen
+
+.PHONY: process-mod-lint
+process-mod-lint:
+	@python3 tools/lint_process_mod_contracts.py
+
+.PHONY: process-no-internal-exports-lint
+process-no-internal-exports-lint:
+	@python3 tools/lint_process_no_internal_exports.py
+
+.PHONY: process-no-side-effects-lint
+process-no-side-effects-lint:
+	@python3 tools/lint_process_no_side_effects.py
+
+.PHONY: process-alias-pkg-lint
+process-alias-pkg-lint:
+	@python3 tools/lint_process_alias_pkg.py
+
+.PHONY: process-sensitive-imports-lint
+process-sensitive-imports-lint:
+	@python3 tools/lint_process_sensitive_imports.py
+
+.PHONY: process-export-naming-lint
+process-export-naming-lint:
+	@python3 tools/lint_process_export_naming.py
+
+.PHONY: process-security-lint
+process-security-lint:
+	@python3 tools/lint_process_security.py
+
+.PHONY: process-compat-contracts-lint
+process-compat-contracts-lint:
+	@python3 tools/lint_process_compat_contracts.py
+
+.PHONY: process-contract-snapshots
+process-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=process
+	@tools/process_contract_snapshots.sh
+
+.PHONY: process-contract-snapshots-update
+process-contract-snapshots-update:
+	@tools/process_contract_snapshots.sh --update
+
+.PHONY: process-facade-snapshot
+process-facade-snapshot:
+	@tools/process_facade_snapshot.sh
+
+.PHONY: process-facade-snapshot-update
+process-facade-snapshot-update:
+	@tools/process_facade_snapshot.sh --update
+
+.PHONY: process-smoke
+process-smoke:
+	@tools/process_smoke.sh
+
+.PHONY: process-no-side-effects-test
+process-no-side-effects-test:
+	@SRC=tests/process/vitte_process_no_side_effects.vit tools/process_smoke.sh
+
+.PHONY: process-profile-strict-test
+process-profile-strict-test:
+	@SRC=tests/process/process_profile_strict.vit tools/process_smoke.sh
+
+.PHONY: process-analyze-json
+process-analyze-json:
+	@tools/analyze_process_json.sh
+
+.PHONY: process-contract-diff
+process-contract-diff:
+	@tools/process_contract_diff.sh
+
+.PHONY: process-bench
+process-bench:
+	@tools/process_bench.sh
+	@tools/process_macro_bench.sh
+
+.PHONY: process-fuzz
+process-fuzz:
+	@tools/process_fuzz.sh
+
+.PHONY: process-docsgen
+process-docsgen:
+	@tools/process_docsgen.sh
+
+.PHONY: process-profile-matrix
+process-profile-matrix:
+	@tools/process_profile_matrix.sh
+
+.PHONY: process-ci-report
+process-ci-report:
+	@tools/process_ci_report.sh
+
+.PHONY: process-only-ci
+process-only-ci: process-mod-lint process-no-internal-exports-lint process-no-side-effects-lint process-sensitive-imports-lint process-export-naming-lint process-security-lint process-contract-snapshots process-facade-snapshot process-smoke process-no-side-effects-test process-profile-strict-test process-analyze-json process-compat-contracts-lint process-profile-matrix process-ci-report
+
+.PHONY: process-strict-ci
+process-strict-ci: process-only-ci process-alias-pkg-lint process-contract-diff process-bench process-fuzz process-docsgen
+
+.PHONY: json-mod-lint
+json-mod-lint:
+	@python3 tools/lint_json_mod_contracts.py
+
+.PHONY: json-no-internal-exports-lint
+json-no-internal-exports-lint:
+	@python3 tools/lint_json_no_internal_exports.py
+
+.PHONY: json-no-side-effects-lint
+json-no-side-effects-lint:
+	@python3 tools/lint_json_no_side_effects.py
+
+.PHONY: json-alias-pkg-lint
+json-alias-pkg-lint:
+	@python3 tools/lint_json_alias_pkg.py
+
+.PHONY: json-sensitive-imports-lint
+json-sensitive-imports-lint:
+	@python3 tools/lint_json_sensitive_imports.py
+
+.PHONY: json-export-naming-lint
+json-export-naming-lint:
+	@python3 tools/lint_json_export_naming.py
+
+.PHONY: json-compat-contracts-lint
+json-compat-contracts-lint:
+	@python3 tools/lint_json_compat_contracts.py
+
+.PHONY: json-security-lint
+json-security-lint:
+	@python3 tools/lint_json_security.py
+
+.PHONY: json-contract-snapshots
+json-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=json
+	@tools/json_contract_snapshots.sh
+
+.PHONY: json-contract-snapshots-update
+json-contract-snapshots-update:
+	@tools/json_contract_snapshots.sh --update
+
+.PHONY: json-facade-snapshot
+json-facade-snapshot:
+	@tools/json_facade_snapshot.sh
+
+.PHONY: json-facade-snapshot-update
+json-facade-snapshot-update:
+	@tools/json_facade_snapshot.sh --update
+
+.PHONY: json-smoke
+json-smoke:
+	@tools/json_smoke.sh
+
+.PHONY: json-no-side-effects-test
+json-no-side-effects-test:
+	@SRC=tests/json/vitte_json_no_side_effects.vit tools/json_smoke.sh
+
+.PHONY: json-profile-strict-test
+json-profile-strict-test:
+	@SRC=tests/json/json_profile_strict.vit tools/json_smoke.sh
+
+.PHONY: json-analyze-json
+json-analyze-json:
+	@tools/analyze_json_json.sh
+
+.PHONY: json-contract-diff
+json-contract-diff:
+	@tools/json_contract_diff.sh
+
+.PHONY: json-bench
+json-bench:
+	@tools/json_bench.sh
+	@tools/json_macro_bench.sh
+
+.PHONY: json-fuzz
+json-fuzz:
+	@tools/json_fuzz.sh
+
+.PHONY: json-docsgen
+json-docsgen:
+	@tools/json_docsgen.sh
+
+.PHONY: json-profile-matrix
+json-profile-matrix:
+	@tools/json_profile_matrix.sh
+
+.PHONY: json-ci-report
+json-ci-report:
+	@tools/json_ci_report.sh
+
+.PHONY: json-only-ci
+json-only-ci: json-mod-lint json-no-internal-exports-lint json-no-side-effects-lint json-sensitive-imports-lint json-export-naming-lint json-security-lint json-contract-snapshots json-facade-snapshot json-smoke json-no-side-effects-test json-profile-strict-test json-analyze-json json-compat-contracts-lint json-profile-matrix json-ci-report
+
+.PHONY: json-strict-ci
+json-strict-ci: json-only-ci json-alias-pkg-lint json-contract-diff json-bench json-fuzz json-docsgen
+
+.PHONY: yaml-mod-lint
+yaml-mod-lint:
+	@python3 tools/lint_yaml_mod_contracts.py
+
+.PHONY: yaml-no-internal-exports-lint
+yaml-no-internal-exports-lint:
+	@python3 tools/lint_yaml_no_internal_exports.py
+
+.PHONY: yaml-no-side-effects-lint
+yaml-no-side-effects-lint:
+	@python3 tools/lint_yaml_no_side_effects.py
+
+.PHONY: yaml-alias-pkg-lint
+yaml-alias-pkg-lint:
+	@python3 tools/lint_yaml_alias_pkg.py
+
+.PHONY: yaml-sensitive-imports-lint
+yaml-sensitive-imports-lint:
+	@python3 tools/lint_yaml_sensitive_imports.py
+
+.PHONY: yaml-export-naming-lint
+yaml-export-naming-lint:
+	@python3 tools/lint_yaml_export_naming.py
+
+.PHONY: yaml-compat-contracts-lint
+yaml-compat-contracts-lint:
+	@python3 tools/lint_yaml_compat_contracts.py
+
+.PHONY: yaml-security-lint
+yaml-security-lint:
+	@python3 tools/lint_yaml_security.py
+
+.PHONY: yaml-contract-snapshots
+yaml-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=yaml
+	@tools/yaml_contract_snapshots.sh
+
+.PHONY: yaml-contract-snapshots-update
+yaml-contract-snapshots-update:
+	@tools/yaml_contract_snapshots.sh --update
+
+.PHONY: yaml-facade-snapshot
+yaml-facade-snapshot:
+	@tools/yaml_facade_snapshot.sh
+
+.PHONY: yaml-facade-snapshot-update
+yaml-facade-snapshot-update:
+	@tools/yaml_facade_snapshot.sh --update
+
+.PHONY: yaml-smoke
+yaml-smoke:
+	@tools/yaml_smoke.sh
+
+.PHONY: yaml-no-side-effects-test
+yaml-no-side-effects-test:
+	@SRC=tests/yaml/vitte_yaml_no_side_effects.vit tools/yaml_smoke.sh
+
+.PHONY: yaml-profile-strict-test
+yaml-profile-strict-test:
+	@SRC=tests/yaml/yaml_profile_strict.vit tools/yaml_smoke.sh
+
+.PHONY: yaml-analyze-json
+yaml-analyze-json:
+	@tools/analyze_yaml_json.sh
+
+.PHONY: yaml-contract-diff
+yaml-contract-diff:
+	@tools/yaml_contract_diff.sh
+
+.PHONY: yaml-bench
+yaml-bench:
+	@tools/yaml_bench.sh
+	@tools/yaml_macro_bench.sh
+
+.PHONY: yaml-fuzz
+yaml-fuzz:
+	@tools/yaml_fuzz.sh
+
+.PHONY: yaml-docsgen
+yaml-docsgen:
+	@tools/yaml_docsgen.sh
+
+.PHONY: yaml-profile-matrix
+yaml-profile-matrix:
+	@tools/yaml_profile_matrix.sh
+
+.PHONY: yaml-ci-report
+yaml-ci-report:
+	@tools/yaml_ci_report.sh
+
+.PHONY: yaml-only-ci
+yaml-only-ci: yaml-mod-lint yaml-no-internal-exports-lint yaml-no-side-effects-lint yaml-sensitive-imports-lint yaml-export-naming-lint yaml-security-lint yaml-contract-snapshots yaml-facade-snapshot yaml-smoke yaml-no-side-effects-test yaml-profile-strict-test yaml-analyze-json yaml-compat-contracts-lint yaml-profile-matrix yaml-ci-report
+
+.PHONY: yaml-strict-ci
+yaml-strict-ci: yaml-only-ci yaml-alias-pkg-lint yaml-contract-diff yaml-bench yaml-fuzz yaml-docsgen
+
+.PHONY: test-mod-lint
+test-mod-lint:
+	@python3 tools/lint_test_mod_contracts.py
+
+.PHONY: test-no-internal-exports-lint
+test-no-internal-exports-lint:
+	@python3 tools/lint_test_no_internal_exports.py
+
+.PHONY: test-no-side-effects-lint
+test-no-side-effects-lint:
+	@python3 tools/lint_test_no_side_effects.py
+
+.PHONY: test-alias-pkg-lint
+test-alias-pkg-lint:
+	@python3 tools/lint_test_alias_pkg.py
+
+.PHONY: test-sensitive-imports-lint
+test-sensitive-imports-lint:
+	@python3 tools/lint_test_sensitive_imports.py
+
+.PHONY: test-export-naming-lint
+test-export-naming-lint:
+	@python3 tools/lint_test_export_naming.py
+
+.PHONY: test-compat-contracts-lint
+test-compat-contracts-lint:
+	@python3 tools/lint_test_compat_contracts.py
+
+.PHONY: test-security-lint
+test-security-lint:
+	@python3 tools/lint_test_security.py
+
+.PHONY: test-contract-snapshots
+test-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=test
+	@tools/test_contract_snapshots.sh
+
+.PHONY: test-contract-snapshots-update
+test-contract-snapshots-update:
+	@tools/test_contract_snapshots.sh --update
+
+.PHONY: test-facade-snapshot
+test-facade-snapshot:
+	@tools/test_facade_snapshot.sh
+
+.PHONY: test-facade-snapshot-update
+test-facade-snapshot-update:
+	@tools/test_facade_snapshot.sh --update
+
+.PHONY: test-smoke
+test-smoke:
+	@tools/test_smoke.sh
+
+.PHONY: test-no-side-effects-test
+test-no-side-effects-test:
+	@SRC=tests/test/vitte_test_no_side_effects.vit tools/test_smoke.sh
+
+.PHONY: test-profile-strict-test
+test-profile-strict-test:
+	@SRC=tests/test/test_profile_strict.vit tools/test_smoke.sh
+
+.PHONY: test-analyze-json
+test-analyze-json:
+	@tools/analyze_test_json.sh
+
+.PHONY: test-contract-diff
+test-contract-diff:
+	@tools/test_contract_diff.sh
+
+.PHONY: test-bench
+test-bench:
+	@tools/test_bench.sh
+	@tools/test_macro_bench.sh
+
+.PHONY: test-fuzz
+test-fuzz:
+	@tools/test_fuzz.sh
+
+.PHONY: test-docsgen
+test-docsgen:
+	@tools/test_docsgen.sh
+
+.PHONY: test-profile-matrix
+test-profile-matrix:
+	@tools/test_profile_matrix.sh
+
+.PHONY: test-ci-report
+test-ci-report:
+	@tools/test_ci_report.sh
+
+.PHONY: test-only-ci
+test-only-ci: test-mod-lint test-no-internal-exports-lint test-no-side-effects-lint test-sensitive-imports-lint test-export-naming-lint test-security-lint test-contract-snapshots test-facade-snapshot test-smoke test-no-side-effects-test test-profile-strict-test test-analyze-json test-compat-contracts-lint test-profile-matrix test-ci-report
+
+.PHONY: test-strict-ci
+test-strict-ci: test-only-ci test-alias-pkg-lint test-contract-diff test-bench test-fuzz test-docsgen
+
+.PHONY: lint-mod-lint
+lint-mod-lint:
+	@python3 tools/lint_lint_mod_contracts.py
+
+.PHONY: lint-no-internal-exports-lint
+lint-no-internal-exports-lint:
+	@python3 tools/lint_lint_no_internal_exports.py
+
+.PHONY: lint-no-side-effects-lint
+lint-no-side-effects-lint:
+	@python3 tools/lint_lint_no_side_effects.py
+
+.PHONY: lint-alias-pkg-lint
+lint-alias-pkg-lint:
+	@python3 tools/lint_lint_alias_pkg.py
+
+.PHONY: lint-sensitive-imports-lint
+lint-sensitive-imports-lint:
+	@python3 tools/lint_lint_sensitive_imports.py
+
+.PHONY: lint-export-naming-lint
+lint-export-naming-lint:
+	@python3 tools/lint_lint_export_naming.py
+
+.PHONY: lint-compat-contracts-lint
+lint-compat-contracts-lint:
+	@python3 tools/lint_lint_compat_contracts.py
+
+.PHONY: lint-security-lint
+lint-security-lint:
+	@python3 tools/lint_lint_security.py
+
+.PHONY: lint-contract-snapshots
+lint-contract-snapshots:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=lint
+	@tools/lint_contract_snapshots_pkg.sh
+
+.PHONY: lint-contract-snapshots-update
+lint-contract-snapshots-update:
+	@tools/lint_contract_snapshots_pkg.sh --update
+
+.PHONY: lint-facade-snapshot
+lint-facade-snapshot:
+	@tools/lint_facade_snapshot_pkg.sh
+
+.PHONY: lint-facade-snapshot-update
+lint-facade-snapshot-update:
+	@tools/lint_facade_snapshot_pkg.sh --update
+
+.PHONY: lint-smoke
+lint-smoke:
+	@tools/lint_smoke_pkg.sh
+
+.PHONY: lint-no-side-effects-test
+lint-no-side-effects-test:
+	@SRC=tests/lint/vitte_lint_no_side_effects.vit tools/lint_smoke_pkg.sh
+
+.PHONY: lint-profile-strict-test
+lint-profile-strict-test:
+	@SRC=tests/lint/lint_profile_strict.vit tools/lint_smoke_pkg.sh
+
+.PHONY: lint-analyze-json
+lint-analyze-json:
+	@tools/analyze_lint_json.sh
+
+.PHONY: lint-contract-diff
+lint-contract-diff:
+	@tools/lint_contract_diff_pkg.sh
+
+.PHONY: lint-bench
+lint-bench:
+	@tools/lint_bench_pkg.sh
+	@tools/lint_macro_bench_pkg.sh
+
+.PHONY: lint-fuzz
+lint-fuzz:
+	@tools/lint_fuzz_pkg.sh
+
+.PHONY: lint-docsgen
+lint-docsgen:
+	@tools/lint_docsgen_pkg.sh
+
+.PHONY: lint-profile-matrix
+lint-profile-matrix:
+	@tools/lint_profile_matrix_pkg.sh
+
+.PHONY: lint-ci-report
+lint-ci-report:
+	@tools/lint_ci_report_pkg.sh
+
+.PHONY: lint-only-ci
+lint-only-ci: lint-mod-lint lint-no-internal-exports-lint lint-no-side-effects-lint lint-sensitive-imports-lint lint-export-naming-lint lint-security-lint lint-contract-snapshots lint-facade-snapshot lint-smoke lint-no-side-effects-test lint-profile-strict-test lint-analyze-json lint-compat-contracts-lint lint-profile-matrix lint-ci-report
+
+.PHONY: lint-strict-ci
+lint-strict-ci: lint-only-ci lint-alias-pkg-lint lint-contract-diff lint-bench lint-fuzz lint-docsgen
+
+.PHONY: contracts-refresh
+contracts-refresh:
+	@python3 tools/generate_contract_snapshots_from_mod.py --packages=core,std,log,fs,db,http,process,json,yaml,test,lint
+	@python3 tools/generate_contract_lockfiles.py
+
+.PHONY: contract-lockfiles-lint
+contract-lockfiles-lint:
+	@python3 tools/lint_contract_lockfiles.py
+
+.PHONY: facade-role-contracts-lint
+facade-role-contracts-lint:
+	@python3 tools/lint_facade_role_contracts.py
+
+.PHONY: facade-thin-lint
+facade-thin-lint:
+	@python3 tools/lint_facade_thin.py
+
+.PHONY: diag-namespace-lint
+diag-namespace-lint:
+	@python3 tools/lint_diagnostic_namespace_ownership.py
+
+.PHONY: alias-pkg-global-lint
+alias-pkg-global-lint:
+	@python3 tools/lint_alias_pkg_generic.py --roots=src/vitte/packages/core,src/vitte/packages/std,src/vitte/packages/log,src/vitte/packages/fs,src/vitte/packages/db,src/vitte/packages/http,src/vitte/packages/http_client,src/vitte/packages/process,src/vitte/packages/json,src/vitte/packages/yaml,src/vitte/packages/test,src/vitte/packages/lint --tag=alias-pkg-global
+
+.PHONY: no-side-effects-global-lint
+no-side-effects-global-lint:
+	@python3 tools/lint_no_side_effects_generic.py --roots=src/vitte/packages/core,src/vitte/packages/std,src/vitte/packages/log,src/vitte/packages/fs,src/vitte/packages/db,src/vitte/packages/http,src/vitte/packages/http_client,src/vitte/packages/process,src/vitte/packages/json,src/vitte/packages/yaml,src/vitte/packages/test,src/vitte/packages/lint --tag=no-side-effects-global
+
+.PHONY: analyze-json-unify
+analyze-json-unify:
+	@python3 tools/normalize_analyze_report.py --in target/reports/core_analyze.json --out target/reports/core_analyze.json --package=vitte/core --diag-prefix=VITTE-C
+	@python3 tools/normalize_analyze_report.py --in target/reports/std_analyze.json --out target/reports/std_analyze.json --package=vitte/std --diag-prefix=VITTE-S
+	@python3 tools/normalize_analyze_report.py --in target/reports/log_analyze.json --out target/reports/log_analyze.json --package=vitte/log --diag-prefix=VITTE-L
+	@python3 tools/normalize_analyze_report.py --in target/reports/fs_analyze.json --out target/reports/fs_analyze.json --package=vitte/fs --diag-prefix=VITTE-F
+	@python3 tools/normalize_analyze_report.py --in target/reports/db_analyze.json --out target/reports/db_analyze.json --package=vitte/db --diag-prefix=VITTE-D
+	@python3 tools/normalize_analyze_report.py --in target/reports/http_analyze.json --out target/reports/http_analyze.json --package=vitte/http --diag-prefix=VITTE-H
+	@python3 tools/normalize_analyze_report.py --in target/reports/http_client_analyze.json --out target/reports/http_client_analyze.json --package=vitte/http_client --diag-prefix=VITTE-C
+	@python3 tools/normalize_analyze_report.py --in target/reports/process_analyze.json --out target/reports/process_analyze.json --package=vitte/process --diag-prefix=VITTE-P
+	@python3 tools/normalize_analyze_report.py --in target/reports/json_analyze.json --out target/reports/json_analyze.json --package=vitte/json --diag-prefix=VITTE-J
+	@python3 tools/normalize_analyze_report.py --in target/reports/yaml_analyze.json --out target/reports/yaml_analyze.json --package=vitte/yaml --diag-prefix=VITTE-Y
+	@python3 tools/normalize_analyze_report.py --in target/reports/test_analyze.json --out target/reports/test_analyze.json --package=vitte/test --diag-prefix=VITTE-T
+	@python3 tools/normalize_analyze_report.py --in target/reports/lint_analyze.json --out target/reports/lint_analyze.json --package=vitte/lint --diag-prefix=VITTE-I
+
+.PHONY: diagnostics-index
+diagnostics-index:
+	@python3 tools/build_diagnostics_index.py
+
+.PHONY: reports-index
+reports-index:
+	@python3 tools/reports_index.py
+
+.PHONY: contracts-dashboard
+contracts-dashboard:
+	@python3 tools/contracts_dashboard.py
+
+.PHONY: quickfix-schema-snapshots
+quickfix-schema-snapshots:
+	@python3 tools/quickfix_schema_snapshots.py
+
+.PHONY: diagnostics-stability-lint
+diagnostics-stability-lint:
+	@python3 tools/lint_diagnostics_stability.py
+
+.PHONY: lint-rule-ownership-lint
+lint-rule-ownership-lint:
+	@python3 tools/lint_lint_rule_ownership.py
+
+.PHONY: docs-sync-gate
+docs-sync-gate:
+	@python3 tools/docs_sync_gate.py
+
+.PHONY: security-gates-report
+security-gates-report:
+	@tools/security_gates_report.sh
+
+.PHONY: security-hardening-gate
+security-hardening-gate:
+	@python3 tools/security_hardening_gate.py --min-score=$${SECURITY_HARDENING_MIN:-75}
+
+.PHONY: security-baseline-diff
+security-baseline-diff: security-gates-report
+	@python3 tools/security_baseline_diff.py
+
+.PHONY: security-baseline-update
+security-baseline-update: security-gates-report
+	@python3 tools/security_baseline_diff.py --update
+
+.PHONY: plugin-abi-compat
+plugin-abi-compat:
+	@python3 tools/plugin_abi_compat_check.py
+
+.PHONY: plugin-manifest-lint
+plugin-manifest-lint:
+	@python3 tools/lint_plugin_manifest.py
+
+.PHONY: plugin-sandbox-lint
+plugin-sandbox-lint:
+	@python3 tools/lint_plugin_sandbox_permissions.py
+
+.PHONY: plugin-binary-abi
+plugin-binary-abi:
+	@python3 tools/plugin_binary_abi_smoke.py
+
+.PHONY: api-nonregression-doctors
+api-nonregression-doctors:
+	@python3 tools/api_nonregression_doctors.py
+
+.PHONY: api-diff-explainer
+api-diff-explainer:
+	@python3 tools/api_diff_explainer.py
+
+.PHONY: breaking-removal-table
+breaking-removal-table:
+	@python3 tools/test_breaking_removal_table.py
+
+.PHONY: deprecated-wrappers-budget-lint
+deprecated-wrappers-budget-lint:
+	@python3 tools/lint_deprecated_wrappers_budget.py
+
+.PHONY: cross-package-smoke
+cross-package-smoke:
+	@tools/cross_package_smoke.sh
+
+.PHONY: doctors
+doctors:
+	@tools/doctors_dashboard.sh
+
+.PHONY: symbol-index
+symbol-index:
+	@python3 tools/build_symbol_index.py
+
+.PHONY: perf-regression
+perf-regression:
+	@python3 tools/perf_regression_check.py --threshold-pct=15
+
+.PHONY: perf-regression-robust
+perf-regression-robust:
+	@profile="$${PERF_MACHINE_PROFILE:-}"; \
+	if [ -z "$$profile" ]; then \
+	  if [ -n "$${CI:-}" ]; then profile=ci; else profile=dev; fi; \
+	fi; \
+	echo "[perf-regression-robust] profile=$$profile"; \
+	python3 tools/perf_regression_robust.py --profile="$$profile" --threshold-pct=20 --variance-cap-pct=75
+
+.PHONY: perf-budget
+perf-budget:
+	@python3 tools/perf_budget_check.py
+
+.PHONY: analyze-schema-snapshot
+analyze-schema-snapshot: analyze-json-unify
+	@python3 tools/analyze_schema_snapshot.py
+
+.PHONY: analyze-schema-snapshot-update
+analyze-schema-snapshot-update: analyze-json-unify
+	@python3 tools/analyze_schema_snapshot.py --update
+
+.PHONY: network-process-profile-matrix
+network-process-profile-matrix:
+	@tools/network_process_profile_matrix.sh
+
+.PHONY: semantic-contract-tests
+semantic-contract-tests:
+	@tools/semantic_contract_tests.sh
+
+.PHONY: semantic-golden-cross-package
+semantic-golden-cross-package:
+	@python3 tools/semantic_golden_cross_package.py
+
+.PHONY: gtk-quickfix-e2e
+gtk-quickfix-e2e:
+	@tools/gtk_quickfix_e2e.sh
+
+.PHONY: gtk-workflow-snapshots
+gtk-workflow-snapshots:
+	@tools/gtk_workflow_snapshots.sh
+
+.PHONY: generate-highlights
+generate-highlights:
+	@python3 tools/generate_editor_highlights.py
+
+.PHONY: highlight-snapshot-vim
+highlight-snapshot-vim: generate-highlights
+	@tools/highlight_snapshot_vim.sh
+
+.PHONY: highlight-snapshot-emacs
+highlight-snapshot-emacs: generate-highlights
+	@tools/highlight_snapshot_emacs.sh
+
+.PHONY: highlight-snapshot-nano
+highlight-snapshot-nano: generate-highlights
+	@tools/highlight_snapshot_nano.sh
+
+.PHONY: highlight-snapshots-update
+highlight-snapshots-update: generate-highlights
+	@tools/highlight_snapshot_vim.sh --update
+	@tools/highlight_snapshot_emacs.sh --update
+	@tools/highlight_snapshot_nano.sh --update
+
+.PHONY: highlights-coverage
+highlights-coverage: generate-highlights
+	@python3 tools/highlights_coverage.py
+
+.PHONY: tree-sitter-vitte-validate
+tree-sitter-vitte-validate:
+	@python3 tools/tree_sitter_vitte_validate.py
+
+.PHONY: tree-sitter-vitte-smoke
+tree-sitter-vitte-smoke:
+	@tools/tree_sitter_vitte_smoke.sh
+
+.PHONY: tree-sitter-vitte-ci
+tree-sitter-vitte-ci: tree-sitter-vitte-validate tree-sitter-vitte-smoke
+	@echo "[tree-sitter-vitte-ci] OK"
+
+.PHONY: highlights-ci
+highlights-ci: highlight-snapshot-vim highlight-snapshot-emacs highlight-snapshot-nano highlights-coverage tree-sitter-vitte-validate
+	@echo "[highlights-ci] OK"
+
+.PHONY: fuzz-corpus-manage
+fuzz-corpus-manage:
+	@python3 tools/fuzz_corpus_manager.py --write-corpus --minimize
+
+.PHONY: symbol-index-daemon-once
+symbol-index-daemon-once:
+	@python3 tools/symbol_index_daemon.py run-once
+
+.PHONY: debian-packaging-hardening
+debian-packaging-hardening:
+	@tools/debian_packaging_hardening.sh
+
+.PHONY: repro-report
+repro-report:
+	@python3 tools/repro_report.py
+
+.PHONY: deprecation-lifecycle-enforcer
+deprecation-lifecycle-enforcer:
+	@python3 tools/deprecation_lifecycle_enforcer.py --current-version=$${VITTE_VERSION:-3.0.0}
+
+.PHONY: pr-risk-budget
+pr-risk-budget:
+	@python3 tools/pr_risk_budget.py
+
+.PHONY: release-doctor
+release-doctor:
+	@python3 tools/release_doctor.py
+
+.PHONY: packages-only-ci
+packages-only-ci: contracts-refresh contract-lockfiles-lint facade-role-contracts-lint facade-thin-lint diag-namespace-lint alias-pkg-global-lint no-side-effects-global-lint core-only-ci std-only-ci log-only-ci fs-only-ci db-only-ci http-only-ci http-client-only-ci process-only-ci json-only-ci yaml-only-ci test-only-ci lint-only-ci diagnostics-index contracts-dashboard reports-index security-gates-report cross-package-smoke symbol-index analyze-json-unify analyze-schema-snapshot quickfix-schema-snapshots diagnostics-stability-lint api-nonregression-doctors api-diff-explainer lint-rule-ownership-lint breaking-removal-table
+
+.PHONY: packages-strict-ci
+packages-strict-ci: packages-only-ci core-strict-ci std-strict-ci log-strict-ci fs-strict-ci db-strict-ci http-strict-ci http-client-strict-ci process-strict-ci json-strict-ci yaml-strict-ci test-strict-ci lint-strict-ci semantic-contract-tests semantic-golden-cross-package highlights-ci deprecated-wrappers-budget-lint deprecation-lifecycle-enforcer plugin-abi-compat plugin-manifest-lint plugin-sandbox-lint plugin-binary-abi fuzz-corpus-manage symbol-index-daemon-once perf-regression-robust perf-budget security-hardening-gate security-baseline-diff docs-sync-gate gtk-quickfix-e2e gtk-workflow-snapshots
+
+.PHONY: packages-changed-ci
+packages-changed-ci:
+	@tools/changed_packages_ci.sh
+
+.PHONY: packages-impacted-strict
+packages-impacted-strict:
+	@targets="$$(python3 tools/packages_impacted_strict.py --base-ref=$${BASE_REF:-HEAD~1})"; \
+	echo "[packages-impacted-strict] targets: $$targets"; \
+	make -s $$targets
+
+.PHONY: package-ci-cached
+package-ci-cached:
+	@tools/pkg_ci_cached.sh "$(PKG)" "$${TARGET:-$(PKG)-only-ci}"
+
+.PHONY: release-readiness
+release-readiness: packages-strict-ci doctors release-doctor contracts-dashboard reports-index security-gates-report security-hardening-gate security-baseline-diff perf-regression-robust perf-budget plugin-abi-compat plugin-manifest-lint plugin-sandbox-lint plugin-binary-abi debian-packaging-hardening repro-report analyze-json-unify analyze-schema-snapshot api-diff-explainer docs-sync-gate pr-risk-budget
+	@echo "[release-readiness] OK"
 
 .PHONY: new-public-packages-snapshots-lint
 new-public-packages-snapshots-lint:
@@ -494,7 +1891,7 @@ packages-contract-snapshots-update:
 packages-gate: package-layout-lint-strict packages-governance-lint no-std-lint module-naming-lint legacy-import-path-lint critical-runtime-matrix-lint new-public-packages-snapshots-lint modules-perf-cache packages-report packages-contract-snapshots
 
 .PHONY: modules-ci-strict
-modules-ci-strict: modules-tests modules-snapshots modules-contract-snapshots module-tree-lint module-naming-lint critical-module-contract-lint experimental-modules-lint public-modules-snapshots-lint modules-perf-cache legacy-import-path-lint migration-check modules-report
+modules-ci-strict: modules-tests modules-snapshots modules-contract-snapshots array-export-snapshot-lint ast-export-snapshot-lint module-tree-lint module-naming-lint critical-module-contract-lint experimental-modules-lint public-modules-snapshots-lint modules-perf-cache legacy-import-path-lint migration-check modules-report
 	@$(BIN_DIR)/$(PROJECT) mod contract-diff --lang=en --old tests/modules/api_diff/old_case/main.vit --new tests/modules/api_diff/new_case/main.vit >/tmp/vitte-modules-ci-contract-diff.out 2>&1 || true
 	@grep -Fq "[contract-diff] BREAKING" /tmp/vitte-modules-ci-contract-diff.out
 	@$(BIN_DIR)/$(PROJECT) mod contract-diff --lang=en --old tests/modules/api_diff/old_case/main.vit --new tests/modules/api_diff/old_case/main.vit >/tmp/vitte-modules-ci-contract-diff-ok.out 2>&1
@@ -534,6 +1931,10 @@ completions-fallback:
 .PHONY: same-output-hash
 same-output-hash:
 	@tools/same_output_hash_test.sh
+
+.PHONY: crash-report-snapshots
+crash-report-snapshots:
+	@tools/crash_report_snapshots.sh
 
 .PHONY: ci-std-fast
 ci-std-fast: std-check extern-abi-host stdlib-api-lint stdlib-profile-snapshots diag-snapshots completions-snapshots wrapper-stage-test
@@ -692,7 +2093,7 @@ vitteos-ci-min: vitteos-scripts-check-soft vitteos-issues-check vitteos-domain-c
 PKG_VERSION ?= 2.1.1
 
 .PHONY: pkg-debian
-pkg-debian:
+pkg-debian: release-readiness
 	@VERSION=$(PKG_VERSION) toolchain/scripts/package/make-debian-deb.sh
 
 .PHONY: pkg-debian-install
@@ -745,9 +2146,17 @@ modules-fix-all-check:
 mod-migrate-imports:
 	@tools/mod_migrate_imports.sh --roots tests examples
 
+.PHONY: alloc-ci-short
+alloc-ci-short:
+	@MODE=short tools/ci_alloc_matrix.sh
+
+.PHONY: alloc-ci-nightly
+alloc-ci-nightly:
+	@MODE=nightly tools/ci_alloc_matrix.sh
+
 .PHONY: modules-weekly-deny-legacy
 modules-weekly-deny-legacy:
-	@DENY_LEGACY_SELF_LEAF=1 tools/modules_tests.sh
+	@DENY_LEGACY_SELF_LEAF=1 ALERTS_FUZZ_NIGHTLY=1 ALLOC_FUZZ_NIGHTLY=1 tools/modules_tests.sh
 
 .PHONY: modules-weekly-legacy-warn-only
 modules-weekly-legacy-warn-only:
@@ -760,6 +2169,24 @@ release-modules-gate: modules-ci-strict modules-contract-snapshots modules-repor
 platon-editor:
 	@./bin/vitte build platon-editor/editor_core.vit -o platon-editor/editor_core
 	@platon-editor/editor_core
+
+.PHONY: vitte-ide
+vitte-ide: dirs
+	$(CXX) $(CXXFLAGS) apps/vitte_ide_cpp/vitte_ide.cpp -o $(BIN_DIR)/vitte-ide -lncurses -pthread
+
+.PHONY: vitte-ide-plugin-analyzer
+vitte-ide-plugin-analyzer: plugins/vitte_analyzer_pack.so
+
+plugins/vitte_analyzer_pack.so: plugins/vitte_analyzer_pack.cpp apps/vitte_ide_gtk/plugin_api.hpp
+	$(CXX) $(CXXFLAGS) -fPIC -shared plugins/vitte_analyzer_pack.cpp -o plugins/vitte_analyzer_pack.so
+
+.PHONY: vitte-ide-gtk
+vitte-ide-gtk: dirs vitte-ide-plugin-analyzer
+	$(CXX) $(CXXFLAGS) apps/vitte_ide_gtk/vitte_ide_gtk.cpp -o $(BIN_DIR)/vitte-ide-gtk $(shell pkg-config --cflags --libs gtk+-3.0) -pthread -ldl
+
+.PHONY: tui-ide-snapshots
+tui-ide-snapshots:
+	@tools/tui_ide_snapshots.sh
 
 # ------------------------------------------------------------
 # Clean
@@ -811,6 +2238,227 @@ help:
 	@echo "  make modules-snapshots assert mod graph/doctor outputs"
 	@echo "  make modules-snapshots-update regenerate modules snapshot files (.must/.diagjson/.codes/.fr)"
 	@echo "  make modules-snapshots-bless regenerate modules snapshots and print diffs"
+	@echo "  make core-mod-lint enforce vitte/core facade invariants and no side-effects"
+	@echo "  make core-contract-snapshots validate tests/modules/contracts/core snapshots"
+	@echo "  make core-contract-snapshots-update refresh core contracts snapshot hash"
+	@echo "  make core-facade-snapshot validate sorted core facade API snapshot + hash"
+	@echo "  make core-facade-snapshot-update refresh core facade API snapshot + hash"
+	@echo "  make core-smoke run vitte/core smoke check fixture"
+	@echo "  make core-no-side-effects-test ensure import-only core check fixture passes"
+	@echo "  make core-profile-strict-test run strict core profile fixture"
+	@echo "  make core-analyze-json emit target/reports/core_analyze.json"
+	@echo "  make core-contract-diff compare core facade baseline vs current exports"
+	@echo "  make core-bench run micro benchmark harness for core helpers"
+	@echo "  make core-fuzz run placeholder fuzz harness with versioned seeds"
+	@echo "  make core-gtk-e2e generate GTK core quickfix interaction snapshot"
+	@echo "  make core-only-ci run core-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make core-strict-ci run core-only-ci + strict alias/import lint + bench/fuzz"
+	@echo "  make std-mod-lint enforce vitte/std facade invariants and diagnostics namespace"
+	@echo "  make std-no-side-effects-lint enforce no 'entry' across src/vitte/packages/std"
+	@echo "  make std-contract-snapshots validate tests/modules/contracts/std snapshots"
+	@echo "  make std-contract-snapshots-update refresh std contracts snapshot hash"
+	@echo "  make std-facade-snapshot validate sorted std facade API snapshot + hash"
+	@echo "  make std-facade-snapshot-update refresh std facade API snapshot + hash"
+	@echo "  make std-smoke run vitte/std smoke check fixture"
+	@echo "  make std-no-side-effects-test ensure import-only std check fixture passes"
+	@echo "  make std-profile-strict-test run strict std profile fixture"
+	@echo "  make std-analyze-json emit target/reports/std_analyze.json"
+	@echo "  make std-contract-diff compare std facade baseline vs current exports"
+	@echo "  make std-bench run std micro + import latency benchmarks"
+	@echo "  make std-fuzz run std fuzz seed harness"
+	@echo "  make std-docsgen generate docs/std API markdown index"
+	@echo "  make std-symbol-index generate persistent std symbol index"
+	@echo "  make std-symbol-search Q='sym:foo kind:proc module:std/base' query std symbol index"
+	@echo "  make std-only-ci run std-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make std-strict-ci run std-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make log-mod-lint enforce vitte/log facade invariants and diagnostics namespace"
+	@echo "  make log-no-side-effects-lint enforce no 'entry' across src/vitte/packages/log"
+	@echo "  make log-contract-snapshots validate tests/modules/contracts/log snapshots"
+	@echo "  make log-facade-snapshot validate sorted log facade API snapshot + hash"
+	@echo "  make log-smoke run vitte/log smoke check fixture"
+	@echo "  make log-no-side-effects-test ensure import-only log check fixture passes"
+	@echo "  make log-profile-strict-test run strict log profile fixture"
+	@echo "  make log-analyze-json emit target/reports/log_analyze.json"
+	@echo "  make log-contract-diff compare log facade baseline vs current exports"
+	@echo "  make log-bench run log micro + macro benchmarks"
+	@echo "  make log-fuzz run log fuzz seed harness"
+	@echo "  make log-docsgen generate docs/log API markdown index"
+	@echo "  make log-only-ci run log-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make log-strict-ci run log-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make fs-mod-lint enforce vitte/fs facade invariants and diagnostics namespace"
+	@echo "  make fs-no-side-effects-lint enforce no 'entry' across src/vitte/packages/fs"
+	@echo "  make fs-contract-snapshots validate tests/modules/contracts/fs snapshots"
+	@echo "  make fs-facade-snapshot validate sorted fs facade API snapshot + hash"
+	@echo "  make fs-smoke run vitte/fs smoke check fixture"
+	@echo "  make fs-no-side-effects-test ensure import-only fs check fixture passes"
+	@echo "  make fs-profile-strict-test run strict fs profile fixture"
+	@echo "  make fs-analyze-json emit target/reports/fs_analyze.json"
+	@echo "  make fs-contract-diff compare fs facade baseline vs current exports"
+	@echo "  make fs-bench run fs micro + macro benchmarks"
+	@echo "  make fs-fuzz run fs fuzz seed harness"
+	@echo "  make fs-docsgen generate docs/fs API markdown index"
+	@echo "  make fs-only-ci run fs-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make fs-strict-ci run fs-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make db-mod-lint enforce vitte/db facade invariants and diagnostics namespace"
+	@echo "  make db-no-side-effects-lint enforce no 'entry' across src/vitte/packages/db"
+	@echo "  make db-contract-snapshots validate tests/modules/contracts/db snapshots"
+	@echo "  make db-facade-snapshot validate sorted db facade API snapshot + hash"
+	@echo "  make db-smoke run vitte/db smoke check fixture"
+	@echo "  make db-no-side-effects-test ensure import-only db check fixture passes"
+	@echo "  make db-profile-strict-test run strict db profile fixture"
+	@echo "  make db-analyze-json emit target/reports/db_analyze.json"
+	@echo "  make db-contract-diff compare db facade baseline vs current exports"
+	@echo "  make db-bench run db micro + macro benchmarks"
+	@echo "  make db-fuzz run db fuzz seed harness"
+	@echo "  make db-docsgen generate docs/db API markdown index"
+	@echo "  make db-only-ci run db-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make db-strict-ci run db-only-ci + strict alias lint + migration-compat + bench/fuzz/docs"
+	@echo "  make http-mod-lint enforce vitte/http facade invariants and diagnostics namespace"
+	@echo "  make http-client-mod-lint enforce vitte/http_client facade invariants and diagnostics namespace"
+	@echo "  make http-contract-snapshots validate tests/modules/contracts/http snapshots"
+	@echo "  make http-facade-snapshot validate sorted http facade API snapshot + hash"
+	@echo "  make http-smoke run vitte/http smoke check fixture"
+	@echo "  make http-no-side-effects-test ensure import-only http check fixture passes"
+	@echo "  make http-profile-strict-test run strict http profile fixture"
+	@echo "  make http-analyze-json emit target/reports/http_analyze.json"
+	@echo "  make http-contract-diff compare http facade baseline vs current exports"
+	@echo "  make http-bench run http micro + macro benchmarks"
+	@echo "  make http-fuzz run http fuzz seed harness"
+	@echo "  make http-docsgen generate docs/http API markdown index"
+	@echo "  make http-only-ci run http-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make http-strict-ci run http-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make json-mod-lint enforce vitte/json facade invariants and diagnostics namespace"
+	@echo "  make json-contract-snapshots validate tests/modules/contracts/json snapshots"
+	@echo "  make json-facade-snapshot validate sorted json facade API snapshot + hash"
+	@echo "  make json-smoke run vitte/json smoke check fixture"
+	@echo "  make json-no-side-effects-test ensure import-only json check fixture passes"
+	@echo "  make json-profile-strict-test run strict json profile fixture"
+	@echo "  make json-analyze-json emit target/reports/json_analyze.json"
+	@echo "  make json-contract-diff compare json facade baseline vs current exports"
+	@echo "  make json-bench run json micro + macro benchmarks"
+	@echo "  make json-fuzz run json fuzz seed harness"
+	@echo "  make json-docsgen generate docs/json API markdown index"
+	@echo "  make json-only-ci run json-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make json-strict-ci run json-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make yaml-mod-lint enforce vitte/yaml facade invariants and diagnostics namespace"
+	@echo "  make yaml-contract-snapshots validate tests/modules/contracts/yaml snapshots"
+	@echo "  make yaml-facade-snapshot validate sorted yaml facade API snapshot + hash"
+	@echo "  make yaml-smoke run vitte/yaml smoke check fixture"
+	@echo "  make yaml-no-side-effects-test ensure import-only yaml check fixture passes"
+	@echo "  make yaml-profile-strict-test run strict yaml profile fixture"
+	@echo "  make yaml-analyze-json emit target/reports/yaml_analyze.json"
+	@echo "  make yaml-contract-diff compare yaml facade baseline vs current exports"
+	@echo "  make yaml-bench run yaml micro + macro benchmarks"
+	@echo "  make yaml-fuzz run yaml fuzz seed harness"
+	@echo "  make yaml-docsgen generate docs/yaml API markdown index"
+	@echo "  make yaml-only-ci run yaml-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make yaml-strict-ci run yaml-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make test-mod-lint enforce vitte/test facade invariants and diagnostics namespace"
+	@echo "  make test-contract-snapshots validate tests/modules/contracts/test snapshots"
+	@echo "  make test-facade-snapshot validate sorted test facade API snapshot + hash"
+	@echo "  make test-smoke run vitte/test smoke check fixture"
+	@echo "  make test-no-side-effects-test ensure import-only test check fixture passes"
+	@echo "  make test-profile-strict-test run strict test profile fixture"
+	@echo "  make test-analyze-json emit target/reports/test_analyze.json"
+	@echo "  make test-contract-diff compare test facade baseline vs current exports"
+	@echo "  make test-bench run test micro + macro benchmarks"
+	@echo "  make test-fuzz run test fuzz seed harness"
+	@echo "  make test-docsgen generate docs/test API markdown index"
+	@echo "  make test-only-ci run test-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make test-strict-ci run test-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make lint-mod-lint enforce vitte/lint facade invariants and diagnostics namespace"
+	@echo "  make lint-contract-snapshots validate tests/modules/contracts/lint snapshots"
+	@echo "  make lint-facade-snapshot validate sorted lint facade API snapshot + hash"
+	@echo "  make lint-smoke run vitte/lint smoke check fixture"
+	@echo "  make lint-no-side-effects-test ensure import-only lint check fixture passes"
+	@echo "  make lint-profile-strict-test run strict lint profile fixture"
+	@echo "  make lint-analyze-json emit target/reports/lint_analyze.json"
+	@echo "  make lint-contract-diff compare lint facade baseline vs current exports"
+	@echo "  make lint-bench run lint micro + macro benchmarks"
+	@echo "  make lint-fuzz run lint fuzz seed harness"
+	@echo "  make lint-docsgen generate docs/lint API markdown index"
+	@echo "  make lint-only-ci run lint-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make lint-strict-ci run lint-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make http-client-contract-snapshots validate tests/modules/contracts/http_client snapshots"
+	@echo "  make http-client-facade-snapshot validate sorted http_client facade API snapshot + hash"
+	@echo "  make http-client-smoke run vitte/http_client smoke check fixture"
+	@echo "  make http-client-no-side-effects-test ensure import-only http_client check fixture passes"
+	@echo "  make http-client-profile-strict-test run strict http_client profile fixture"
+	@echo "  make http-client-analyze-json emit target/reports/http_client_analyze.json"
+	@echo "  make http-client-bench run http_client micro + macro benchmarks"
+	@echo "  make http-client-fuzz run http_client fuzz seed harness"
+	@echo "  make http-client-docsgen generate docs/http_client API markdown index"
+	@echo "  make http-client-only-ci run http_client-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make http-client-strict-ci run http-client-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make process-mod-lint enforce vitte/process facade invariants and diagnostics namespace"
+	@echo "  make process-contract-snapshots validate tests/modules/contracts/process snapshots"
+	@echo "  make process-facade-snapshot validate sorted process facade API snapshot + hash"
+	@echo "  make process-smoke run vitte/process smoke check fixture"
+	@echo "  make process-no-side-effects-test ensure import-only process check fixture passes"
+	@echo "  make process-profile-strict-test run strict process profile fixture"
+	@echo "  make process-analyze-json emit target/reports/process_analyze.json"
+	@echo "  make process-contract-diff compare process facade baseline vs current exports"
+	@echo "  make process-bench run process micro + macro benchmarks"
+	@echo "  make process-fuzz run process fuzz seed harness"
+	@echo "  make process-docsgen generate docs/process API markdown index"
+	@echo "  make process-only-ci run process-focused lint + snapshots + smoke + analyze-json"
+	@echo "  make process-strict-ci run process-only-ci + strict alias lint + contract diff + bench/fuzz/docs"
+	@echo "  make contracts-refresh regenerate contracts snapshots/hash/lockfiles from mod.vit"
+	@echo "  make contract-lockfiles-lint validate generated contract lockfiles consistency"
+	@echo "  make facade-role-contracts-lint enforce unified ROLE-CONTRACT template across key facades"
+	@echo "  make facade-thin-lint enforce lightweight facades (mod.vit)"
+	@echo "  make diag-namespace-lint enforce diagnostic namespace ownership per package"
+	@echo "  make alias-pkg-global-lint run unified alias *_pkg lint engine"
+	@echo "  make no-side-effects-global-lint run unified no-side-effects lint engine"
+	@echo "  make diagnostics-index build central diagnostics index JSON/Markdown"
+	@echo "  make contracts-dashboard build markdown dashboard for contracts/hash/status"
+	@echo "  make reports-index build unified target/reports/index.json for IDE/pipeline"
+	@echo "  make security-gates-report build consolidated multi-package security gates report"
+	@echo "  make security-hardening-gate enforce SSRF/TLS/CRLF/process/fs hardening minimum score"
+	@echo "  make security-baseline-diff compare security gates report against versioned baseline"
+	@echo "  make security-baseline-update refresh versioned security baseline from current report"
+	@echo "  make analyze-json-unify normalize analyze reports to stable schema v1.0"
+	@echo "  make analyze-schema-snapshot verify global analyze schema snapshot"
+	@echo "  make analyze-schema-snapshot-update update global analyze schema snapshot"
+	@echo "  make api-nonregression-doctors enforce doctor/quickfix facade API presence"
+	@echo "  make network-process-profile-matrix emit core/desktop/system matrix for http/http_client/process"
+	@echo "  make cross-package-smoke run HTTP->process->log->fs smoke scenario"
+	@echo "  make doctors run all API doctors and emit dashboard report"
+	@echo "  make symbol-index build persistent symbol index for IDE/compiler sharing"
+	@echo "  make symbol-index-daemon-once build shared symbol-index shards/manifest"
+	@echo "  make generate-highlights regenerate vim/emacs/nano/tree-sitter highlight assets from grammar"
+	@echo "  make highlight-snapshot-vim verify vim highlight snapshot"
+	@echo "  make highlight-snapshot-emacs verify emacs highlight snapshot"
+	@echo "  make highlight-snapshot-nano verify nano highlight snapshot"
+	@echo "  make highlight-snapshots-update refresh editor highlight snapshots"
+	@echo "  make highlights-coverage write target/reports/highlights_coverage.json and enforce strict constructs"
+	@echo "  make highlights-ci run highlight snapshots + coverage gate (vim+emacs strict required)"
+	@echo "  make tree-sitter-vitte-validate static-validate VITTE tree-sitter grammar/query/corpus presence"
+	@echo "  make tree-sitter-vitte-smoke run tree-sitter generate/test when CLI is available"
+	@echo "  make tree-sitter-vitte-ci run validate + smoke for VITTE tree-sitter parser"
+	@echo "  make semantic-contract-tests run behavior-oriented contract checks (not just exports)"
+	@echo "  make semantic-golden-cross-package run golden behavior check HTTP->Process->Log->FS->DB"
+	@echo "  make fuzz-corpus-manage run centralized fuzz corpus dedup/minimize/triage report"
+	@echo "  make perf-regression compare bench outputs with baseline threshold"
+	@echo "  make perf-regression-robust run median/warmup/variance-aware perf gate"
+	@echo "  make perf-budget enforce per-package p95 budgets from tools/perf_budget.json"
+	@echo "  make plugin-abi-compat validate plugin command ABI surface"
+	@echo "  make plugin-manifest-lint validate plugins/plugin.toml command schema declarations"
+	@echo "  make plugin-sandbox-lint validate per-command plugin permission policy"
+	@echo "  make plugin-binary-abi compile+dlopen plugin shared library and validate ABI"
+	@echo "  make deprecation-lifecycle-enforcer fail on expired deprecated wrappers by version"
+	@echo "  make debian-packaging-hardening validate desktop/metainfo/assets packaging readiness"
+	@echo "  make repro-report generate build provenance/reproducibility report JSON"
+	@echo "  make pr-risk-budget compute PR risk budget (breaking/perf/security/docs)"
+	@echo "  make release-doctor aggregate contracts/perf/security/docs/ABI gates with failing reports"
+	@echo "  make gtk-workflow-snapshots emit GTK workflow snapshots marker file"
+	@echo "  make gtk-quickfix-e2e validate GTK quickfix flow markers (Problems->preview->apply->recheck)"
+	@echo "  make breaking-removal-table run table-driven breaking removal detection across key packages"
+	@echo "  make deprecated-wrappers-budget-lint enforce deprecated wrapper removal budget policy"
+	@echo "  make packages-only-ci run unified fast package gate for core/std/log/fs/db/http/http_client/process/json/yaml/test/lint"
+	@echo "  make packages-strict-ci run full strict gate including perf/plugin/deprecation checks"
+	@echo "  make packages-changed-ci run only impacted package CI targets (BASE_REF=HEAD~1 by default)"
+	@echo "  make release-readiness run contracts+security+perf+ABI+schema aggregate gate"
 	@echo "  make explain-snapshots assert vitte explain outputs"
 	@echo "  make same-output-hash verify deterministic emit hash stability"
 	@echo "  make completions-gen regenerate bash/zsh/fish completions from unified spec"
@@ -856,6 +2504,8 @@ help:
 	@echo "  make vitteos-ci-local run local VitteOS CI chain without external /bin migration dataset"
 	@echo "  make vitteos-ci-min run minimal fast checks for pre-commit local loop"
 	@echo "  make platon-editor build and self-test platon editor core"
+	@echo "  make vitte-ide build C++ TUI IDE for Vitte projects (auto-check/build/debug/suggestions)"
+	@echo "  make vitte-ide-gtk build C++ GTK IDE (Geany-like GUI with tabs/tree/problems)"
 	@echo "  make std-check  verify std layout"
 	@echo "  make clean      remove build artifacts"
 	@echo "  make distclean  full cleanup"

--- a/toolchain/scripts/package/make-debian-deb.sh
+++ b/toolchain/scripts/package/make-debian-deb.sh
@@ -8,17 +8,22 @@
 set -euo pipefail
 
 ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+DEPS_FILE="${DEPS_FILE:-$ROOT_DIR/toolchain/scripts/install/debian-deps.sh}"
 
 VERSION="${VERSION:-2.1.1}"
 PACKAGE_NAME="${PACKAGE_NAME:-vitte}"
 MAINTAINER="${MAINTAINER:-Vitte Team <maintainers@vitte.dev>}"
 DESCRIPTION="${DESCRIPTION:-Vitte systems language toolchain}"
 HOMEPAGE="${HOMEPAGE:-https://vitte.netlify.app/}"
+VCS_URL="${VCS_URL:-https://github.com/vitte/vitte}"
+BUGS_URL="${BUGS_URL:-https://github.com/vitte/vitte/issues}"
 SECTION="${SECTION:-devel}"
 PRIORITY="${PRIORITY:-optional}"
 OUT_DIR="${OUT_DIR:-$ROOT_DIR/pkgout}"
 ARCH="${ARCH:-$(dpkg --print-architecture 2>/dev/null || echo amd64)}"
-DEPENDS="${DEPENDS:-bash, libc6, libstdc++6, libssl3 | libssl1.1, libcurl4}"
+DEPENDS="${DEPENDS:-}"
+PROJECT_INFO_TITLE="${PROJECT_INFO_TITLE:-Vitte systems language toolchain}"
+RELEASE_READINESS_GATE="${RELEASE_READINESS_GATE:-1}"
 
 STAGE_BASE="$ROOT_DIR/.debstage/${PACKAGE_NAME}-${VERSION}"
 STAGE_ROOT="$STAGE_BASE/root"
@@ -30,6 +35,15 @@ die() { printf "[make-debian-deb][error] %s\n" "$*" >&2; exit 1; }
 
 has() { command -v "$1" >/dev/null 2>&1; }
 
+if [ ! -f "$DEPS_FILE" ]; then
+  die "missing deps file: $DEPS_FILE"
+fi
+# shellcheck disable=SC1090
+source "$DEPS_FILE"
+if [ -z "$DEPENDS" ]; then
+  DEPENDS="$DEBIAN_RUNTIME_DEPENDS"
+fi
+
 resolve_bin() {
   local name="$1"
   local a="$ROOT_DIR/bin/$name"
@@ -39,19 +53,52 @@ resolve_bin() {
   return 1
 }
 
+ensure_bin() {
+  local name="$1"
+  local make_target="$2"
+  local src
+  src="$(resolve_bin "$name" || true)"
+  if [ -n "$src" ]; then
+    printf "%s\n" "$src"
+    return 0
+  fi
+  if has make; then
+    log "building missing binary '$name' via: make $make_target"
+    make -C "$ROOT_DIR" "$make_target"
+    src="$(resolve_bin "$name" || true)"
+  fi
+  [ -n "$src" ] || die "$name binary not found (expected bin/$name or target/bin/$name)"
+  printf "%s\n" "$src"
+}
+
 require_tools() {
   has dpkg-deb || die "dpkg-deb is required"
   has rsync || die "rsync is required"
   has python3 || die "python3 is required"
 }
 
+run_release_readiness_gate() {
+  [ "$RELEASE_READINESS_GATE" = "1" ] || {
+    log "release-readiness gate disabled (RELEASE_READINESS_GATE=$RELEASE_READINESS_GATE)"
+    return 0
+  }
+  has make || die "make is required for release-readiness gate"
+  log "running release-readiness gate before Debian packaging"
+  make -C "$ROOT_DIR" -s release-readiness
+}
+
 stage_payload() {
   local vitte_bin
-  vitte_bin="$(resolve_bin vitte || true)"
-  [ -n "$vitte_bin" ] || die "vitte binary not found (expected bin/vitte or target/bin/vitte)"
+  local vitte_ide_bin
+  local vitte_ide_gtk_bin
+  vitte_bin="$(ensure_bin vitte build)"
+  vitte_ide_bin="$(ensure_bin vitte-ide vitte-ide)"
+  vitte_ide_gtk_bin="$(ensure_bin vitte-ide-gtk vitte-ide-gtk)"
 
   mkdir -p "$STAGE_ROOT/usr/local/libexec/vitte" "$STAGE_ROOT/usr/local/bin"
   install -m 0755 "$vitte_bin" "$STAGE_ROOT/usr/local/libexec/vitte/vitte"
+  install -m 0755 "$vitte_ide_bin" "$STAGE_ROOT/usr/local/libexec/vitte/vitte-ide"
+  install -m 0755 "$vitte_ide_gtk_bin" "$STAGE_ROOT/usr/local/libexec/vitte/vitte-ide-gtk"
 
   cat > "$STAGE_ROOT/usr/local/bin/vitte" <<'EOF'
 #!/usr/bin/env bash
@@ -63,16 +110,41 @@ exec /usr/local/libexec/vitte/vitte "$@"
 EOF
   chmod 0755 "$STAGE_ROOT/usr/local/bin/vitte"
 
-  for legacy in vittec vitte-linker; do
-    local src
-    src="$(resolve_bin "$legacy" || true)"
-    if [ -n "$src" ]; then
-      install -m 0755 "$src" "$STAGE_ROOT/usr/local/libexec/vitte/$legacy"
-      ln -sfn "../libexec/vitte/$legacy" "$STAGE_ROOT/usr/local/bin/$legacy"
-    else
-      ln -sfn "vitte" "$STAGE_ROOT/usr/local/bin/$legacy"
-    fi
-  done
+  cat > "$STAGE_ROOT/usr/local/bin/vitte-ide" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -z "${VITTE_ROOT:-}" ]; then
+  export VITTE_ROOT="/usr/local/share/vitte"
+fi
+if [ -n "${DISPLAY:-}" ] && [ -x /usr/local/libexec/vitte/vitte-ide-gtk ]; then
+  exec /usr/local/libexec/vitte/vitte-ide-gtk "$@"
+fi
+exec /usr/local/libexec/vitte/vitte-ide "$@"
+EOF
+  chmod 0755 "$STAGE_ROOT/usr/local/bin/vitte-ide"
+
+  cat > "$STAGE_ROOT/usr/local/bin/vitte-ide-gtk" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -z "${VITTE_ROOT:-}" ]; then
+  export VITTE_ROOT="/usr/local/share/vitte"
+fi
+exec /usr/local/libexec/vitte/vitte-ide-gtk "$@"
+EOF
+  chmod 0755 "$STAGE_ROOT/usr/local/bin/vitte-ide-gtk"
+
+  cat > "$STAGE_ROOT/usr/local/bin/vitte-editor" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -z "${VITTE_ROOT:-}" ]; then
+  export VITTE_ROOT="/usr/local/share/vitte"
+fi
+if [ -n "${DISPLAY:-}" ] && [ -x /usr/local/libexec/vitte/vitte-ide-gtk ]; then
+  exec /usr/local/libexec/vitte/vitte-ide-gtk "$@"
+fi
+exec /usr/local/libexec/vitte/vitte-ide "$@"
+EOF
+  chmod 0755 "$STAGE_ROOT/usr/local/bin/vitte-editor"
 
   mkdir -p "$STAGE_ROOT/usr/local/share/vitte/src/vitte"
   mkdir -p "$STAGE_ROOT/usr/local/share/vitte/src/compiler/backends"
@@ -81,19 +153,23 @@ EOF
 
   rsync -a "$ROOT_DIR/src/vitte/packages/" "$STAGE_ROOT/usr/local/share/vitte/src/vitte/packages/"
   rsync -a "$ROOT_DIR/src/compiler/backends/runtime/" "$STAGE_ROOT/usr/local/share/vitte/src/compiler/backends/runtime/"
+  if [ -f "$ROOT_DIR/version" ]; then
+    install -m 0644 "$ROOT_DIR/version" "$STAGE_ROOT/usr/local/share/vitte/version"
+  fi
 
-  mkdir -p "$STAGE_ROOT/usr/local/share/vitte/editors/vim" \
-           "$STAGE_ROOT/usr/local/share/vitte/editors/emacs" \
-           "$STAGE_ROOT/usr/local/share/vitte/editors/nano"
-  rsync -a "$ROOT_DIR/editors/vim/" "$STAGE_ROOT/usr/local/share/vitte/editors/vim/"
-  rsync -a "$ROOT_DIR/editors/emacs/" "$STAGE_ROOT/usr/local/share/vitte/editors/emacs/"
-  rsync -a "$ROOT_DIR/editors/nano/" "$STAGE_ROOT/usr/local/share/vitte/editors/nano/"
+  mkdir -p "$STAGE_ROOT/usr/local/share/vitte/editors"
+  if [ -d "$ROOT_DIR/editors" ]; then
+    rsync -a \
+      --exclude 'vscode/node_modules/' \
+      --exclude 'vscode/.vscode/' \
+      "$ROOT_DIR/editors/" "$STAGE_ROOT/usr/local/share/vitte/editors/"
+  fi
   [ -f "$ROOT_DIR/editors/README.md" ] && install -m 0644 "$ROOT_DIR/editors/README.md" "$STAGE_ROOT/usr/local/share/vitte/editors/README.md"
 
   install -m 0644 "$ROOT_DIR/toolchain/scripts/install/templates/env.sh" "$STAGE_ROOT/usr/local/share/vitte/env.sh"
 
   mkdir -p "$STAGE_ROOT/usr/local/share/man/man1"
-  for m in vitte.1 vittec.1 vitte-linker.1; do
+  for m in vitte.1 vitte-editor.1; do
     [ -f "$ROOT_DIR/man/$m" ] && install -m 0644 "$ROOT_DIR/man/$m" "$STAGE_ROOT/usr/local/share/man/man1/$m"
   done
 
@@ -110,10 +186,139 @@ EOF
   install -m 0644 "$ROOT_DIR/completions/bash/vitte" "$STAGE_ROOT/usr/local/share/vitte/completions/bash/vitte"
   install -m 0644 "$ROOT_DIR/completions/zsh/_vitte" "$STAGE_ROOT/usr/local/share/vitte/completions/zsh/_vitte"
   install -m 0644 "$ROOT_DIR/completions/fish/vitte.fish" "$STAGE_ROOT/usr/local/share/vitte/completions/fish/vitte.fish"
+
+  mkdir -p "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME"
+  [ -f "$ROOT_DIR/LICENSE" ] && install -m 0644 "$ROOT_DIR/LICENSE" "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME/LICENSE"
+  [ -f "$ROOT_DIR/README.md" ] && install -m 0644 "$ROOT_DIR/README.md" "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME/README.md"
+  [ -f "$ROOT_DIR/CHANGELOG.md" ] && install -m 0644 "$ROOT_DIR/CHANGELOG.md" "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME/CHANGELOG.md"
+  [ -f "$ROOT_DIR/CONTRIBUTING.md" ] && install -m 0644 "$ROOT_DIR/CONTRIBUTING.md" "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME/CONTRIBUTING.md"
+  [ -f "$ROOT_DIR/CODE_OF_CONDUCT.md" ] && install -m 0644 "$ROOT_DIR/CODE_OF_CONDUCT.md" "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME/CODE_OF_CONDUCT.md"
+  [ -f "$ROOT_DIR/SECURITY.md" ] && install -m 0644 "$ROOT_DIR/SECURITY.md" "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME/SECURITY.md"
+  [ -f "$ROOT_DIR/SUPPORT.md" ] && install -m 0644 "$ROOT_DIR/SUPPORT.md" "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME/SUPPORT.md"
+
+  local git_commit
+  git_commit="$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || true)"
+  cat > "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME/PROJECT_INFO" <<EOF
+Name: ${PACKAGE_NAME}
+Title: ${PROJECT_INFO_TITLE}
+Version: ${VERSION}
+Architecture: ${ARCH}
+Homepage: ${HOMEPAGE}
+VCS: ${VCS_URL}
+Issues: ${BUGS_URL}
+Maintainer: ${MAINTAINER}
+Build-Date-UTC: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+Git-Commit: ${git_commit:-unknown}
+Binary: /usr/local/bin/vitte
+IDE-Binary: /usr/local/bin/vitte-ide
+IDE-GTK-Binary: /usr/local/bin/vitte-ide-gtk
+Editor-Binary: /usr/local/bin/vitte-editor
+Root: /usr/local/share/vitte
+License-File: /usr/share/doc/${PACKAGE_NAME}/LICENSE
+EOF
+
+  mkdir -p "$STAGE_ROOT/usr/share/icons/hicolor/scalable/apps"
+  mkdir -p "$STAGE_ROOT/usr/share/pixmaps"
+  install -m 0644 "$ROOT_DIR/toolchain/assets/vitte-logo-circle-blue.svg" "$STAGE_ROOT/usr/share/icons/hicolor/scalable/apps/vitte.svg"
+  install -m 0644 "$ROOT_DIR/toolchain/assets/vitte-logo-circle-blue.svg" "$STAGE_ROOT/usr/share/pixmaps/vitte.svg"
+  cat > "$STAGE_ROOT/usr/share/doc/$PACKAGE_NAME/copyright" <<'EOF'
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: vitte
+Upstream-Contact: Vitte Team <maintainers@vitte.dev>
+Source: https://github.com/vitte/vitte
+
+Files: *
+Copyright: 2021-2026 Vitte contributors
+License: GPL-3.0-only
+ This package is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; version 3.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ .
+ On Debian systems, the full text of the GNU General Public License
+ version 3 can be found in /usr/share/common-licenses/GPL-3.
+EOF
+
+  mkdir -p "$STAGE_ROOT/usr/share/applications"
+  cat > "$STAGE_ROOT/usr/share/applications/vitte.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=VITTE
+GenericName=Systems Language Toolchain
+Comment=Vitte IDE and toolchain
+Exec=vitte-ide-gtk
+Icon=vitte
+Terminal=false
+Categories=Development;IDE;
+Keywords=compiler;language;toolchain;vitte;ide;editor;
+NoDisplay=false
+Actions=OpenGtk;OpenTui;OpenTerminal;
+
+[Desktop Action OpenGtk]
+Name=Open VITTE GTK IDE
+Exec=vitte-ide-gtk
+
+[Desktop Action OpenTui]
+Name=Open VITTE Terminal IDE
+Exec=vitte-ide
+Terminal=true
+
+[Desktop Action OpenTerminal]
+Name=Open VITTE Shell
+Exec=x-terminal-emulator -e bash -lc "vitte --help; exec bash"
+Terminal=false
+EOF
+
+  mkdir -p "$STAGE_ROOT/usr/share/metainfo"
+  cat > "$STAGE_ROOT/usr/share/metainfo/vitte.metainfo.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>vitte.desktop</id>
+  <name>Vitte</name>
+  <summary>Vitte systems language toolchain</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <icon type="cached">vitte</icon>
+  <developer id="dev.vitte">
+    <name>Vitte Team</name>
+  </developer>
+  <description>
+    <p>Unified Vitte toolchain including compiler, runtime sources, standard packages, editor support and shell completions.</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>VITTE GTK IDE main workspace</caption>
+      <image type="source">https://raw.githubusercontent.com/vitte/vitte/main/toolchain/assets/vitte-logo-circle-blue.svg</image>
+    </screenshot>
+    <screenshot>
+      <caption>VITTE project navigation and diagnostics</caption>
+      <image type="source">https://raw.githubusercontent.com/vitte/vitte/main/toolchain/assets/vitte-logo-circle-blue.svg</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">${HOMEPAGE}</url>
+  <url type="bugtracker">${BUGS_URL}</url>
+  <url type="vcs-browser">${VCS_URL}</url>
+  <provides>
+    <binary>vitte</binary>
+    <binary>vitte-ide</binary>
+    <binary>vitte-ide-gtk</binary>
+    <binary>vitte-editor</binary>
+  </provides>
+  <releases>
+    <release version="${VERSION}" date="$(date -u +"%Y-%m-%d")"/>
+  </releases>
+  <launchable type="desktop-id">vitte.desktop</launchable>
+</component>
+EOF
 }
 
 write_control_files() {
   mkdir -p "$DEBIAN_DIR"
+  local installed_size
+  installed_size="$(du -sk "$STAGE_ROOT" | awk '{print $1}')"
 
   cat > "$DEBIAN_DIR/control" <<EOF
 Package: ${PACKAGE_NAME}
@@ -124,6 +329,10 @@ Architecture: ${ARCH}
 Maintainer: ${MAINTAINER}
 Depends: ${DEPENDS}
 Homepage: ${HOMEPAGE}
+Installed-Size: ${installed_size}
+Vcs-Browser: ${VCS_URL}
+Vcs-Git: ${VCS_URL}.git
+Bugs: ${BUGS_URL}
 Description: ${DESCRIPTION}
  Unified Vitte toolchain package including binary, runtime sources,
  standard packages, editors support, manpages and shell completions.
@@ -184,6 +393,18 @@ if [ "${1:-}" = "configure" ]; then
     echo "[vitte deb] postinst check failed: vitte --help" >&2
     exit 1
   fi
+  if [ ! -x /usr/local/bin/vitte-ide ]; then
+    echo "[vitte deb] postinst check failed: missing /usr/local/bin/vitte-ide" >&2
+    exit 1
+  fi
+  if [ ! -x /usr/local/bin/vitte-ide-gtk ]; then
+    echo "[vitte deb] postinst check failed: missing /usr/local/bin/vitte-ide-gtk" >&2
+    exit 1
+  fi
+  if [ ! -x /usr/local/bin/vitte-editor ]; then
+    echo "[vitte deb] postinst check failed: missing /usr/local/bin/vitte-editor" >&2
+    exit 1
+  fi
 
   TMP="/tmp/vitte_deb_verify_$$.vit"
   cat > "$TMP" <<'VEOF'
@@ -220,8 +441,13 @@ VEOF
   cat <<MSG
 [vitte deb] install complete
 [vitte deb] binary: /usr/local/bin/vitte
+[vitte deb] ide:    /usr/local/bin/vitte-ide
+[vitte deb] ide-gui:/usr/local/bin/vitte-ide-gtk
+[vitte deb] editor: /usr/local/bin/vitte-editor
 [vitte deb] root:   /usr/local/share/vitte
 [vitte deb] man:    /usr/local/share/man/man1/vitte.1
+[vitte deb] docs:   /usr/share/doc/vitte
+[vitte deb] logo:   /usr/share/icons/hicolor/scalable/apps/vitte.svg
 [vitte deb] env:    source /usr/local/share/vitte/env.sh
 MSG
 fi
@@ -248,6 +474,7 @@ EOF
 main() {
   require_tools
   cd "$ROOT_DIR"
+  run_release_readiness_gate
   mkdir -p "$OUT_DIR"
   rm -rf "$STAGE_BASE"
   mkdir -p "$STAGE_ROOT"

--- a/tools/release_doctor.py
+++ b/tools/release_doctor.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPORTS = ROOT / "target/reports"
+OUT_JSON = REPORTS / "release_doctor.json"
+OUT_MD = REPORTS / "release_doctor.md"
+
+
+def run(name: str, cmd: list[str], report: str | None = None) -> dict:
+    p = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    item = {
+        "name": name,
+        "cmd": " ".join(cmd),
+        "status": "ok" if p.returncode == 0 else "fail",
+        "rc": p.returncode,
+        "stdout": p.stdout[-4000:],
+        "stderr": p.stderr[-4000:],
+    }
+    if report:
+        item["report"] = report
+    return item
+
+
+def main() -> int:
+    REPORTS.mkdir(parents=True, exist_ok=True)
+    checks = [
+        run("contracts_lockfiles", ["make", "-s", "contract-lockfiles-lint"]),
+        run("contracts_dashboard", ["make", "-s", "contracts-dashboard"], "target/reports/contracts_dashboard.md"),
+        run("reports_index", ["make", "-s", "reports-index"], "target/reports/index.json"),
+        run("security_hardening", ["make", "-s", "security-hardening-gate"], "target/reports/security_hardening.json"),
+        run("security_baseline_diff", ["make", "-s", "security-baseline-diff"]),
+        run("perf_robust", ["make", "-s", "perf-regression-robust"]),
+        run("perf_budget", ["make", "-s", "perf-budget"]),
+        run("docs_sync", ["make", "-s", "docs-sync-gate"]),
+        run("plugin_abi_compat", ["make", "-s", "plugin-abi-compat"]),
+        run("plugin_manifest", ["make", "-s", "plugin-manifest-lint"]),
+        run("plugin_sandbox", ["make", "-s", "plugin-sandbox-lint"]),
+        run("plugin_binary_abi", ["make", "-s", "plugin-binary-abi"] , "target/reports/plugin_binary_abi.json"),
+        run("repro_report", ["make", "-s", "repro-report"], "target/reports/repro.json"),
+    ]
+
+    failing = [c for c in checks if c["status"] != "ok"]
+    data = {
+        "schema_version": "1.0",
+        "status": "ok" if not failing else "fail",
+        "checks": checks,
+        "failing_reports": [c.get("report") for c in failing if c.get("report")],
+    }
+    OUT_JSON.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    md = ["# Release Doctor", "", f"status: **{data['status']}**", "", "| check | status | report |", "|---|---|---|"]
+    for c in checks:
+        md.append(f"| {c['name']} | {c['status']} | {c.get('report','-')} |")
+    if data["failing_reports"]:
+        md.append("")
+        md.append("## Failing Reports")
+        for r in data["failing_reports"]:
+            md.append(f"- {r}")
+    OUT_MD.write_text("\n".join(md) + "\n", encoding="utf-8")
+
+    print(f"[release-doctor] status={data['status']} checks={len(checks)}")
+    if data["failing_reports"]:
+        print("[release-doctor] failing reports: " + ", ".join(data["failing_reports"]))
+    return 0 if data["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a hard `release-readiness` gate before Debian packaging
- block packaging when contracts/security/perf/docs/ABI checks fail

## Changes
- `Makefile`
  - `pkg-debian` now depends on `release-readiness`
- `toolchain/scripts/package/make-debian-deb.sh`
  - run `make -s release-readiness` before staging/building the `.deb`
  - add opt-out switch: `RELEASE_READINESS_GATE=0`
- `.github/workflows/debian-crash-regressions.yml`
  - add explicit `Release readiness gate` step in CI
- `tools/release_doctor.py`
  - extend checks to cover explicit contracts/security/perf/ABI gates in report output

## Goal
Prevent Debian artifact generation when release-critical gates fail.
