### PR TITLE
feat(ci): add changed-packages and impacted-strict selectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -756,6 +756,16 @@ modules-weekly-legacy-warn-only:
 .PHONY: release-modules-gate
 release-modules-gate: modules-ci-strict modules-contract-snapshots modules-report legacy-import-allowlist-empty
 
+.PHONY: packages-changed-ci
+packages-changed-ci:
+	@tools/changed_packages_ci.sh
+
+.PHONY: packages-impacted-strict
+packages-impacted-strict:
+	@targets="$$(python3 tools/packages_impacted_strict.py --base-ref=$${BASE_REF:-HEAD~1})"; \
+	echo "[packages-impacted-strict] targets: $$targets"; \
+	make -s $$targets
+
 .PHONY: platon-editor
 platon-editor:
 	@./bin/vitte build platon-editor/editor_core.vit -o platon-editor/editor_core
@@ -824,6 +834,8 @@ help:
 	@echo "  make pkg-macos build macOS installer pkg (PKG_VERSION=$(PKG_VERSION))"
 	@echo "  make pkg-macos-uninstall build macOS uninstall pkg (PKG_VERSION=$(PKG_VERSION))"
 	@echo "  make release-check run build + ci-fast + ci-completions + pkg build"
+	@echo "  make packages-changed-ci run package CI only for changed packages (BASE_REF=HEAD~1 by default)"
+	@echo "  make packages-impacted-strict run strict CI on changed packages + reverse dependency closure"
 	@echo "  make ci-mod-fast module-focused CI (grammar + snapshots + module tests)"
 	@echo "  make ci-fast-compiler compiler-focused CI with cache skip (grammar + resolve + module snapshots + explain + runtime matrix)"
 	@echo "  make vittec-kernel build target/kernel-tools/vittec-kernel (no curl runtime)"

--- a/tools/changed_packages_ci.sh
+++ b/tools/changed_packages_ci.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+BASE_REF="${BASE_REF:-HEAD~1}"
+
+if ! git -C "$ROOT_DIR" rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "[changed-packages-ci][warn] BASE_REF=$BASE_REF not found, running packages-only-ci"
+  exec make -C "$ROOT_DIR" -s packages-only-ci
+fi
+
+changed=$(git -C "$ROOT_DIR" diff --name-only "$BASE_REF"...HEAD)
+if [ -z "$changed" ]; then
+  echo "[changed-packages-ci] no changes detected; running facade gates only"
+  exec make -C "$ROOT_DIR" -s facade-role-contracts-lint facade-thin-lint diag-namespace-lint
+fi
+
+pkgs=()
+while IFS= read -r f; do
+  case "$f" in
+    src/vitte/packages/*)
+      p=$(echo "$f" | cut -d/ -f4)
+      pkgs+=("$p")
+      ;;
+    tests/modules/contracts/*)
+      p=$(echo "$f" | cut -d/ -f4)
+      pkgs+=("$p")
+      ;;
+    tools/lint_*_*)
+      p=$(basename "$f" | sed -E 's/^lint_([a-z_]+)_.*/\1/')
+      pkgs+=("$p")
+      ;;
+  esac
+done <<< "$changed"
+
+if [ ${#pkgs[@]} -eq 0 ]; then
+  echo "[changed-packages-ci] no package-local changes; running packages-only-ci"
+  exec make -C "$ROOT_DIR" -s packages-only-ci
+fi
+
+# unique
+uniq_pkgs=$(printf '%s\n' "${pkgs[@]}" | sort -u)
+
+targets=(facade-role-contracts-lint facade-thin-lint diag-namespace-lint)
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  case "$p" in
+    core|std|log|fs|db|http|process|json|yaml|test|lint)
+      targets+=("$p-only-ci")
+      ;;
+    http_client)
+      targets+=("http-client-only-ci")
+      ;;
+  esac
+done <<< "$uniq_pkgs"
+
+echo "[changed-packages-ci] targets: ${targets[*]}"
+make -C "$ROOT_DIR" -s "${targets[@]}"

--- a/tools/package_deps.json
+++ b/tools/package_deps.json
@@ -1,0 +1,14 @@
+{
+  "core": [],
+  "std": ["core"],
+  "log": ["core", "std"],
+  "fs": ["core", "std"],
+  "db": ["core", "std", "log"],
+  "http": ["core", "std", "log", "fs"],
+  "http_client": ["core", "std", "log", "http"],
+  "process": ["core", "std", "log", "fs"],
+  "json": ["core", "std"],
+  "yaml": ["core", "std", "json"],
+  "test": ["core", "std", "json", "yaml", "log", "fs", "db", "http", "http_client", "process"],
+  "lint": ["core", "std", "test"]
+}

--- a/tools/packages_impacted_strict.py
+++ b/tools/packages_impacted_strict.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPS = ROOT / 'tools/package_deps.json'
+
+
+def get_changed(base_ref: str) -> list[str]:
+    try:
+        out = subprocess.check_output(['git', '-C', str(ROOT), 'diff', '--name-only', f'{base_ref}...HEAD'], text=True)
+    except Exception:
+        return []
+    return [l.strip() for l in out.splitlines() if l.strip()]
+
+
+def reverse_closure(pkgs: set[str], deps: dict[str, list[str]]) -> set[str]:
+    changed = set(pkgs)
+    while True:
+        added = set()
+        for p, pdeps in deps.items():
+            if p in changed:
+                continue
+            if any(d in changed for d in pdeps):
+                added.add(p)
+        if not added:
+            break
+        changed |= added
+    return changed
+
+
+def strict_target(pkg: str) -> str:
+    if pkg == 'http_client':
+        return 'http-client-strict-ci'
+    return f'{pkg}-strict-ci'
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--base-ref', default='HEAD~1')
+    args = ap.parse_args()
+
+    deps = json.loads(DEPS.read_text(encoding='utf-8'))
+    files = get_changed(args.base_ref)
+    changed_pkgs: set[str] = set()
+    for f in files:
+        parts = f.split('/')
+        if len(parts) >= 4 and parts[0] == 'src' and parts[1] == 'vitte' and parts[2] == 'packages':
+            changed_pkgs.add(parts[3])
+        if len(parts) >= 4 and parts[0] == 'tests' and parts[1] == 'modules' and parts[2] == 'contracts':
+            changed_pkgs.add(parts[3])
+
+    if not changed_pkgs:
+        print('packages-only-ci')
+        return 0
+
+    impacted = reverse_closure(changed_pkgs, deps)
+    targets = ['facade-role-contracts-lint', 'facade-thin-lint', 'diag-namespace-lint']
+    targets.extend(sorted(strict_target(p) for p in impacted if p in deps))
+    print(' '.join(targets))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Introduce package-scoped CI selectors to speed up monorepo iteration loops while preserving strict checks when needed.

## Changes
- add `tools/changed_packages_ci.sh`
  - detects changed package scopes from git diff
  - runs only relevant `*-only-ci` package targets
  - falls back to global package gates when package scope is not detectable
- add `tools/packages_impacted_strict.py`
  - computes reverse dependency closure from changed packages
  - outputs strict targets for impacted packages
- add `tools/package_deps.json`
  - declarative package dependency graph used for impacted target resolution
- update `Makefile`
  - new target: `packages-changed-ci`
  - new target: `packages-impacted-strict`
  - help text entries for both targets

## Why
Running full package CI for every change is expensive in a large workspace. These selectors keep PR feedback fast and still allow strict dependency-aware validation.

## Notes
- default base reference is `HEAD~1` (override with `BASE_REF=...`)
- strict impacted mode includes reverse dependency propagation
