### PR TITLE
feat(tools): add contracts and lint governance suite

### DIFF
--- a/tools/LINTS.md
+++ b/tools/LINTS.md
@@ -52,11 +52,12 @@ Command:
 tools/lint_critical_module_contracts.py
 ```
 
-Checks (`abi/http/db/core`):
+Checks (`abi/http/db/core/actor/alerts`):
 - requires `info.vit` metadata keys: `owner`, `stability`, `since`, `deprecated_in`
 - requires `OWNERS` non-empty with `@team/name` format
 - enforces owner coherence between `info.vit` and `OWNERS`
 - requires `ROLE-CONTRACT` header metadata in `mod.vit`
+- strict ROLE-CONTRACT keys for `actor/alerts`: `input_contract`, `output_contract`, `boundary`, `versioning`, `api_surface_stable`
 
 ## 5) Module naming lint
 
@@ -131,9 +132,21 @@ tools/lint_critical_runtime_matrix.py
 ```
 
 Checks:
-- snapshot matrix exists for critical modules (`abi/core/db/http`) across runtime profiles (`core/system/desktop/arduino`)
+- snapshot matrix exists for critical modules (`abi/core/db/http/alerts`) across runtime profiles (`core/system/desktop/arduino`)
 
-## 11) New public packages snapshot lint
+## 11) Export policy lint
+
+Command:
+
+```bash
+tools/lint_export_policy.py --module alerts --scope public --current-version 2.0.0 --baseline-version 2.0.0 --removed-file /tmp/removed.txt
+```
+
+Checks:
+- forbids stable export removals without major version bump
+- allows explicit override with `--allow-breaking`
+
+## 12) New public packages snapshot lint
 
 Command:
 
@@ -144,7 +157,7 @@ BASE_REF=origin/main tools/lint_new_public_packages_have_snapshots.py
 Checks:
 - each newly added `src/vitte/packages/**/mod.vit` (vs `BASE_REF`) must have snapshot coverage
 
-## 12) No std imports lint
+## 13) No std imports lint
 
 Command:
 

--- a/tools/analyze_schema_snapshot.py
+++ b/tools/analyze_schema_snapshot.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "tools/facade_packages.json"
+SNAP = ROOT / "tests/modules/snapshots/analyze_schema.global.must"
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--update", action="store_true")
+    args = ap.parse_args()
+
+    cfg = json.loads(CFG.read_text(encoding="utf-8"))
+    lines: list[str] = ["schema_version=1.0"]
+    for ent in cfg["packages"]:
+        pkg = ent["name"]
+        report = ROOT / f"target/reports/{pkg}_analyze.json"
+        data = load_json(report)
+        sv = str(data.get("schema_version", "<missing>"))
+        keys = ",".join(sorted(data.keys())) if data else "<missing>"
+        lines.append(f"{pkg}|schema={sv}|keys={keys}")
+
+    snap_txt = "\n".join(lines) + "\n"
+    if args.update:
+        SNAP.parent.mkdir(parents=True, exist_ok=True)
+        SNAP.write_text(snap_txt, encoding="utf-8")
+        print(f"[analyze-schema-snapshot] updated {SNAP}")
+        return 0
+
+    if not SNAP.exists():
+        print(f"[analyze-schema-snapshot][error] missing {SNAP}")
+        return 1
+    want = SNAP.read_text(encoding="utf-8")
+    if want != snap_txt:
+        print("[analyze-schema-snapshot][error] snapshot mismatch")
+        out = ROOT / "target/reports/analyze_schema.global.out"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(snap_txt, encoding="utf-8")
+        print(f"[analyze-schema-snapshot][error] wrote actual to {out}")
+        return 1
+    print("[analyze-schema-snapshot] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/api_diff_explainer.py
+++ b/tools/api_diff_explainer.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / 'tools/facade_packages.json'
+OUT = ROOT / 'target/reports/api_diff_explainer.md'
+
+
+def read_set(p: Path) -> set[str]:
+    if not p.exists():
+        return set()
+    return {l.strip() for l in p.read_text(encoding='utf-8').splitlines() if l.strip()}
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding='utf-8'))
+    lines = ['# API Diff Explainer', '']
+    has_breaking = False
+
+    for ent in cfg['packages']:
+        pkg = ent['name']
+        cdir = ROOT / f'tests/modules/contracts/{pkg}'
+        baseline = read_set(cdir / f'{pkg}.facade.api')
+        current = read_set(cdir / f'{pkg}.exports')
+        removed = sorted(baseline - current)
+        added = sorted(current - baseline)
+        lines.append(f'## {pkg}')
+        if not removed and not added:
+            lines.append('- Status: no API diff')
+            lines.append('')
+            continue
+        if removed:
+            has_breaking = True
+            lines.append('- Status: BREAKING (symbol removals detected)')
+            lines.append('- Why breaking: additive-only policy forbids removals in stable line')
+            lines.append('- Impact: downstream imports/IDE quickfix mappings may fail')
+            lines.append('- Migration hints:')
+            lines.append('  - Restore removed symbol as compatibility wrapper')
+            lines.append('  - Or bump major and provide migration note')
+            lines.append('  - Or alias old symbol to new stable symbol')
+            lines.append('- Removed symbols:')
+            for s in removed[:40]:
+                lines.append(f'  - `{s}`')
+        if added:
+            lines.append('- Added symbols:')
+            for s in added[:40]:
+                lines.append(f'  - `{s}`')
+        lines.append('')
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+    print(f'[api-diff-explainer] wrote {OUT}')
+    if has_breaking:
+        print('[api-diff-explainer] BREAKING entries present; see report')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/contracts_dashboard.py
+++ b/tools/contracts_dashboard.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "tools/facade_packages.json"
+OUT = ROOT / "target/reports/contracts_dashboard.md"
+
+
+def sha256_text(path: Path) -> str:
+    if not path.exists():
+        return "missing"
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding="utf-8"))
+    lines: list[str] = [
+        "# Contracts Dashboard",
+        "",
+        "| package | maturity | exports | facade | lockfile | sha256(exports) | status |",
+        "|---|---|---|---|---|---|---|",
+    ]
+
+    for ent in cfg["packages"]:
+        p = ent["name"]
+        maturity = ent.get("maturity", "unknown")
+        cdir = ROOT / f"tests/modules/contracts/{p}"
+        exports = cdir / f"{p}.exports"
+        facade = cdir / f"{p}.facade.api"
+        lock = cdir / f"{p}.contract.lock.json"
+        status = "OK" if exports.exists() and facade.exists() and lock.exists() else "MISSING"
+        lines.append(
+            f"| {p} | {maturity} | {'yes' if exports.exists() else 'no'} | {'yes' if facade.exists() else 'no'} | {'yes' if lock.exists() else 'no'} | `{sha256_text(exports)[:12]}` | {status} |"
+        )
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[contracts-dashboard] wrote {OUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/core_contract_diff.sh
+++ b/tools/core_contract_diff.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+OLD="${1:-$ROOT_DIR/tests/modules/contracts/core/core.facade.api}"
+NEW="${2:-$ROOT_DIR/tests/modules/contracts/core/core.exports}"
+
+[ -f "$OLD" ] || { echo "[core-contract-diff][error] missing old: $OLD" >&2; exit 1; }
+[ -f "$NEW" ] || { echo "[core-contract-diff][error] missing new: $NEW" >&2; exit 1; }
+
+tmp_old="$(mktemp)"
+tmp_new="$(mktemp)"
+trap 'rm -f "$tmp_old" "$tmp_new"' EXIT
+LC_ALL=C sort "$OLD" > "$tmp_old"
+LC_ALL=C sort "$NEW" > "$tmp_new"
+
+if diff -u "$tmp_old" "$tmp_new"; then
+  echo "[core-contract-diff] OK"
+  exit 0
+fi
+
+echo "[core-contract-diff] BREAKING OR CHANGED API"
+exit 1

--- a/tools/core_contract_snapshots.sh
+++ b/tools/core_contract_snapshots.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+CORE_DIR="${CORE_DIR:-$ROOT_DIR/tests/modules/contracts/core}"
+UPDATE=0
+
+log() { printf "[core-contract-snapshots] %s\n" "$*"; }
+die() { printf "[core-contract-snapshots][error] %s\n" "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    -h|--help)
+      cat <<'USAGE'
+usage: tools/core_contract_snapshots.sh [--update]
+
+Checks (or updates) core.exports/public/internal + sha snapshot consistency.
+USAGE
+      exit 0
+      ;;
+    *) die "unknown option: $1" ;;
+  esac
+  shift
+done
+
+[ -d "$CORE_DIR" ] || die "missing dir: $CORE_DIR"
+
+ALL="$CORE_DIR/core.exports"
+PUB="$CORE_DIR/core.exports.public"
+INT="$CORE_DIR/core.exports.internal"
+SHA="$CORE_DIR/core.exports.sha256"
+FACADE="$CORE_DIR/core.facade.api"
+FACADE_SHA="$CORE_DIR/core.facade.api.sha256"
+
+for f in "$ALL" "$PUB" "$INT"; do
+  [ -f "$f" ] || die "missing snapshot file: $f"
+done
+
+if [ "$UPDATE" -eq 1 ]; then
+  sha="$(sha256sum "$ALL" | awk '{print $1}')"
+  printf "%s\n" "$sha" > "$SHA"
+  "$ROOT_DIR/tools/core_facade_snapshot.sh" --update
+  log "updated $SHA"
+  exit 0
+fi
+
+[ -f "$SHA" ] || die "missing hash file: $SHA"
+
+if ! diff -u "$ALL" "$PUB" >/dev/null 2>&1; then
+  diff -u "$ALL" "$PUB" || true
+  die "core.exports and core.exports.public diverge"
+fi
+
+if [ -s "$INT" ]; then
+  die "core.exports.internal must stay empty for stable core facade"
+fi
+
+if ! diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null 2>&1; then
+  die "core.exports must be sorted (stable API ordering)"
+fi
+
+[ -f "$FACADE" ] || die "missing facade snapshot: $FACADE"
+[ -f "$FACADE_SHA" ] || die "missing facade hash: $FACADE_SHA"
+"$ROOT_DIR/tools/core_facade_snapshot.sh"
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$ALL" | awk '{print $1}')"
+if [ "$expected" != "$actual" ]; then
+  die "sha mismatch expected=$expected got=$actual (run --update if intended)"
+fi
+
+log "OK"

--- a/tools/core_facade_snapshot.sh
+++ b/tools/core_facade_snapshot.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/core/core.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/core/core.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/core/core.facade.api.sha256"
+UPDATE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    *) echo "[core-facade-snapshot][error] unknown arg: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[ -f "$SRC" ] || { echo "[core-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+
+if [ "$UPDATE" -eq 1 ]; then
+  cp "$tmp" "$OUT"
+  sha256sum "$OUT" | awk '{print $1}' > "$SHA"
+  echo "[core-facade-snapshot] updated"
+  exit 0
+fi
+
+[ -f "$OUT" ] || { echo "[core-facade-snapshot][error] missing $OUT (run --update)" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[core-facade-snapshot][error] missing $SHA (run --update)" >&2; exit 1; }
+
+diff -u "$OUT" "$tmp" >/dev/null || {
+  diff -u "$OUT" "$tmp" || true
+  echo "[core-facade-snapshot][error] core facade snapshot mismatch" >&2
+  exit 1
+}
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$OUT" | awk '{print $1}')"
+[ "$expected" = "$actual" ] || {
+  echo "[core-facade-snapshot][error] sha mismatch expected=$expected got=$actual" >&2
+  exit 1
+}
+
+echo "[core-facade-snapshot] OK"

--- a/tools/db_contract_diff.sh
+++ b/tools/db_contract_diff.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+python3 "$ROOT_DIR/tools/lint_db_compat_contracts.py"

--- a/tools/db_contract_snapshots.sh
+++ b/tools/db_contract_snapshots.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+DB_DIR="${DB_DIR:-$ROOT_DIR/tests/modules/contracts/db}"
+UPDATE=0
+
+log() { printf "[db-contract-snapshots] %s\n" "$*"; }
+die() { printf "[db-contract-snapshots][error] %s\n" "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    *) die "unknown option: $1" ;;
+  esac
+  shift
+done
+
+[ -d "$DB_DIR" ] || die "missing dir: $DB_DIR"
+
+ALL="$DB_DIR/db.exports"
+PUB="$DB_DIR/db.exports.public"
+INT="$DB_DIR/db.exports.internal"
+SHA="$DB_DIR/db.exports.sha256"
+FACADE="$DB_DIR/db.facade.api"
+FACADE_SHA="$DB_DIR/db.facade.api.sha256"
+
+for f in "$ALL" "$PUB" "$INT"; do
+  [ -f "$f" ] || die "missing snapshot file: $f"
+done
+
+if [ "$UPDATE" -eq 1 ]; then
+  sha="$(sha256sum "$ALL" | awk '{print $1}')"
+  printf "%s\n" "$sha" > "$SHA"
+  "$ROOT_DIR/tools/db_facade_snapshot.sh" --update
+  log "updated $SHA"
+  exit 0
+fi
+
+[ -f "$SHA" ] || die "missing hash file: $SHA"
+
+if ! diff -u "$ALL" "$PUB" >/dev/null 2>&1; then
+  diff -u "$ALL" "$PUB" || true
+  die "db.exports and db.exports.public diverge"
+fi
+
+if [ -s "$INT" ]; then
+  die "db.exports.internal must stay empty"
+fi
+
+if ! diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null 2>&1; then
+  die "db.exports must be sorted"
+fi
+
+[ -f "$FACADE" ] || die "missing facade snapshot: $FACADE"
+[ -f "$FACADE_SHA" ] || die "missing facade hash: $FACADE_SHA"
+"$ROOT_DIR/tools/db_facade_snapshot.sh"
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$ALL" | awk '{print $1}')"
+if [ "$expected" != "$actual" ]; then
+  die "sha mismatch expected=$expected got=$actual"
+fi
+
+log "OK"

--- a/tools/db_facade_snapshot.sh
+++ b/tools/db_facade_snapshot.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/db/db.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/db/db.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/db/db.facade.api.sha256"
+UPDATE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    *) echo "[db-facade-snapshot][error] unknown arg: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[ -f "$SRC" ] || { echo "[db-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+
+if [ "$UPDATE" -eq 1 ]; then
+  cp "$tmp" "$OUT"
+  sha256sum "$OUT" | awk '{print $1}' > "$SHA"
+  echo "[db-facade-snapshot] updated"
+  exit 0
+fi
+
+[ -f "$OUT" ] || { echo "[db-facade-snapshot][error] missing $OUT (run --update)" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[db-facade-snapshot][error] missing $SHA (run --update)" >&2; exit 1; }
+
+diff -u "$OUT" "$tmp" >/dev/null || {
+  diff -u "$OUT" "$tmp" || true
+  echo "[db-facade-snapshot][error] db facade snapshot mismatch" >&2
+  exit 1
+}
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$OUT" | awk '{print $1}')"
+[ "$expected" = "$actual" ] || {
+  echo "[db-facade-snapshot][error] sha mismatch expected=$expected got=$actual" >&2
+  exit 1
+}
+
+echo "[db-facade-snapshot] OK"

--- a/tools/facade_packages.json
+++ b/tools/facade_packages.json
@@ -1,0 +1,148 @@
+{
+  "packages": [
+    {
+      "name": "core",
+      "diag_prefix": "VITTE-C",
+      "module": "vitte/core",
+      "maturity": "hardened",
+      "facade_thin": {
+        "mode": "error",
+        "warn_loops": 8,
+        "max_loops": 20,
+        "max_procs": 120
+      }
+    },
+    {
+      "name": "std",
+      "diag_prefix": "VITTE-S",
+      "module": "vitte/std",
+      "maturity": "stable",
+      "facade_thin": {
+        "mode": "warn",
+        "warn_loops": 8,
+        "max_loops": 20,
+        "max_procs": 120
+      }
+    },
+    {
+      "name": "log",
+      "diag_prefix": "VITTE-L",
+      "module": "vitte/log",
+      "maturity": "stable",
+      "facade_thin": {
+        "mode": "warn",
+        "warn_loops": 8,
+        "max_loops": 20,
+        "max_procs": 120
+      }
+    },
+    {
+      "name": "fs",
+      "diag_prefix": "VITTE-F",
+      "module": "vitte/fs",
+      "maturity": "stable",
+      "facade_thin": {
+        "mode": "error",
+        "warn_loops": 20,
+        "max_loops": 30,
+        "max_procs": 120
+      }
+    },
+    {
+      "name": "db",
+      "diag_prefix": "VITTE-D",
+      "module": "vitte/db",
+      "maturity": "stable",
+      "facade_thin": {
+        "mode": "warn",
+        "warn_loops": 8,
+        "max_loops": 20,
+        "max_procs": 120
+      }
+    },
+    {
+      "name": "http",
+      "diag_prefix": "VITTE-H",
+      "module": "vitte/http",
+      "maturity": "stable",
+      "facade_thin": {
+        "mode": "warn",
+        "warn_loops": 8,
+        "max_loops": 20,
+        "max_procs": 120
+      }
+    },
+    {
+      "name": "http_client",
+      "diag_prefix": "VITTE-C",
+      "module": "vitte/http_client",
+      "maturity": "stable",
+      "facade_thin": {
+        "mode": "warn",
+        "warn_loops": 8,
+        "max_loops": 20,
+        "max_procs": 120
+      }
+    },
+    {
+      "name": "process",
+      "diag_prefix": "VITTE-P",
+      "module": "vitte/process",
+      "maturity": "stable",
+      "facade_thin": {
+        "mode": "warn",
+        "warn_loops": 8,
+        "max_loops": 20,
+        "max_procs": 120
+      }
+    },
+    {
+      "name": "json",
+      "diag_prefix": "VITTE-J",
+      "module": "vitte/json",
+      "maturity": "experimental",
+      "facade_thin": {
+        "mode": "warn",
+        "warn_loops": 10,
+        "max_loops": 24,
+        "max_procs": 140
+      }
+    },
+    {
+      "name": "yaml",
+      "diag_prefix": "VITTE-Y",
+      "module": "vitte/yaml",
+      "maturity": "experimental",
+      "facade_thin": {
+        "mode": "warn",
+        "warn_loops": 10,
+        "max_loops": 24,
+        "max_procs": 140
+      }
+    },
+    {
+      "name": "test",
+      "diag_prefix": "VITTE-T",
+      "module": "vitte/test",
+      "maturity": "hardened",
+      "facade_thin": {
+        "mode": "error",
+        "warn_loops": 8,
+        "max_loops": 20,
+        "max_procs": 120
+      }
+    },
+    {
+      "name": "lint",
+      "diag_prefix": "VITTE-I",
+      "module": "vitte/lint",
+      "maturity": "hardened",
+      "facade_thin": {
+        "mode": "error",
+        "warn_loops": 8,
+        "max_loops": 20,
+        "max_procs": 120
+      }
+    }
+  ]
+}

--- a/tools/fs_contract_diff.sh
+++ b/tools/fs_contract_diff.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+python3 "$ROOT_DIR/tools/lint_fs_compat_contracts.py"

--- a/tools/fs_contract_snapshots.sh
+++ b/tools/fs_contract_snapshots.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+FS_DIR="${FS_DIR:-$ROOT_DIR/tests/modules/contracts/fs}"
+UPDATE=0
+
+log() { printf "[fs-contract-snapshots] %s\n" "$*"; }
+die() { printf "[fs-contract-snapshots][error] %s\n" "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    *) die "unknown option: $1" ;;
+  esac
+  shift
+done
+
+[ -d "$FS_DIR" ] || die "missing dir: $FS_DIR"
+
+ALL="$FS_DIR/fs.exports"
+PUB="$FS_DIR/fs.exports.public"
+INT="$FS_DIR/fs.exports.internal"
+SHA="$FS_DIR/fs.exports.sha256"
+FACADE="$FS_DIR/fs.facade.api"
+FACADE_SHA="$FS_DIR/fs.facade.api.sha256"
+
+for f in "$ALL" "$PUB" "$INT"; do
+  [ -f "$f" ] || die "missing snapshot file: $f"
+done
+
+if [ "$UPDATE" -eq 1 ]; then
+  sha="$(sha256sum "$ALL" | awk '{print $1}')"
+  printf "%s\n" "$sha" > "$SHA"
+  "$ROOT_DIR/tools/fs_facade_snapshot.sh" --update
+  log "updated $SHA"
+  exit 0
+fi
+
+[ -f "$SHA" ] || die "missing hash file: $SHA"
+
+if ! diff -u "$ALL" "$PUB" >/dev/null 2>&1; then
+  diff -u "$ALL" "$PUB" || true
+  die "fs.exports and fs.exports.public diverge"
+fi
+
+if [ -s "$INT" ]; then
+  die "fs.exports.internal must stay empty"
+fi
+
+if ! diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null 2>&1; then
+  die "fs.exports must be sorted"
+fi
+
+[ -f "$FACADE" ] || die "missing facade snapshot: $FACADE"
+[ -f "$FACADE_SHA" ] || die "missing facade hash: $FACADE_SHA"
+"$ROOT_DIR/tools/fs_facade_snapshot.sh"
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$ALL" | awk '{print $1}')"
+if [ "$expected" != "$actual" ]; then
+  die "sha mismatch expected=$expected got=$actual"
+fi
+
+log "OK"

--- a/tools/fs_facade_snapshot.sh
+++ b/tools/fs_facade_snapshot.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/fs/fs.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/fs/fs.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/fs/fs.facade.api.sha256"
+UPDATE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    *) echo "[fs-facade-snapshot][error] unknown arg: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[ -f "$SRC" ] || { echo "[fs-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+
+if [ "$UPDATE" -eq 1 ]; then
+  cp "$tmp" "$OUT"
+  sha256sum "$OUT" | awk '{print $1}' > "$SHA"
+  echo "[fs-facade-snapshot] updated"
+  exit 0
+fi
+
+[ -f "$OUT" ] || { echo "[fs-facade-snapshot][error] missing $OUT (run --update)" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[fs-facade-snapshot][error] missing $SHA (run --update)" >&2; exit 1; }
+
+diff -u "$OUT" "$tmp" >/dev/null || {
+  diff -u "$OUT" "$tmp" || true
+  echo "[fs-facade-snapshot][error] fs facade snapshot mismatch" >&2
+  exit 1
+}
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$OUT" | awk '{print $1}')"
+[ "$expected" = "$actual" ] || {
+  echo "[fs-facade-snapshot][error] sha mismatch expected=$expected got=$actual" >&2
+  exit 1
+}
+
+echo "[fs-facade-snapshot] OK"

--- a/tools/generate_contract_lockfiles.py
+++ b/tools/generate_contract_lockfiles.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import hashlib, json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "tools/facade_packages.json"
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def read_lines(p: Path) -> list[str]:
+    if not p.exists():
+        return []
+    return [l.strip() for l in p.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding="utf-8"))
+    for ent in cfg["packages"]:
+        pkg = ent["name"]
+        cdir = ROOT / f"tests/modules/contracts/{pkg}"
+        cdir.mkdir(parents=True, exist_ok=True)
+        exports = read_lines(cdir / f"{pkg}.exports")
+        facade = read_lines(cdir / f"{pkg}.facade.api")
+        payload = {
+            "package": pkg,
+            "module": ent["module"],
+            "diag_prefix": ent["diag_prefix"],
+            "exports_count": len(exports),
+            "exports_sha256": sha256_text("\n".join(exports) + "\n"),
+            "facade_count": len(facade),
+            "facade_sha256": sha256_text("\n".join(facade) + "\n"),
+            "exports": exports,
+        }
+        out = cdir / f"{pkg}.contract.lock.json"
+        out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"[contract-lock] {pkg} -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate_contract_snapshots_from_mod.py
+++ b/tools/generate_contract_snapshots_from_mod.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, hashlib, json, re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "tools/facade_packages.json"
+DECL_RE = re.compile(r"^\s*(pick|form|proc)\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def sha256_file(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def exports_from_mod(mod: Path) -> list[str]:
+    out: set[str] = set()
+    txt = mod.read_text(encoding="utf-8")
+    for line in txt.splitlines():
+        m = DECL_RE.match(line)
+        if m:
+            out.add(m.group(2))
+    return sorted(out)
+
+
+def write_contract(pkg: str) -> None:
+    mod = ROOT / f"src/vitte/packages/{pkg}/mod.vit"
+    if not mod.exists():
+        raise FileNotFoundError(mod)
+    cdir = ROOT / f"tests/modules/contracts/{pkg}"
+    cdir.mkdir(parents=True, exist_ok=True)
+    exports = exports_from_mod(mod)
+
+    all_p = cdir / f"{pkg}.exports"
+    pub_p = cdir / f"{pkg}.exports.public"
+    int_p = cdir / f"{pkg}.exports.internal"
+    all_sha = cdir / f"{pkg}.exports.sha256"
+    facade = cdir / f"{pkg}.facade.api"
+    facade_sha = cdir / f"{pkg}.facade.api.sha256"
+
+    text = "\n".join(exports) + "\n"
+    all_p.write_text(text, encoding="utf-8")
+    pub_p.write_text(text, encoding="utf-8")
+    int_p.write_text("", encoding="utf-8")
+    all_sha.write_text(sha256_file(all_p) + "\n", encoding="utf-8")
+    facade.write_text(text, encoding="utf-8")
+    facade_sha.write_text(sha256_file(facade) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--packages", default="")
+    args = ap.parse_args()
+
+    cfg = json.loads(CFG.read_text(encoding="utf-8"))
+    known = [p["name"] for p in cfg["packages"]]
+    targets = [t.strip() for t in args.packages.split(",") if t.strip()] if args.packages else known
+
+    for pkg in targets:
+        if pkg not in known:
+            print(f"[contract-gen][error] unknown package: {pkg}")
+            return 1
+        write_contract(pkg)
+        print(f"[contract-gen] updated {pkg}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/http_client_contract_snapshots.sh
+++ b/tools/http_client_contract_snapshots.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+DIR="$ROOT_DIR/tests/modules/contracts/http_client"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[http-client-contract-snapshots][error] unknown $1" >&2; exit 1;; esac; shift; done
+ALL="$DIR/http_client.exports"; PUB="$DIR/http_client.exports.public"; INT="$DIR/http_client.exports.internal"; SHA="$DIR/http_client.exports.sha256"
+for f in "$ALL" "$PUB" "$INT"; do [ -f "$f" ] || { echo "[http-client-contract-snapshots][error] missing $f" >&2; exit 1; }; done
+if [ "$UPDATE" -eq 1 ]; then sha256sum "$ALL"|awk '{print $1}'>$SHA; "$ROOT_DIR/tools/http_client_facade_snapshot.sh" --update; echo "[http-client-contract-snapshots] updated"; exit 0; fi
+[ -f "$SHA" ] || { echo "[http-client-contract-snapshots][error] missing $SHA" >&2; exit 1; }
+diff -u "$ALL" "$PUB" >/dev/null || { diff -u "$ALL" "$PUB" || true; echo "[http-client-contract-snapshots][error] public diverge" >&2; exit 1; }
+[ ! -s "$INT" ] || { echo "[http-client-contract-snapshots][error] internal snapshot must be empty" >&2; exit 1; }
+diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null || { echo "[http-client-contract-snapshots][error] exports must be sorted" >&2; exit 1; }
+"$ROOT_DIR/tools/http_client_facade_snapshot.sh"
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$ALL"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[http-client-contract-snapshots][error] sha mismatch" >&2; exit 1; }
+echo "[http-client-contract-snapshots] OK"

--- a/tools/http_client_facade_snapshot.sh
+++ b/tools/http_client_facade_snapshot.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/http_client/http_client.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/http_client/http_client.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/http_client/http_client.facade.api.sha256"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[http-client-facade-snapshot][error] unknown arg: $1" >&2; exit 1;; esac; shift; done
+[ -f "$SRC" ] || { echo "[http-client-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+if [ "$UPDATE" -eq 1 ]; then cp "$tmp" "$OUT"; sha256sum "$OUT"|awk '{print $1}'>$SHA; echo "[http-client-facade-snapshot] updated"; exit 0; fi
+[ -f "$OUT" ] || { echo "[http-client-facade-snapshot][error] missing $OUT" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[http-client-facade-snapshot][error] missing $SHA" >&2; exit 1; }
+diff -u "$OUT" "$tmp" >/dev/null || { diff -u "$OUT" "$tmp" || true; echo "[http-client-facade-snapshot][error] mismatch" >&2; exit 1; }
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$OUT"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[http-client-facade-snapshot][error] sha mismatch" >&2; exit 1; }
+echo "[http-client-facade-snapshot] OK"

--- a/tools/http_contract_diff.sh
+++ b/tools/http_contract_diff.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 "$(cd "$(dirname "$0")/.." && pwd)/tools/lint_http_compat_contracts.py"

--- a/tools/http_contract_snapshots.sh
+++ b/tools/http_contract_snapshots.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+DIR="$ROOT_DIR/tests/modules/contracts/http"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[http-contract-snapshots][error] unknown $1" >&2; exit 1;; esac; shift; done
+ALL="$DIR/http.exports"; PUB="$DIR/http.exports.public"; INT="$DIR/http.exports.internal"; SHA="$DIR/http.exports.sha256"
+for f in "$ALL" "$PUB" "$INT"; do [ -f "$f" ] || { echo "[http-contract-snapshots][error] missing $f" >&2; exit 1; }; done
+if [ "$UPDATE" -eq 1 ]; then sha256sum "$ALL"|awk '{print $1}'>$SHA; "$ROOT_DIR/tools/http_facade_snapshot.sh" --update; echo "[http-contract-snapshots] updated"; exit 0; fi
+[ -f "$SHA" ] || { echo "[http-contract-snapshots][error] missing $SHA" >&2; exit 1; }
+diff -u "$ALL" "$PUB" >/dev/null || { diff -u "$ALL" "$PUB" || true; echo "[http-contract-snapshots][error] public diverge" >&2; exit 1; }
+[ ! -s "$INT" ] || { echo "[http-contract-snapshots][error] internal snapshot must be empty" >&2; exit 1; }
+diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null || { echo "[http-contract-snapshots][error] exports must be sorted" >&2; exit 1; }
+"$ROOT_DIR/tools/http_facade_snapshot.sh"
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$ALL"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[http-contract-snapshots][error] sha mismatch" >&2; exit 1; }
+echo "[http-contract-snapshots] OK"

--- a/tools/http_facade_snapshot.sh
+++ b/tools/http_facade_snapshot.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/http/http.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/http/http.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/http/http.facade.api.sha256"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[http-facade-snapshot][error] unknown arg: $1" >&2; exit 1;; esac; shift; done
+[ -f "$SRC" ] || { echo "[http-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+if [ "$UPDATE" -eq 1 ]; then cp "$tmp" "$OUT"; sha256sum "$OUT"|awk '{print $1}'>$SHA; echo "[http-facade-snapshot] updated"; exit 0; fi
+[ -f "$OUT" ] || { echo "[http-facade-snapshot][error] missing $OUT" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[http-facade-snapshot][error] missing $SHA" >&2; exit 1; }
+diff -u "$OUT" "$tmp" >/dev/null || { diff -u "$OUT" "$tmp" || true; echo "[http-facade-snapshot][error] mismatch" >&2; exit 1; }
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$OUT"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[http-facade-snapshot][error] sha mismatch" >&2; exit 1; }
+echo "[http-facade-snapshot] OK"

--- a/tools/json_contract_diff.sh
+++ b/tools/json_contract_diff.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 "$(cd "$(dirname "$0")/.." && pwd)/tools/lint_json_compat_contracts.py"

--- a/tools/json_contract_snapshots.sh
+++ b/tools/json_contract_snapshots.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+DIR="$ROOT_DIR/tests/modules/contracts/json"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[json-contract-snapshots][error] unknown $1" >&2; exit 1;; esac; shift; done
+ALL="$DIR/json.exports"; PUB="$DIR/json.exports.public"; INT="$DIR/json.exports.internal"; SHA="$DIR/json.exports.sha256"
+for f in "$ALL" "$PUB" "$INT"; do [ -f "$f" ] || { echo "[json-contract-snapshots][error] missing $f" >&2; exit 1; }; done
+if [ "$UPDATE" -eq 1 ]; then sha256sum "$ALL"|awk '{print $1}'>$SHA; "$ROOT_DIR/tools/json_facade_snapshot.sh" --update; echo "[json-contract-snapshots] updated"; exit 0; fi
+[ -f "$SHA" ] || { echo "[json-contract-snapshots][error] missing $SHA" >&2; exit 1; }
+diff -u "$ALL" "$PUB" >/dev/null || { diff -u "$ALL" "$PUB" || true; echo "[json-contract-snapshots][error] public diverge" >&2; exit 1; }
+[ ! -s "$INT" ] || { echo "[json-contract-snapshots][error] internal snapshot must be empty" >&2; exit 1; }
+diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null || { echo "[json-contract-snapshots][error] exports must be sorted" >&2; exit 1; }
+"$ROOT_DIR/tools/json_facade_snapshot.sh"
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$ALL"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[json-contract-snapshots][error] sha mismatch" >&2; exit 1; }
+echo "[json-contract-snapshots] OK"

--- a/tools/json_facade_snapshot.sh
+++ b/tools/json_facade_snapshot.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/json/json.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/json/json.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/json/json.facade.api.sha256"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[json-facade-snapshot][error] unknown arg: $1" >&2; exit 1;; esac; shift; done
+[ -f "$SRC" ] || { echo "[json-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+if [ "$UPDATE" -eq 1 ]; then cp "$tmp" "$OUT"; sha256sum "$OUT"|awk '{print $1}'>$SHA; echo "[json-facade-snapshot] updated"; exit 0; fi
+[ -f "$OUT" ] || { echo "[json-facade-snapshot][error] missing $OUT" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[json-facade-snapshot][error] missing $SHA" >&2; exit 1; }
+diff -u "$OUT" "$tmp" >/dev/null || { diff -u "$OUT" "$tmp" || true; echo "[json-facade-snapshot][error] mismatch" >&2; exit 1; }
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$OUT"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[json-facade-snapshot][error] sha mismatch" >&2; exit 1; }
+echo "[json-facade-snapshot] OK"

--- a/tools/lint_alias_pkg_generic.py
+++ b/tools/lint_alias_pkg_generic.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, re
+from pathlib import Path
+
+USE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--roots", required=True, help="comma separated roots")
+    ap.add_argument("--tag", default="alias-pkg-generic")
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    errs: list[str] = []
+    for root_s in [r.strip() for r in args.roots.split(",") if r.strip()]:
+        root = repo / root_s
+        if not root.exists():
+            continue
+        for p in root.rglob("*.vit"):
+            for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), 1):
+                m = USE.match(line)
+                if m and not m.group(2).endswith("_pkg"):
+                    errs.append(f"{p}:{i}: alias must end with _pkg")
+    if errs:
+        for e in errs:
+            print(f"[{args.tag}][error] {e}")
+        return 1
+    print(f"[{args.tag}] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_array_export_snapshot.py
+++ b/tools/lint_array_export_snapshot.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def check(root: Path, rel: str) -> list[str]:
+    errs: list[str] = []
+    d = root / rel
+    required = [
+        "array.exports",
+        "array.exports.public",
+        "array.exports.internal",
+        "array.exports.sha256",
+    ]
+    for n in required:
+        p = d / n
+        if not p.exists():
+            errs.append(f"missing {p}")
+    if errs:
+        return errs
+
+    exp = (d / "array.exports").read_text(encoding="utf-8")
+    pub = (d / "array.exports.public").read_text(encoding="utf-8")
+    if exp != pub:
+        errs.append(f"{d}: public snapshot diverges from exports")
+
+    digest = sha(d / "array.exports")
+    recorded = (d / "array.exports.sha256").read_text(encoding="utf-8").strip()
+    if digest != recorded:
+        errs.append(f"{d}: sha mismatch expected={recorded} got={digest}")
+
+    if "stable_api_surface" not in exp:
+        errs.append(f"{d}: stable_api_surface missing from exports")
+    if "api_version" not in exp:
+        errs.append(f"{d}: api_version missing from exports")
+
+    return errs
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    paths = [
+        "src/vitte/packages/contracts_snapshots/array",
+        "tests/modules/contracts/array",
+    ]
+    errors: list[str] = []
+    for rel in paths:
+        errors.extend(check(repo, rel))
+
+    if errors:
+        for e in errors:
+            print(f"[array-export-lint][error] {e}")
+        return 1
+
+    print("[array-export-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_ast_export_snapshot.py
+++ b/tools/lint_ast_export_snapshot.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def check(root: Path, rel: str) -> list[str]:
+    errs: list[str] = []
+    d = root / rel
+    required = [
+        "ast.exports",
+        "ast.exports.public",
+        "ast.exports.internal",
+        "ast.exports.sha256",
+    ]
+    for n in required:
+        p = d / n
+        if not p.exists():
+            errs.append(f"missing {p}")
+    if errs:
+        return errs
+
+    exp = (d / "ast.exports").read_text(encoding="utf-8")
+    pub = (d / "ast.exports.public").read_text(encoding="utf-8")
+    if exp != pub:
+        errs.append(f"{d}: public snapshot diverges from exports")
+
+    digest = sha(d / "ast.exports")
+    recorded = (d / "ast.exports.sha256").read_text(encoding="utf-8").strip()
+    if digest != recorded:
+        errs.append(f"{d}: sha mismatch expected={recorded} got={digest}")
+
+    for required_symbol in (
+        "stable_api_surface",
+        "api_version",
+        "stable_validate_tree",
+        "stable_walk_preorder",
+        "stable_metrics",
+    ):
+        if required_symbol not in exp:
+            errs.append(f"{d}: {required_symbol} missing from exports")
+
+    return errs
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    paths = [
+        "src/vitte/packages/contracts_snapshots/ast",
+        "tests/modules/contracts/ast",
+    ]
+    errors: list[str] = []
+    for rel in paths:
+        errors.extend(check(repo, rel))
+
+    if errors:
+        for e in errors:
+            print(f"[ast-export-lint][error] {e}")
+        return 1
+
+    print("[ast-export-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_bench_pkg.sh
+++ b/tools/lint_bench_pkg.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"; OUT_DIR="$ROOT_DIR/target/bench"; mkdir -p "$OUT_DIR"
+start="$(date +%s%3N)"; rg --line-number --no-heading "proc " "$ROOT_DIR/src/vitte/packages/lint" >/dev/null 2>&1 || true; end="$(date +%s%3N)"; ms=$((end-start))
+echo "bench:lint_engine_core" > "$OUT_DIR/lint_bench_micro.out"; echo "measured_ms:$ms" >> "$OUT_DIR/lint_bench_micro.out"; cp "$OUT_DIR/lint_bench_micro.out" "$ROOT_DIR/tests/lint/bench/lint_bench_micro.latest"
+echo "[lint-bench] wrote $OUT_DIR/lint_bench_micro.out"

--- a/tools/lint_ci_report_pkg.sh
+++ b/tools/lint_ci_report_pkg.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"; mkdir -p "$ROOT_DIR/target/reports"
+rg -n "VITTE-I[0-9]{4}" "$ROOT_DIR/src/vitte/packages/lint" > "$ROOT_DIR/target/reports/lint_diag_codes.report" || true
+echo "[lint-ci-report] wrote target/reports/lint_diag_codes.report"

--- a/tools/lint_contract_diff_pkg.sh
+++ b/tools/lint_contract_diff_pkg.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 "$(cd "$(dirname "$0")/.." && pwd)/tools/lint_lint_compat_contracts.py"

--- a/tools/lint_contract_lockfiles.py
+++ b/tools/lint_contract_lockfiles.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json, hashlib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / 'tools/facade_packages.json'
+
+
+def sha(s: str) -> str:
+    return hashlib.sha256(s.encode('utf-8')).hexdigest()
+
+
+def read_lines(p: Path):
+    return [l.strip() for l in p.read_text(encoding='utf-8').splitlines() if l.strip()] if p.exists() else []
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding='utf-8'))
+    errs=[]
+    for ent in cfg['packages']:
+        pkg=ent['name']
+        cdir=ROOT/f'tests/modules/contracts/{pkg}'
+        lock=cdir/f'{pkg}.contract.lock.json'
+        if not lock.exists():
+            errs.append(f'{pkg}: missing lockfile')
+            continue
+        data=json.loads(lock.read_text(encoding='utf-8'))
+        exp=read_lines(cdir/f'{pkg}.exports')
+        exp_sha=sha('\n'.join(exp)+'\n')
+        if data.get('exports_sha256') != exp_sha:
+            errs.append(f'{pkg}: lockfile exports_sha256 mismatch')
+    if errs:
+        for e in errs:
+            print(f'[contract-lockfiles][error] {e}')
+        return 1
+    print('[contract-lockfiles] OK')
+    return 0
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tools/lint_contract_snapshots_pkg.sh
+++ b/tools/lint_contract_snapshots_pkg.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+DIR="$ROOT_DIR/tests/modules/contracts/lint"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[lint-contract-snapshots][error] unknown $1" >&2; exit 1;; esac; shift; done
+ALL="$DIR/lint.exports"; PUB="$DIR/lint.exports.public"; INT="$DIR/lint.exports.internal"; SHA="$DIR/lint.exports.sha256"
+for f in "$ALL" "$PUB" "$INT"; do [ -f "$f" ] || { echo "[lint-contract-snapshots][error] missing $f" >&2; exit 1; }; done
+if [ "$UPDATE" -eq 1 ]; then sha256sum "$ALL"|awk '{print $1}'>$SHA; "$ROOT_DIR/tools/lint_facade_snapshot_pkg.sh" --update; echo "[lint-contract-snapshots] updated"; exit 0; fi
+[ -f "$SHA" ] || { echo "[lint-contract-snapshots][error] missing $SHA" >&2; exit 1; }
+diff -u "$ALL" "$PUB" >/dev/null || { diff -u "$ALL" "$PUB" || true; echo "[lint-contract-snapshots][error] public diverge" >&2; exit 1; }
+[ ! -s "$INT" ] || { echo "[lint-contract-snapshots][error] internal snapshot must be empty" >&2; exit 1; }
+diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null || { echo "[lint-contract-snapshots][error] exports must be sorted" >&2; exit 1; }
+"$ROOT_DIR/tools/lint_facade_snapshot_pkg.sh"
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$ALL"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[lint-contract-snapshots][error] sha mismatch" >&2; exit 1; }
+echo "[lint-contract-snapshots] OK"

--- a/tools/lint_core_alias_pkg.py
+++ b/tools/lint_core_alias_pkg.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+USE_AS = re.compile(r"^\s*use\s+[^\s]+\s+as\s+([A-Za-z_][A-Za-z0-9_]*)\s*$")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "tests/modules/contracts/core"
+    errs: list[str] = []
+    for p in root.rglob("*.vit"):
+        for i, raw in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+            m = USE_AS.match(raw.strip())
+            if not m:
+                continue
+            alias = m.group(1)
+            if not alias.endswith("_pkg"):
+                errs.append(f"{p}:{i}: alias must end with _pkg (got: {alias})")
+    if errs:
+        for e in errs:
+            print(f"[core-alias-pkg][error] {e}")
+        return 1
+    print("[core-alias-pkg] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_core_compat_contracts.py
+++ b/tools/lint_core_compat_contracts.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_set(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/core/core.exports"
+    facade = repo / "tests/modules/contracts/core/core.facade.api"
+    public = repo / "tests/modules/contracts/core/core.exports.public"
+
+    current = read_set(exports)
+    expected = read_set(facade)
+    public_set = read_set(public)
+
+    errs: list[str] = []
+    removed = sorted(expected - current)
+    if removed:
+        errs.append(f"breaking removals detected: {', '.join(removed)}")
+
+    if current != public_set:
+        errs.append("core.exports and core.exports.public diverge")
+
+    if errs:
+        for e in errs:
+            print(f"[core-compat-contracts][error] {e}")
+        return 1
+
+    print("[core-compat-contracts] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_core_export_naming.py
+++ b/tools/lint_core_export_naming.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+SNAKE_OR_PASCAL = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/core/core.exports"
+    if not exports.exists():
+        print(f"[core-export-naming][error] missing {exports}")
+        return 1
+
+    errs: list[str] = []
+    for i, raw in enumerate(exports.read_text(encoding="utf-8").splitlines(), start=1):
+        name = raw.strip()
+        if not name:
+            continue
+        if not SNAKE_OR_PASCAL.match(name):
+            errs.append(f"{exports}:{i}: invalid export name '{name}'")
+
+    if errs:
+        for e in errs:
+            print(f"[core-export-naming][error] {e}")
+        return 1
+    print("[core-export-naming] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_core_mod_contracts.py
+++ b/tools/lint_core_mod_contracts.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+DIAG_PREFIX = "VITTE-C"
+
+
+def non_comment_non_empty(text: str) -> list[str]:
+    out: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    core_mod = repo / "src/vitte/packages/core/mod.vit"
+    if not core_mod.exists():
+        print(f"[core-mod-lint][error] missing file: {core_mod}")
+        return 1
+
+    text = core_mod.read_text(encoding="utf-8")
+    lines = non_comment_non_empty(text)
+    errs: list[str] = []
+
+    if "PREAMBLE (API stable facade)" not in text:
+        errs.append(f"{core_mod}: missing PREAMBLE block")
+    if "<<< ROLE-CONTRACT" not in text:
+        errs.append(f"{core_mod}: missing ROLE-CONTRACT block")
+
+    if any(line.startswith("entry ") for line in lines):
+        errs.append(f"{core_mod}: import-time side effect risk: 'entry' is forbidden in core facade")
+
+    role_required = (
+        "versioning:",
+        "api_surface_stable:",
+        "boundary:",
+        "input_contract:",
+        "output_contract:",
+    )
+    for key in role_required:
+        if key not in text:
+            errs.append(f"{core_mod}: ROLE-CONTRACT missing '{key}'")
+
+    export_names: list[str] = []
+    export_patterns = (
+        re.compile(r"^pick\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^form\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^proc\s+([A-Za-z_][A-Za-z0-9_]*)"),
+    )
+    for line in lines:
+        for pat in export_patterns:
+            m = pat.match(line)
+            if m:
+                export_names.append(m.group(1))
+                break
+
+    if not export_names:
+        errs.append(f"{core_mod}: no public exports found")
+
+    snake_or_pascal = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+    for name in export_names:
+        if not snake_or_pascal.match(name):
+            errs.append(f"{core_mod}: exported name '{name}' violates naming convention")
+
+    # Reserve coded diagnostics namespace for core checks.
+    if DIAG_PREFIX not in text and "role:" in text:
+        # This warning is advisory to keep the check non-blocking for now.
+        print(f"[core-mod-lint][warn] {core_mod}: no {DIAG_PREFIX} reference yet in facade metadata")
+
+    if errs:
+        for e in errs:
+            print(f"[core-mod-lint][error] {e}")
+        print(f"[core-mod-lint] FAILED: {len(errs)} error(s)")
+        return 1
+
+    print("[core-mod-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_core_no_entry.py
+++ b/tools/lint_core_no_entry.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/core"
+    errors: list[str] = []
+    for p in root.rglob("*.vit"):
+        txt = p.read_text(encoding="utf-8")
+        for i, raw in enumerate(txt.splitlines(), start=1):
+            line = raw.strip()
+            if line.startswith("entry "):
+                errors.append(f"{p}:{i}: entry forbidden in core packages")
+    if errors:
+        for e in errors:
+            print(f"[core-no-entry][error] {e}")
+        return 1
+    print("[core-no-entry] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_core_no_internal_exports.py
+++ b/tools/lint_core_no_internal_exports.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    core_mod = repo / "src/vitte/packages/core/mod.vit"
+    internal_snap = repo / "tests/modules/contracts/core/core.exports.internal"
+    errors: list[str] = []
+
+    if not core_mod.exists():
+        errors.append(f"missing file: {core_mod}")
+    else:
+        txt = core_mod.read_text(encoding="utf-8")
+        if "internal/" in txt:
+            errors.append(f"{core_mod}: public facade must not import internal modules")
+
+    if not internal_snap.exists():
+        errors.append(f"missing snapshot: {internal_snap}")
+    else:
+        if internal_snap.read_text(encoding="utf-8").strip():
+            errors.append(f"{internal_snap}: must stay empty (no internal exports)")
+
+    if errors:
+        for e in errors:
+            print(f"[core-no-internal-exports][error] {e}")
+        return 1
+    print("[core-no-internal-exports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_core_sensitive_imports.py
+++ b/tools/lint_core_sensitive_imports.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+DENY = (
+    "vitte/ffi",
+    "vitte/process",
+    "vitte/net",
+    "vitte/http_client",
+)
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/core"
+    errs: list[str] = []
+
+    for p in root.rglob("*.vit"):
+        for i, raw in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+            line = raw.strip()
+            if not line.startswith("use "):
+                continue
+            for denied in DENY:
+                if f"use {denied} " in line or line == f"use {denied}":
+                    errs.append(f"{p}:{i}: sensitive import denied in core: {denied}")
+
+    if errs:
+        for e in errs:
+            print(f"[core-sensitive-imports][error] {e}")
+        return 1
+    print("[core-sensitive-imports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_critical_module_contracts.py
+++ b/tools/lint_critical_module_contracts.py
@@ -5,8 +5,10 @@ import argparse
 import re
 from pathlib import Path
 
-CRITICAL = ("abi", "http", "db", "core")
+CRITICAL = ("abi", "http", "db", "core", "actor", "alerts")
 REQUIRED_FIELDS = ("owner", "stability", "since", "deprecated_in")
+STRICT_ROLE_FIELDS = ("input_contract", "output_contract", "boundary", "versioning", "api_surface_stable")
+STRICT_ROLE_MODULES = {"actor", "alerts"}
 OWNER_RE = re.compile(r"^@[a-z0-9_.-]+/[a-z0-9_.-]+$")
 
 
@@ -74,6 +76,11 @@ def main() -> int:
                 errors.append(f"{info}: missing field '{field}:'")
             if field not in role_kv or not role_kv[field]:
                 errors.append(f"{mod_vit}: ROLE-CONTRACT missing field '{field}:'")
+
+        if mod in STRICT_ROLE_MODULES:
+            for field in STRICT_ROLE_FIELDS:
+                if field not in role_kv or not role_kv[field]:
+                    errors.append(f"{mod_vit}: ROLE-CONTRACT strict missing field '{field}:'")
 
         if "<<< ROLE-CONTRACT" not in read_text(mod_vit):
             errors.append(f"{mod_vit}: missing ROLE-CONTRACT header")

--- a/tools/lint_critical_runtime_matrix.py
+++ b/tools/lint_critical_runtime_matrix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 PROFILES = ("core", "system", "desktop", "arduino")
-CRITICAL = ("abi", "core", "db", "http")
+CRITICAL = ("abi", "core", "db", "http", "alerts")
 
 
 def main() -> int:

--- a/tools/lint_db_alias_pkg.py
+++ b/tools/lint_db_alias_pkg.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+USE_RE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    roots = [repo / "src/vitte/packages/db", repo / "tests/db", repo / "tests/modules/contracts/db"]
+    errs: list[str] = []
+
+    for root in roots:
+        if not root.exists():
+            continue
+        for p in root.rglob("*.vit"):
+            for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+                m = USE_RE.match(line)
+                if not m:
+                    continue
+                alias = m.group(2)
+                if not alias.endswith("_pkg"):
+                    errs.append(f"{p}:{i}: alias must end with _pkg (got {alias})")
+
+    if errs:
+        for e in errs:
+            print(f"[db-alias-pkg-lint][error] {e}")
+        return 1
+    print("[db-alias-pkg-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_db_compat_contracts.py
+++ b/tools/lint_db_compat_contracts.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_set(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/db/db.exports"
+    facade = repo / "tests/modules/contracts/db/db.facade.api"
+    public = repo / "tests/modules/contracts/db/db.exports.public"
+
+    current = read_set(exports)
+    expected = read_set(facade)
+    public_set = read_set(public)
+
+    errs: list[str] = []
+    removed = sorted(expected - current)
+    if removed:
+        errs.append(f"breaking removals detected: {', '.join(removed)}")
+
+    if current != public_set:
+        errs.append("db.exports and db.exports.public diverge")
+
+    if errs:
+        for e in errs:
+            print(f"[db-compat-contracts][error] {e}")
+        return 1
+
+    print("[db-compat-contracts] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_db_export_naming.py
+++ b/tools/lint_db_export_naming.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+NAME_RE = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/db/db.exports"
+    if not exports.exists():
+        print(f"[db-export-naming][error] missing {exports}")
+        return 1
+
+    errs: list[str] = []
+    for i, raw in enumerate(exports.read_text(encoding="utf-8").splitlines(), start=1):
+        name = raw.strip()
+        if not name:
+            continue
+        if not NAME_RE.match(name):
+            errs.append(f"{exports}:{i}: invalid export name: {name}")
+
+    if errs:
+        for e in errs:
+            print(f"[db-export-naming][error] {e}")
+        return 1
+    print("[db-export-naming] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_db_migration_compat.py
+++ b/tools/lint_db_migration_compat.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    mod = repo / "src/vitte/packages/db/mod.vit"
+    txt = mod.read_text(encoding="utf-8") if mod.exists() else ""
+
+    required = ["MigrationState", "migration_lock", "migration_apply", "migration_compat_check"]
+    missing = [x for x in required if x not in txt]
+    if missing:
+        for m in missing:
+            print(f"[db-migration-compat][error] missing symbol: {m}")
+        return 1
+    print("[db-migration-compat] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_db_mod_contracts.py
+++ b/tools/lint_db_mod_contracts.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DIAG_PREFIX = "VITTE-D"
+
+
+def non_comment_non_empty(text: str) -> list[str]:
+    out: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    mod = repo / "src/vitte/packages/db/mod.vit"
+    if not mod.exists():
+        print(f"[db-mod-lint][error] missing file: {mod}")
+        return 1
+
+    text = mod.read_text(encoding="utf-8")
+    lines = non_comment_non_empty(text)
+    errs: list[str] = []
+
+    if "PREAMBLE (API stable facade)" not in text:
+        errs.append(f"{mod}: missing PREAMBLE block")
+    if "<<< ROLE-CONTRACT" not in text:
+        errs.append(f"{mod}: missing ROLE-CONTRACT block")
+    if any(line.startswith("entry ") for line in lines):
+        errs.append(f"{mod}: import-time side effect risk: 'entry' is forbidden")
+
+    for key in ("versioning:", "api_surface_stable:", "boundary:", "input_contract:", "output_contract:", "diagnostics:"):
+        if key not in text:
+            errs.append(f"{mod}: ROLE-CONTRACT missing '{key}'")
+
+    if DIAG_PREFIX not in text:
+        errs.append(f"{mod}: diagnostics namespace must reference {DIAG_PREFIX}")
+
+    if "use vitte/db/internal/" not in text:
+        errs.append(f"{mod}: must route implementation through vitte/db/internal/*")
+
+    if "DbResult" not in text or "DbError" not in text:
+        errs.append(f"{mod}: missing DbResult/DbError canonical types")
+
+    export_names: list[str] = []
+    pats = (
+        re.compile(r"^pick\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^form\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^proc\s+([A-Za-z_][A-Za-z0-9_]*)"),
+    )
+    for line in lines:
+        for pat in pats:
+            m = pat.match(line)
+            if m:
+                export_names.append(m.group(1))
+                break
+
+    snake_or_pascal = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+    for name in export_names:
+        if not snake_or_pascal.match(name):
+            errs.append(f"{mod}: exported name '{name}' violates naming convention")
+
+    if errs:
+        for e in errs:
+            print(f"[db-mod-lint][error] {e}")
+        return 1
+    print("[db-mod-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_db_no_internal_exports.py
+++ b/tools/lint_db_no_internal_exports.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    internal_snap = repo / "tests/modules/contracts/db/db.exports.internal"
+    errs: list[str] = []
+
+    if not internal_snap.exists():
+        errs.append(f"missing snapshot: {internal_snap}")
+    elif internal_snap.read_text(encoding="utf-8").strip():
+        errs.append(f"{internal_snap}: must stay empty")
+
+    if errs:
+        for e in errs:
+            print(f"[db-no-internal-exports][error] {e}")
+        return 1
+    print("[db-no-internal-exports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_db_no_side_effects.py
+++ b/tools/lint_db_no_side_effects.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/db"
+    errs: list[str] = []
+    for p in root.rglob("*.vit"):
+        for i, raw in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+            line = raw.strip()
+            if line.startswith("#"):
+                continue
+            if line.startswith("entry "):
+                errs.append(f"{p}:{i}: entry is forbidden")
+    if errs:
+        for e in errs:
+            print(f"[db-no-side-effects][error] {e}")
+        return 1
+    print("[db-no-side-effects] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_db_sensitive_imports.py
+++ b/tools/lint_db_sensitive_imports.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+USE_RE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+SENSITIVE = {"vitte/ffi", "vitte/process", "vitte/net"}
+
+
+def read_allowlist(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            out.add(line)
+    return out
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/db"
+    allow = read_allowlist(repo / "tests/modules/contracts/db/db_sensitive_imports.allow")
+    errs: list[str] = []
+
+    for p in root.rglob("*.vit"):
+        rel = p.relative_to(repo).as_posix()
+        for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+            m = USE_RE.match(line)
+            if not m:
+                continue
+            target = m.group(1)
+            if target in SENSITIVE and f"{rel}:{target}" not in allow:
+                errs.append(f"{p}:{i}: sensitive import denied: {target}")
+
+    if errs:
+        for e in errs:
+            print(f"[db-sensitive-imports][error] {e}")
+        return 1
+    print("[db-sensitive-imports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_db_sql_injection.py
+++ b/tools/lint_db_sql_injection.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    mod = repo / "src/vitte/packages/db/mod.vit"
+    errs: list[str] = []
+    txt = mod.read_text(encoding="utf-8") if mod.exists() else ""
+
+    # Keep this rule pragmatic: enforce prepared path exists and unsafe concat guard exists.
+    if "proc prepare(" not in txt:
+        errs.append("missing prepare() API")
+    if "is_safe_sql" not in txt:
+        errs.append("missing SQL safety guard")
+    if "execute_prepared" not in txt:
+        errs.append("missing execute_prepared path")
+
+    if errs:
+        for e in errs:
+            print(f"[db-sql-injection-lint][error] {e}")
+        return 1
+    print("[db-sql-injection-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_deprecated_wrappers_budget.py
+++ b/tools/lint_deprecated_wrappers_budget.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    errs=[]
+    for p in (ROOT/'src/vitte/packages').rglob('mod.vit'):
+        txt=p.read_text(encoding='utf-8')
+        for m in re.finditer(r'DEPRECATED[^\n]*removal target:\s*v([0-9]+)\.([0-9]+)\.([0-9]+)', txt):
+            major=int(m.group(1))
+            if major <= 3:
+                errs.append(f'{p}: removal target too close/expired: {m.group(0)}')
+    if errs:
+        for e in errs:
+            print(f'[deprecated-budget][error] {e}')
+        return 1
+    print('[deprecated-budget] OK')
+    return 0
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tools/lint_diagnostic_namespace_ownership.py
+++ b/tools/lint_diagnostic_namespace_ownership.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "tools/facade_packages.json"
+CODE_RE = re.compile(r"VITTE-([A-Z]+)[0-9]{4}")
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding="utf-8"))
+    errs: list[str] = []
+    for ent in cfg["packages"]:
+        pkg = ent["name"]
+        expected = ent["diag_prefix"].split("-")[1]
+        root = ROOT / f"src/vitte/packages/{pkg}"
+        if not root.exists():
+            continue
+        for f in root.rglob("*.vit"):
+            txt = f.read_text(encoding="utf-8")
+            for m in CODE_RE.finditer(txt):
+                got = m.group(1)
+                if got != expected:
+                    errs.append(
+                        f"{pkg}:{f.relative_to(ROOT)}: mixed diag namespace {m.group(0)} expected {ent['diag_prefix']}****"
+                    )
+    if errs:
+        for e in errs:
+            print(f"[diag-namespace][error] {e}")
+        return 1
+    print("[diag-namespace] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_diagnostics_stability.py
+++ b/tools/lint_diagnostics_stability.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / 'tools/facade_packages.json'
+CODE_RE = re.compile(r'VITTE-[A-Z]+[0-9]{4}')
+
+
+def codes_in_runtime(path: Path, marker: str) -> set[str]:
+    if not path.exists():
+        return set()
+    txt = path.read_text(encoding='utf-8')
+    m = re.search(rf'proc\s+{marker}\s*\([^\)]*\)\s*->\s*string\s*\{{(.*?)\n\}}', txt, flags=re.S)
+    if not m:
+        return set()
+    return set(CODE_RE.findall(m.group(1)))
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding='utf-8'))
+    errs = []
+    for ent in cfg['packages']:
+        p = ent['name']
+        mod = ROOT / f'src/vitte/packages/{p}/mod.vit'
+        rt = ROOT / f'src/vitte/packages/{p}/internal/runtime.vit'
+        if not mod.exists() or not rt.exists():
+            continue
+        mod_txt = mod.read_text(encoding='utf-8')
+        if 'proc diagnostics_doc_url(' not in mod_txt:
+            errs.append(f'{p}: missing diagnostics_doc_url in facade')
+        msg_codes = codes_in_runtime(rt, 'diag_message')
+        fix_codes = codes_in_runtime(rt, 'quickfix_for')
+        if not msg_codes:
+            errs.append(f'{p}: missing or unparsable diag_message mapping in runtime')
+            continue
+        unknown_fix_codes = sorted([c for c in fix_codes if c not in msg_codes])
+        if unknown_fix_codes:
+            errs.append(
+                f'{p}: quickfix_for has unknown codes not declared in diag_message: '
+                + ', '.join(unknown_fix_codes)
+            )
+    if errs:
+        for e in errs:
+            print(f'[diag-stability][error] {e}')
+        return 1
+    print('[diag-stability] OK')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/lint_docsgen_pkg.sh
+++ b/tools/lint_docsgen_pkg.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"; SRC="$ROOT_DIR/src/vitte/packages/lint"; OUT_DIR="$ROOT_DIR/docs/lint/api"; INDEX="$ROOT_DIR/docs/lint/API_INDEX.md"; mkdir -p "$OUT_DIR"
+{ echo "# lint API index"; echo; for f in $(find "$SRC" -name '*.vit' | sort); do rel="${f#$ROOT_DIR/}"; md="$OUT_DIR/${rel//\//_}.md"; { echo "# $rel"; echo; echo "## usage"; echo "- use ${rel#src/vitte/packages/} as *_pkg"; echo; echo "## contre-exemple"; echo "- avoid non-deterministic lint output"; echo; echo "## symbols"; rg '^\s*(pick|form|proc)\s+' "$f" || true; } > "$md"; echo "- [$rel](api/$(basename "$md"))"; done; } > "$INDEX"
+echo "[lint-docsgen] wrote $INDEX"

--- a/tools/lint_export_policy.py
+++ b/tools/lint_export_policy.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def major(version: str) -> str:
+    v = version.strip()
+    if not v:
+        return "0"
+    return v.split(".", 1)[0]
+
+
+def read_removed(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    out: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line:
+            out.append(line)
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Fail when stable export removals occur without major version bump"
+    )
+    p.add_argument("--module", required=True, help="module/package name")
+    p.add_argument("--scope", required=True, help="exports scope (all/public/internal)")
+    p.add_argument("--current-version", required=True)
+    p.add_argument("--baseline-version", required=True)
+    p.add_argument("--removed-file", required=True, help="path with removed symbols, one per line")
+    p.add_argument("--allow-breaking", action="store_true")
+    args = p.parse_args()
+
+    removed = read_removed(Path(args.removed_file))
+    print(
+        "[export-policy-lint] "
+        f"module={args.module} scope={args.scope} removed={len(removed)} "
+        f"baseline={args.baseline_version} current={args.current_version}"
+    )
+
+    if not removed:
+        print("[export-policy-lint] OK")
+        return 0
+    if args.allow_breaking:
+        print("[export-policy-lint] OK (allow-breaking)")
+        return 0
+
+    if major(args.current_version) == major(args.baseline_version):
+        print("[export-policy-lint][error] breaking export removal without major bump")
+        for sym in removed:
+            print(f"[export-policy-lint][error] removed: {sym}")
+        return 1
+
+    print("[export-policy-lint] OK (major bump detected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_facade_role_contracts.py
+++ b/tools/lint_facade_role_contracts.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "tools/facade_packages.json"
+
+REQUIRED_KEYS = [
+    "package",
+    "role",
+    "input_contract",
+    "output_contract",
+    "boundary",
+    "versioning",
+    "api_surface_stable",
+    "diagnostics",
+    "compat_policy",
+    "internal_exports",
+    "api_version",
+]
+
+
+def parse_role_contract(txt: str) -> dict[str, str]:
+    m = re.search(r"<<< ROLE-CONTRACT\n(.*?)\n>>>", txt, flags=re.S)
+    if not m:
+        return {}
+    out: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding="utf-8"))
+    errs: list[str] = []
+
+    for ent in cfg["packages"]:
+        pkg = ent["name"]
+        diag_pref = ent["diag_prefix"]
+        mod = ROOT / f"src/vitte/packages/{pkg}/mod.vit"
+        txt = mod.read_text(encoding="utf-8") if mod.exists() else ""
+        if not txt:
+            errs.append(f"{pkg}: missing mod.vit")
+            continue
+        if "PREAMBLE (API stable facade)" not in txt:
+            errs.append(f"{pkg}: missing PREAMBLE")
+        if re.search(r"^\s*entry\s+", txt, flags=re.M):
+            errs.append(f"{pkg}: entry forbidden in facade")
+
+        block = parse_role_contract(txt)
+        if not block:
+            errs.append(f"{pkg}: missing ROLE-CONTRACT block")
+            continue
+
+        for k in REQUIRED_KEYS:
+            if k not in block:
+                errs.append(f"{pkg}: ROLE-CONTRACT missing key '{k}'")
+
+        if block.get("package") != f"vitte/{pkg}":
+            errs.append(f"{pkg}: ROLE-CONTRACT package mismatch")
+        if block.get("compat_policy") != "additive-only":
+            errs.append(f"{pkg}: compat_policy must be additive-only")
+        if block.get("internal_exports") != "forbidden":
+            errs.append(f"{pkg}: internal_exports must be forbidden")
+        if not re.fullmatch(r"v[0-9]+(?:\.[0-9]+)?", block.get("api_version", "")):
+            errs.append(f"{pkg}: api_version must match v<major>[.<minor>]")
+
+        diagnostics = block.get("diagnostics", "")
+        if diag_pref not in diagnostics:
+            errs.append(f"{pkg}: diagnostics range must contain {diag_pref}")
+        if not re.search(rf"{re.escape(diag_pref)}[A-Z0-9x]*", diagnostics):
+            errs.append(f"{pkg}: diagnostics format invalid")
+
+        for need_proc in ["proc api_version()", "proc doctor_status()", "proc diagnostics_message(", "proc diagnostics_quickfix(", "proc diagnostics_doc_url("]:
+            if need_proc not in txt:
+                errs.append(f"{pkg}: missing facade proc {need_proc}")
+
+    if errs:
+        for e in errs:
+            print(f"[facade-role-contracts][error] {e}")
+        return 1
+    print("[facade-role-contracts] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_facade_snapshot_pkg.sh
+++ b/tools/lint_facade_snapshot_pkg.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/lint/lint.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/lint/lint.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/lint/lint.facade.api.sha256"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[lint-facade-snapshot][error] unknown arg: $1" >&2; exit 1;; esac; shift; done
+[ -f "$SRC" ] || { echo "[lint-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+if [ "$UPDATE" -eq 1 ]; then cp "$tmp" "$OUT"; sha256sum "$OUT"|awk '{print $1}'>$SHA; echo "[lint-facade-snapshot] updated"; exit 0; fi
+[ -f "$OUT" ] || { echo "[lint-facade-snapshot][error] missing $OUT" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[lint-facade-snapshot][error] missing $SHA" >&2; exit 1; }
+diff -u "$OUT" "$tmp" >/dev/null || { diff -u "$OUT" "$tmp" || true; echo "[lint-facade-snapshot][error] mismatch" >&2; exit 1; }
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$OUT"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[lint-facade-snapshot][error] sha mismatch" >&2; exit 1; }
+echo "[lint-facade-snapshot] OK"

--- a/tools/lint_facade_thin.py
+++ b/tools/lint_facade_thin.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "tools/facade_packages.json"
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding="utf-8"))
+    errs: list[str] = []
+    warns: list[str] = []
+    for ent in cfg["packages"]:
+        pkg = ent["name"]
+        thin = ent.get("facade_thin", {})
+        mode = str(thin.get("mode", "warn")).lower()
+        warn_loops = int(thin.get("warn_loops", 15))
+        max_loops = int(thin.get("max_loops", 40))
+        max_procs = int(thin.get("max_procs", 120))
+        mod = ROOT / f"src/vitte/packages/{pkg}/mod.vit"
+        if not mod.exists():
+            errs.append(f"{pkg}: missing mod.vit")
+            continue
+        txt = mod.read_text(encoding="utf-8")
+        procs = re.findall(r"^\s*proc\s+", txt, flags=re.M)
+        loops = re.findall(r"\bloop\s*\{", txt)
+        if len(procs) > max_procs:
+            msg = f"{pkg}: too many proc in facade ({len(procs)} > {max_procs})"
+            if mode == "error":
+                errs.append(msg)
+            else:
+                warns.append(msg)
+        if len(loops) > max_loops:
+            msg = f"{pkg}: too many loops in facade ({len(loops)} > {max_loops})"
+            if mode == "error":
+                errs.append(msg)
+            else:
+                warns.append(msg)
+        elif len(loops) > warn_loops:
+            warns.append(f"{pkg}: loop density high ({len(loops)} > {warn_loops})")
+    for w in warns:
+        print(f"[facade-thin][warn] {w}")
+    if errs:
+        for e in errs:
+            print(f"[facade-thin][error] {e}")
+        return 1
+    print("[facade-thin] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_fs_alias_pkg.py
+++ b/tools/lint_fs_alias_pkg.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+USE_RE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    roots = [repo / "src/vitte/packages/fs", repo / "tests/fs", repo / "tests/modules/contracts/fs"]
+    errs: list[str] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        for p in root.rglob("*.vit"):
+            for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+                m = USE_RE.match(line)
+                if not m:
+                    continue
+                alias = m.group(2)
+                if not alias.endswith("_pkg"):
+                    errs.append(f"{p}:{i}: alias must end with _pkg (got {alias})")
+
+    if errs:
+        for e in errs:
+            print(f"[fs-alias-pkg-lint][error] {e}")
+        return 1
+    print("[fs-alias-pkg-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_fs_compat_contracts.py
+++ b/tools/lint_fs_compat_contracts.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_set(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/fs/fs.exports"
+    facade = repo / "tests/modules/contracts/fs/fs.facade.api"
+    public = repo / "tests/modules/contracts/fs/fs.exports.public"
+
+    current = read_set(exports)
+    expected = read_set(facade)
+    public_set = read_set(public)
+
+    errs: list[str] = []
+    removed = sorted(expected - current)
+    if removed:
+        errs.append(f"breaking removals detected: {', '.join(removed)}")
+    if current != public_set:
+        errs.append("fs.exports and fs.exports.public diverge")
+
+    if errs:
+        for e in errs:
+            print(f"[fs-compat-contracts][error] {e}")
+        return 1
+    print("[fs-compat-contracts] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_fs_export_naming.py
+++ b/tools/lint_fs_export_naming.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+NAME_RE = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/fs/fs.exports"
+    if not exports.exists():
+        print(f"[fs-export-naming][error] missing {exports}")
+        return 1
+    errs: list[str] = []
+    for i, raw in enumerate(exports.read_text(encoding="utf-8").splitlines(), start=1):
+        name = raw.strip()
+        if not name:
+            continue
+        if not NAME_RE.match(name):
+            errs.append(f"{exports}:{i}: invalid export name: {name}")
+    if errs:
+        for e in errs:
+            print(f"[fs-export-naming][error] {e}")
+        return 1
+    print("[fs-export-naming] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_fs_mod_contracts.py
+++ b/tools/lint_fs_mod_contracts.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DIAG_PREFIX = "VITTE-F"
+
+
+def non_comment_non_empty(text: str) -> list[str]:
+    out: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    mod = repo / "src/vitte/packages/fs/mod.vit"
+    if not mod.exists():
+        print(f"[fs-mod-lint][error] missing file: {mod}")
+        return 1
+
+    text = mod.read_text(encoding="utf-8")
+    lines = non_comment_non_empty(text)
+    errs: list[str] = []
+
+    if "PREAMBLE (API stable facade)" not in text:
+        errs.append(f"{mod}: missing PREAMBLE block")
+    if "<<< ROLE-CONTRACT" not in text:
+        errs.append(f"{mod}: missing ROLE-CONTRACT block")
+    if any(line.startswith("entry ") for line in lines):
+        errs.append(f"{mod}: import-time side effect risk: 'entry' is forbidden")
+
+    for key in ("versioning:", "api_surface_stable:", "boundary:", "input_contract:", "output_contract:", "diagnostics:"):
+        if key not in text:
+            errs.append(f"{mod}: ROLE-CONTRACT missing '{key}'")
+
+    if DIAG_PREFIX not in text:
+        errs.append(f"{mod}: diagnostics namespace must reference {DIAG_PREFIX}")
+
+    if "use vitte/fs/internal/" not in text:
+        errs.append(f"{mod}: must route implementation through vitte/fs/internal/*")
+
+    export_names: list[str] = []
+    pats = (
+        re.compile(r"^pick\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^form\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^proc\s+([A-Za-z_][A-Za-z0-9_]*)"),
+    )
+    for line in lines:
+        for pat in pats:
+            m = pat.match(line)
+            if m:
+                export_names.append(m.group(1))
+                break
+
+    snake_or_pascal = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+    for name in export_names:
+        if not snake_or_pascal.match(name):
+            errs.append(f"{mod}: exported name '{name}' violates naming convention")
+
+    if errs:
+        for e in errs:
+            print(f"[fs-mod-lint][error] {e}")
+        return 1
+    print("[fs-mod-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_fs_no_internal_exports.py
+++ b/tools/lint_fs_no_internal_exports.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    internal_snap = repo / "tests/modules/contracts/fs/fs.exports.internal"
+    errs: list[str] = []
+    if not internal_snap.exists():
+        errs.append(f"missing snapshot: {internal_snap}")
+    elif internal_snap.read_text(encoding="utf-8").strip():
+        errs.append(f"{internal_snap}: must stay empty")
+
+    if errs:
+        for e in errs:
+            print(f"[fs-no-internal-exports][error] {e}")
+        return 1
+    print("[fs-no-internal-exports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_fs_no_side_effects.py
+++ b/tools/lint_fs_no_side_effects.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/fs"
+    errs: list[str] = []
+    for p in root.rglob("*.vit"):
+        for i, raw in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+            line = raw.strip()
+            if line.startswith("#"):
+                continue
+            if line.startswith("entry "):
+                errs.append(f"{p}:{i}: entry is forbidden")
+    if errs:
+        for e in errs:
+            print(f"[fs-no-side-effects][error] {e}")
+        return 1
+    print("[fs-no-side-effects] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_fs_sensitive_imports.py
+++ b/tools/lint_fs_sensitive_imports.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+USE_RE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+SENSITIVE = {"vitte/ffi", "vitte/process", "vitte/net"}
+
+
+def read_allowlist(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            out.add(line)
+    return out
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/fs"
+    allow = read_allowlist(repo / "tests/modules/contracts/fs/fs_sensitive_imports.allow")
+    errs: list[str] = []
+
+    for p in root.rglob("*.vit"):
+        rel = p.relative_to(repo).as_posix()
+        for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+            m = USE_RE.match(line)
+            if not m:
+                continue
+            target = m.group(1)
+            if target in SENSITIVE and f"{rel}:{target}" not in allow:
+                errs.append(f"{p}:{i}: sensitive import denied: {target}")
+
+    if errs:
+        for e in errs:
+            print(f"[fs-sensitive-imports][error] {e}")
+        return 1
+    print("[fs-sensitive-imports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_fuzz_pkg.sh
+++ b/tools/lint_fuzz_pkg.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+FUZZ_SECS="${FUZZ_SECS:-0}"
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"; SEEDS="$ROOT_DIR/tests/lint/fuzz_seeds"; OUT="$ROOT_DIR/target/fuzz/lint_fuzz_report.txt"; mkdir -p "$(dirname "$OUT")"; count=0; : > "$OUT"
+for f in rules fix diag; do seed="$SEEDS/$f.seed"; if [ -f "$seed" ]; then bytes="$(wc -c < "$seed" | tr -d ' ')"; echo "$f:seed_bytes=$bytes" >> "$OUT"; count=$((count+1)); fi; done
+echo "total_seeds=$count" >> "$OUT"; echo "[lint-fuzz] wrote (budget=${FUZZ_SECS}s) $OUT with $count seeds"

--- a/tools/lint_http_alias_pkg.py
+++ b/tools/lint_http_alias_pkg.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+
+def check(paths, tag):
+    errs=[]
+    for root in paths:
+        if not root.exists(): continue
+        for p in root.rglob('*.vit'):
+            for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+                m=USE.match(l)
+                if m and not m.group(2).endswith('_pkg'): errs.append(f'{p}:{i}: alias must end with _pkg')
+    if errs:
+        for e in errs: print(f'[{tag}][error] {e}')
+        return 1
+    print(f'[{tag}] OK'); return 0
+
+if __name__=='__main__':
+    repo=Path(__file__).resolve().parents[1]
+    a=check([repo/'src/vitte/packages/http',repo/'tests/http',repo/'tests/modules/contracts/http'],'http-alias-pkg-lint')
+    b=check([repo/'src/vitte/packages/http_client',repo/'tests/http_client',repo/'tests/modules/contracts/http_client'],'http-client-alias-pkg-lint')
+    raise SystemExit(1 if (a or b) else 0)

--- a/tools/lint_http_client_mod_contracts.py
+++ b/tools/lint_http_client_mod_contracts.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+DIAG_PREFIX='VITTE-C'
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    mod=repo/'src/vitte/packages/http_client/mod.vit'
+    txt=mod.read_text(encoding='utf-8') if mod.exists() else ''
+    errs=[]
+    if 'PREAMBLE (API stable facade)' not in txt: errs.append('missing PREAMBLE')
+    if '<<< ROLE-CONTRACT' not in txt: errs.append('missing ROLE-CONTRACT')
+    if 'use vitte/http_client/internal/' not in txt: errs.append('missing internal bridge')
+    for k in ('versioning:','api_surface_stable:','diagnostics:'): 
+        if k not in txt: errs.append(f'missing {k}')
+    if DIAG_PREFIX not in txt: errs.append('missing diagnostics prefix')
+    if 'entry ' in txt: errs.append('entry forbidden')
+    name_re=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+    for ln in txt.splitlines():
+        m=re.match(r'\s*(pick|form|proc)\s+([A-Za-z_][A-Za-z0-9_]*)',ln)
+        if m and not name_re.match(m.group(2)): errs.append(f'invalid export name {m.group(2)}')
+    if errs:
+        for e in errs: print(f'[http-client-mod-lint][error] {e}')
+        return 1
+    print('[http-client-mod-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_http_compat_contracts.py
+++ b/tools/lint_http_compat_contracts.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def read_set(p: Path):
+    if not p.exists(): return set()
+    return {l.strip() for l in p.read_text(encoding='utf-8').splitlines() if l.strip()}
+
+def check(root: Path, prefix: str, tag: str):
+    cur=read_set(root/f'{prefix}.exports')
+    exp=read_set(root/f'{prefix}.facade.api')
+    pub=read_set(root/f'{prefix}.exports.public')
+    errs=[]
+    removed=sorted(exp-cur)
+    if removed: errs.append('breaking removals detected: '+', '.join(removed))
+    if cur!=pub: errs.append(f'{prefix}.exports and .public diverge')
+    if errs:
+        for e in errs: print(f'[{tag}][error] {e}')
+        return 1
+    print(f'[{tag}] OK'); return 0
+
+if __name__=='__main__':
+    repo=Path(__file__).resolve().parents[1]
+    a=check(repo/'tests/modules/contracts/http','http','http-compat-contracts')
+    b=check(repo/'tests/modules/contracts/http_client','http_client','http-client-compat-contracts')
+    raise SystemExit(1 if (a or b) else 0)

--- a/tools/lint_http_export_naming.py
+++ b/tools/lint_http_export_naming.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+NAME=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+
+def check(path: Path, tag: str):
+    if not path.exists():
+        print(f'[{tag}][error] missing {path}')
+        return 1
+    errs=[]
+    for i,l in enumerate(path.read_text(encoding='utf-8').splitlines(),1):
+        t=l.strip()
+        if t and not NAME.match(t): errs.append(f'{path}:{i}: invalid {t}')
+    if errs:
+        for e in errs: print(f'[{tag}][error] {e}')
+        return 1
+    print(f'[{tag}] OK'); return 0
+
+if __name__=='__main__':
+    repo=Path(__file__).resolve().parents[1]
+    a=check(repo/'tests/modules/contracts/http/http.exports','http-export-naming')
+    b=check(repo/'tests/modules/contracts/http_client/http_client.exports','http-client-export-naming')
+    raise SystemExit(1 if (a or b) else 0)

--- a/tools/lint_http_mod_contracts.py
+++ b/tools/lint_http_mod_contracts.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+DIAG_PREFIX='VITTE-H'
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    mod=repo/'src/vitte/packages/http/mod.vit'
+    txt=mod.read_text(encoding='utf-8') if mod.exists() else ''
+    errs=[]
+    if 'PREAMBLE (API stable facade)' not in txt: errs.append('missing PREAMBLE')
+    if '<<< ROLE-CONTRACT' not in txt: errs.append('missing ROLE-CONTRACT')
+    if 'use vitte/http/internal/' not in txt: errs.append('missing internal bridge')
+    for k in ('versioning:','api_surface_stable:','diagnostics:'): 
+        if k not in txt: errs.append(f'missing {k}')
+    if DIAG_PREFIX not in txt: errs.append('missing diagnostics prefix')
+    if 'entry ' in txt: errs.append('entry forbidden')
+    name_re=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+    for ln in txt.splitlines():
+        m=re.match(r'\s*(pick|form|proc)\s+([A-Za-z_][A-Za-z0-9_]*)',ln)
+        if m and not name_re.match(m.group(2)): errs.append(f'invalid export name {m.group(2)}')
+    if errs:
+        for e in errs: print(f'[http-mod-lint][error] {e}')
+        return 1
+    print('[http-mod-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_http_no_internal_exports.py
+++ b/tools/lint_http_no_internal_exports.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def check(path: Path, tag: str) -> int:
+    if not path.exists():
+        print(f"[{tag}][error] missing snapshot: {path}")
+        return 1
+    if path.read_text(encoding="utf-8").strip():
+        print(f"[{tag}][error] {path}: must stay empty")
+        return 1
+    print(f"[{tag}] OK")
+    return 0
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    a = check(repo / "tests/modules/contracts/http/http.exports.internal", "http-no-internal-exports")
+    b = check(repo / "tests/modules/contracts/http_client/http_client.exports.internal", "http-client-no-internal-exports")
+    return 1 if (a or b) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_http_no_side_effects.py
+++ b/tools/lint_http_no_side_effects.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def check(root: Path, tag: str)->int:
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            if l.strip().startswith('entry '): errs.append(f'{p}:{i}: entry forbidden')
+    if errs:
+        for e in errs: print(f'[{tag}][error] {e}')
+        return 1
+    print(f'[{tag}] OK'); return 0
+
+if __name__=='__main__':
+    repo=Path(__file__).resolve().parents[1]
+    a=check(repo/'src/vitte/packages/http','http-no-side-effects')
+    b=check(repo/'src/vitte/packages/http_client','http-client-no-side-effects')
+    raise SystemExit(1 if (a or b) else 0)

--- a/tools/lint_http_security.py
+++ b/tools/lint_http_security.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main()->int:
+    repo=Path(__file__).resolve().parents[1]
+    http_txt=(repo/'src/vitte/packages/http/mod.vit').read_text(encoding='utf-8')
+    cli_txt=(repo/'src/vitte/packages/http_client/mod.vit').read_text(encoding='utf-8')
+    errs=[]
+    for need in ['apply_security_gates','VITTE-H0002','VITTE-H0009','with_cors','with_csrf','with_rate_limit']:
+        if need not in http_txt: errs.append(f'http missing {need}')
+    for need in ['validate_request','VITTE-C0002','VITTE-C0003','security_redirect_allowed','strict_tls']:
+        if need not in cli_txt: errs.append(f'http_client missing {need}')
+    if errs:
+        for e in errs: print(f'[http-security-lint][error] {e}')
+        return 1
+    print('[http-security-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_http_sensitive_imports.py
+++ b/tools/lint_http_sensitive_imports.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import json
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+SENSITIVE={'vitte/ffi','vitte/process','vitte/net'}
+
+def read_allow(path: Path):
+    if not path.exists(): return set()
+    out=set()
+    for l in path.read_text(encoding='utf-8').splitlines():
+        t=l.strip()
+        if t and not t.startswith('#'): out.add(t)
+    return out
+
+def read_global_allow(repo: Path):
+    p = repo / 'tools/allowlist_policy.json'
+    if not p.exists():
+        return set()
+    try:
+        data = json.loads(p.read_text(encoding='utf-8'))
+    except Exception:
+        return set()
+    return set(data.get('sensitive_import_allowlist', []))
+
+def check(root: Path, allow: set[str], tag:str):
+    errs=[]
+    for p in root.rglob('*.vit'):
+        rel=p.relative_to(Path(__file__).resolve().parents[1]).as_posix()
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if not m: continue
+            t=m.group(1)
+            if t in SENSITIVE and f'{rel}:{t}' not in allow:
+                errs.append(f'{p}:{i}: sensitive import denied: {t}')
+    if errs:
+        for e in errs: print(f'[{tag}][error] {e}')
+        return 1
+    print(f'[{tag}] OK'); return 0
+
+if __name__=='__main__':
+    repo=Path(__file__).resolve().parents[1]
+    g = read_global_allow(repo)
+    a=check(repo/'src/vitte/packages/http',read_allow(repo/'tests/modules/contracts/http/http_sensitive_imports.allow') | g,'http-sensitive-imports')
+    b=check(repo/'src/vitte/packages/http_client',read_allow(repo/'tests/modules/contracts/http_client/http_client_sensitive_imports.allow') | g,'http-client-sensitive-imports')
+    raise SystemExit(1 if (a or b) else 0)

--- a/tools/lint_json_alias_pkg.py
+++ b/tools/lint_json_alias_pkg.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    root=repo/'src/vitte/packages/json'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if m and not m.group(2).endswith('_pkg'):
+                errs.append(f'{p}:{i}: alias must end with _pkg')
+    if errs:
+        for e in errs: print(f'[json-alias-pkg][error] {e}')
+        return 1
+    print('[json-alias-pkg] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_json_compat_contracts.py
+++ b/tools/lint_json_compat_contracts.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def read_set(p: Path):
+    if not p.exists(): return set()
+    return {l.strip() for l in p.read_text(encoding='utf-8').splitlines() if l.strip()}
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    root=repo/'tests/modules/contracts/json'
+    cur=read_set(root/'json.exports')
+    exp=read_set(root/'json.facade.api')
+    pub=read_set(root/'json.exports.public')
+    errs=[]
+    removed=sorted(exp-cur)
+    if removed: errs.append('breaking removals detected: '+', '.join(removed))
+    if cur!=pub: errs.append('json.exports and json.exports.public diverge')
+    if errs:
+        for e in errs: print(f'[json-compat-contracts][error] {e}')
+        return 1
+    print('[json-compat-contracts] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_json_export_naming.py
+++ b/tools/lint_json_export_naming.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+NAME=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    path=repo/'tests/modules/contracts/json/json.exports'
+    if not path.exists():
+        print(f'[json-export-naming][error] missing {path}')
+        return 1
+    errs=[]
+    for i,l in enumerate(path.read_text(encoding='utf-8').splitlines(),1):
+        t=l.strip()
+        if t and not NAME.match(t): errs.append(f'{path}:{i}: invalid {t}')
+    if errs:
+        for e in errs: print(f'[json-export-naming][error] {e}')
+        return 1
+    print('[json-export-naming] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_json_mod_contracts.py
+++ b/tools/lint_json_mod_contracts.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+DIAG_PREFIX='VITTE-J'
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    mod=repo/'src/vitte/packages/json/mod.vit'
+    txt=mod.read_text(encoding='utf-8') if mod.exists() else ''
+    errs=[]
+    if 'PREAMBLE (API stable facade)' not in txt: errs.append('missing PREAMBLE')
+    if '<<< ROLE-CONTRACT' not in txt: errs.append('missing ROLE-CONTRACT')
+    if 'use vitte/json/internal/runtime as json_runtime_pkg' not in txt: errs.append('missing internal bridge alias')
+    for k in ('versioning:','api_surface_stable:','diagnostics:'):
+        if k not in txt: errs.append(f'missing {k}')
+    if DIAG_PREFIX not in txt: errs.append('missing diagnostics prefix')
+    if 'entry ' in txt: errs.append('entry forbidden')
+    name_re=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+    for ln in txt.splitlines():
+        m=re.match(r'\s*(pick|form|proc)\s+([A-Za-z_][A-Za-z0-9_]*)',ln)
+        if m and not name_re.match(m.group(2)): errs.append(f'invalid export name {m.group(2)}')
+    if errs:
+        for e in errs: print(f'[json-mod-lint][error] {e}')
+        return 1
+    print('[json-mod-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_json_no_internal_exports.py
+++ b/tools/lint_json_no_internal_exports.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+from pathlib import Path
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    p = repo / 'tests/modules/contracts/json/json.exports.internal'
+    if not p.exists():
+        print(f'[json-no-internal-exports][error] missing snapshot: {p}')
+        return 1
+    if p.read_text(encoding='utf-8').strip():
+        print(f'[json-no-internal-exports][error] {p}: must stay empty')
+        return 1
+    print('[json-no-internal-exports] OK')
+    return 0
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/lint_json_no_side_effects.py
+++ b/tools/lint_json_no_side_effects.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1] / 'src/vitte/packages/json'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            if l.strip().startswith('entry '):
+                errs.append(f'{p}:{i}: entry forbidden')
+    if errs:
+        for e in errs:
+            print(f'[json-no-side-effects][error] {e}')
+        return 1
+    print('[json-no-side-effects] OK')
+    return 0
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tools/lint_json_security.py
+++ b/tools/lint_json_security.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main()->int:
+    repo=Path(__file__).resolve().parents[1]
+    txt=(repo/'src/vitte/packages/json/mod.vit').read_text(encoding='utf-8')
+    itxt=(repo/'src/vitte/packages/json/internal/runtime.vit').read_text(encoding='utf-8')
+    errs=[]
+    for need in ['max_bytes','max_depth','max_nodes','strict_utf8','strict_escapes','parse_stream','write_stream']:
+        if need not in txt: errs.append(f'missing {need} in facade')
+    for need in ['VITTE-J0004','VITTE-J0011','validate_parse_input','quickfix_for']:
+        if need not in itxt: errs.append(f'missing {need} in runtime')
+    if errs:
+        for e in errs: print(f'[json-security-lint][error] {e}')
+        return 1
+    print('[json-security-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_json_sensitive_imports.py
+++ b/tools/lint_json_sensitive_imports.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import json
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+SENSITIVE={'vitte/ffi','vitte/net','vitte/process'}
+
+def read_allow(path: Path):
+    if not path.exists(): return set()
+    out=set()
+    for l in path.read_text(encoding='utf-8').splitlines():
+        t=l.strip()
+        if t and not t.startswith('#'): out.add(t)
+    return out
+
+def read_global_allow(repo: Path):
+    p = repo / 'tools/allowlist_policy.json'
+    if not p.exists():
+        return set()
+    try:
+        data = json.loads(p.read_text(encoding='utf-8'))
+    except Exception:
+        return set()
+    return set(data.get('sensitive_import_allowlist', []))
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    allow=read_allow(repo/'tests/modules/contracts/json/json_sensitive_imports.allow') | read_global_allow(repo)
+    root=repo/'src/vitte/packages/json'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        rel=p.relative_to(repo).as_posix()
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if not m: continue
+            t=m.group(1)
+            if t in SENSITIVE and f'{rel}:{t}' not in allow:
+                errs.append(f'{p}:{i}: sensitive import denied: {t}')
+    if errs:
+        for e in errs: print(f'[json-sensitive-imports][error] {e}')
+        return 1
+    print('[json-sensitive-imports] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_lint_alias_pkg.py
+++ b/tools/lint_lint_alias_pkg.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    root=repo/'src/vitte/packages/lint'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if m and not m.group(2).endswith('_pkg'):
+                errs.append(f'{p}:{i}: alias must end with _pkg')
+    if errs:
+        for e in errs: print(f'[lint-alias-pkg][error] {e}')
+        return 1
+    print('[lint-alias-pkg] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_lint_compat_contracts.py
+++ b/tools/lint_lint_compat_contracts.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def read_set(p: Path):
+    if not p.exists(): return set()
+    return {l.strip() for l in p.read_text(encoding='utf-8').splitlines() if l.strip()}
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    root=repo/'tests/modules/contracts/lint'
+    cur=read_set(root/'lint.exports')
+    exp=read_set(root/'lint.facade.api')
+    pub=read_set(root/'lint.exports.public')
+    errs=[]
+    removed=sorted(exp-cur)
+    if removed: errs.append('breaking removals detected: '+', '.join(removed))
+    if cur!=pub: errs.append('lint.exports and lint.exports.public diverge')
+    if errs:
+        for e in errs: print(f'[lint-compat-contracts][error] {e}')
+        return 1
+    print('[lint-compat-contracts] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_lint_export_naming.py
+++ b/tools/lint_lint_export_naming.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+NAME=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    path=repo/'tests/modules/contracts/lint/lint.exports'
+    if not path.exists():
+        print(f'[lint-export-naming][error] missing {path}')
+        return 1
+    errs=[]
+    for i,l in enumerate(path.read_text(encoding='utf-8').splitlines(),1):
+        t=l.strip()
+        if t and not NAME.match(t): errs.append(f'{path}:{i}: invalid {t}')
+    if errs:
+        for e in errs: print(f'[lint-export-naming][error] {e}')
+        return 1
+    print('[lint-export-naming] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_lint_mod_contracts.py
+++ b/tools/lint_lint_mod_contracts.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+DIAG_PREFIX='VITTE-I'
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    mod=repo/'src/vitte/packages/lint/mod.vit'
+    txt=mod.read_text(encoding='utf-8') if mod.exists() else ''
+    errs=[]
+    if 'PREAMBLE (API stable facade)' not in txt: errs.append('missing PREAMBLE')
+    if '<<< ROLE-CONTRACT' not in txt: errs.append('missing ROLE-CONTRACT')
+    if 'use vitte/lint/internal/' not in txt: errs.append('missing internal bridge aliases')
+    for k in ('versioning:','api_surface_stable:','diagnostics:'):
+        if k not in txt: errs.append(f'missing {k}')
+    if DIAG_PREFIX not in txt: errs.append('missing diagnostics prefix')
+    if 'entry ' in txt: errs.append('entry forbidden')
+    name_re=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+    for ln in txt.splitlines():
+        m=re.match(r'\s*(pick|form|proc)\s+([A-Za-z_][A-Za-z0-9_]*)',ln)
+        if m and not name_re.match(m.group(2)): errs.append(f'invalid export name {m.group(2)}')
+    if errs:
+        for e in errs: print(f'[lint-mod-lint][error] {e}')
+        return 1
+    print('[lint-mod-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_lint_no_internal_exports.py
+++ b/tools/lint_lint_no_internal_exports.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    p = repo / 'tests/modules/contracts/lint/lint.exports.internal'
+    if not p.exists():
+        print(f'[lint-no-internal-exports][error] missing snapshot: {p}')
+        return 1
+    if p.read_text(encoding='utf-8').strip():
+        print(f'[lint-no-internal-exports][error] {p}: must stay empty')
+        return 1
+    print('[lint-no-internal-exports] OK')
+    return 0
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/lint_lint_no_side_effects.py
+++ b/tools/lint_lint_no_side_effects.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1] / 'src/vitte/packages/lint'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            if l.strip().startswith('entry '):
+                errs.append(f'{p}:{i}: entry forbidden')
+    if errs:
+        for e in errs:
+            print(f'[lint-no-side-effects][error] {e}')
+        return 1
+    print('[lint-no-side-effects] OK')
+    return 0
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tools/lint_lint_rule_ownership.py
+++ b/tools/lint_lint_rule_ownership.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RULES = ROOT / 'src/vitte/packages/lint/internal/rules.vit'
+META = ROOT / 'tools/lint_rule_ownership.json'
+
+
+def parse_rule_ids(txt: str) -> list[str]:
+    return re.findall(r'LintRule\("([^"]+)"', txt)
+
+
+def main() -> int:
+    if not RULES.exists() or not META.exists():
+        print('[lint-rule-ownership][error] missing rules.vit or lint_rule_ownership.json')
+        return 1
+    ids = parse_rule_ids(RULES.read_text(encoding='utf-8'))
+    meta = json.loads(META.read_text(encoding='utf-8'))
+    errs = []
+    for rid in ids:
+        m = meta.get(rid)
+        if not m:
+            errs.append(f'missing ownership metadata for rule {rid}')
+            continue
+        for key in ['owner', 'rationale', 'false_positive_policy']:
+            if not str(m.get(key, '')).strip():
+                errs.append(f'rule {rid}: missing {key}')
+    if errs:
+        for e in errs:
+            print(f'[lint-rule-ownership][error] {e}')
+        return 1
+    print('[lint-rule-ownership] OK')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/lint_lint_security.py
+++ b/tools/lint_lint_security.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main()->int:
+    repo=Path(__file__).resolve().parents[1]
+    txt=(repo/'src/vitte/packages/lint/mod.vit').read_text(encoding='utf-8')
+    itxt=(repo/'src/vitte/packages/lint/internal/engine.vit').read_text(encoding='utf-8')
+    errs=[]
+    for need in ['quickfix_preview','quickfix_apply','LintConfig','lint_workspace','policy_allows_ci_block']:
+        if need not in txt: errs.append(f'missing {need} in facade')
+    for need in ['VITTE-I0001','VITTE-I0002','diag_message','quickfix_for']:
+        if need not in itxt: errs.append(f'missing {need} in runtime')
+    if errs:
+        for e in errs: print(f'[lint-security-lint][error] {e}')
+        return 1
+    print('[lint-security-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_lint_sensitive_imports.py
+++ b/tools/lint_lint_sensitive_imports.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import json, re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+SENSITIVE={'vitte/ffi','vitte/net'}
+
+def read_allow(path: Path):
+    if not path.exists(): return set()
+    out=set()
+    for l in path.read_text(encoding='utf-8').splitlines():
+        t=l.strip()
+        if t and not t.startswith('#'): out.add(t)
+    return out
+
+def read_global_allow(repo: Path):
+    p = repo / 'tools/allowlist_policy.json'
+    if not p.exists(): return set()
+    try: data=json.loads(p.read_text(encoding='utf-8'))
+    except Exception: return set()
+    return set(data.get('sensitive_import_allowlist', []))
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    allow=read_allow(repo/'tests/modules/contracts/lint/lint_sensitive_imports.allow') | read_global_allow(repo)
+    root=repo/'src/vitte/packages/lint'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        rel=p.relative_to(repo).as_posix()
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if not m: continue
+            t=m.group(1)
+            if t in SENSITIVE and f'{rel}:{t}' not in allow:
+                errs.append(f'{p}:{i}: sensitive import denied: {t}')
+    if errs:
+        for e in errs: print(f'[lint-sensitive-imports][error] {e}')
+        return 1
+    print('[lint-sensitive-imports] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_log_alias_pkg.py
+++ b/tools/lint_log_alias_pkg.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+USE_RE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    roots = [repo / "src/vitte/packages/log", repo / "tests/log", repo / "tests/modules/contracts/log"]
+    errs: list[str] = []
+
+    for root in roots:
+        if not root.exists():
+            continue
+        for p in root.rglob("*.vit"):
+            for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+                m = USE_RE.match(line)
+                if not m:
+                    continue
+                alias = m.group(2)
+                if not alias.endswith("_pkg"):
+                    errs.append(f"{p}:{i}: alias must end with _pkg (got {alias})")
+
+    if errs:
+        for e in errs:
+            print(f"[log-alias-pkg-lint][error] {e}")
+        return 1
+    print("[log-alias-pkg-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_log_compat_contracts.py
+++ b/tools/lint_log_compat_contracts.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_set(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/log/log.exports"
+    facade = repo / "tests/modules/contracts/log/log.facade.api"
+    public = repo / "tests/modules/contracts/log/log.exports.public"
+
+    current = read_set(exports)
+    expected = read_set(facade)
+    public_set = read_set(public)
+
+    errs: list[str] = []
+    removed = sorted(expected - current)
+    if removed:
+        errs.append(f"breaking removals detected: {', '.join(removed)}")
+
+    if current != public_set:
+        errs.append("log.exports and log.exports.public diverge")
+
+    if errs:
+        for e in errs:
+            print(f"[log-compat-contracts][error] {e}")
+        return 1
+
+    print("[log-compat-contracts] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_log_export_naming.py
+++ b/tools/lint_log_export_naming.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+NAME_RE = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/log/log.exports"
+    if not exports.exists():
+        print(f"[log-export-naming][error] missing {exports}")
+        return 1
+
+    errs: list[str] = []
+    for i, raw in enumerate(exports.read_text(encoding="utf-8").splitlines(), start=1):
+        name = raw.strip()
+        if not name:
+            continue
+        if not NAME_RE.match(name):
+            errs.append(f"{exports}:{i}: invalid export name: {name}")
+
+    if errs:
+        for e in errs:
+            print(f"[log-export-naming][error] {e}")
+        return 1
+    print("[log-export-naming] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_log_mod_contracts.py
+++ b/tools/lint_log_mod_contracts.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DIAG_PREFIX = "VITTE-L"
+
+
+def non_comment_non_empty(text: str) -> list[str]:
+    out: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    mod = repo / "src/vitte/packages/log/mod.vit"
+    if not mod.exists():
+        print(f"[log-mod-lint][error] missing file: {mod}")
+        return 1
+
+    text = mod.read_text(encoding="utf-8")
+    lines = non_comment_non_empty(text)
+    errs: list[str] = []
+
+    if "PREAMBLE (API stable facade)" not in text:
+        errs.append(f"{mod}: missing PREAMBLE block")
+    if "<<< ROLE-CONTRACT" not in text:
+        errs.append(f"{mod}: missing ROLE-CONTRACT block")
+    if any(line.startswith("entry ") for line in lines):
+        errs.append(f"{mod}: import-time side effect risk: 'entry' is forbidden")
+
+    required = (
+        "versioning:",
+        "api_surface_stable:",
+        "boundary:",
+        "input_contract:",
+        "output_contract:",
+        "diagnostics:",
+    )
+    for key in required:
+        if key not in text:
+            errs.append(f"{mod}: ROLE-CONTRACT missing '{key}'")
+
+    if DIAG_PREFIX not in text:
+        errs.append(f"{mod}: diagnostics namespace must reference {DIAG_PREFIX}")
+
+    if "use vitte/log/internal/" not in text:
+        errs.append(f"{mod}: must route implementation through vitte/log/internal/*")
+
+    export_names: list[str] = []
+    pats = (
+        re.compile(r"^pick\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^form\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^proc\s+([A-Za-z_][A-Za-z0-9_]*)"),
+    )
+    for line in lines:
+        for pat in pats:
+            m = pat.match(line)
+            if m:
+                export_names.append(m.group(1))
+                break
+
+    snake_or_pascal = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+    for name in export_names:
+        if not snake_or_pascal.match(name):
+            errs.append(f"{mod}: exported name '{name}' violates naming convention")
+
+    if errs:
+        for e in errs:
+            print(f"[log-mod-lint][error] {e}")
+        return 1
+    print("[log-mod-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_log_no_internal_exports.py
+++ b/tools/lint_log_no_internal_exports.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    internal_snap = repo / "tests/modules/contracts/log/log.exports.internal"
+    errs: list[str] = []
+
+    if not internal_snap.exists():
+        errs.append(f"missing snapshot: {internal_snap}")
+    elif internal_snap.read_text(encoding="utf-8").strip():
+        errs.append(f"{internal_snap}: must stay empty")
+
+    if errs:
+        for e in errs:
+            print(f"[log-no-internal-exports][error] {e}")
+        return 1
+    print("[log-no-internal-exports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_log_no_side_effects.py
+++ b/tools/lint_log_no_side_effects.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/log"
+    errs: list[str] = []
+    for p in root.rglob("*.vit"):
+        for i, raw in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+            line = raw.strip()
+            if line.startswith("#"):
+                continue
+            if line.startswith("entry "):
+                errs.append(f"{p}:{i}: entry is forbidden")
+    if errs:
+        for e in errs:
+            print(f"[log-no-side-effects][error] {e}")
+        return 1
+    print("[log-no-side-effects] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_log_sensitive_imports.py
+++ b/tools/lint_log_sensitive_imports.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+USE_RE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+SENSITIVE = {"vitte/ffi", "vitte/process", "vitte/net"}
+
+
+def read_allowlist(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            out.add(line)
+    return out
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/log"
+    allow = read_allowlist(repo / "tests/modules/contracts/log/log_sensitive_imports.allow")
+    errs: list[str] = []
+
+    for p in root.rglob("*.vit"):
+        rel = p.relative_to(repo).as_posix()
+        for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+            m = USE_RE.match(line)
+            if not m:
+                continue
+            target = m.group(1)
+            if target in SENSITIVE and f"{rel}:{target}" not in allow:
+                errs.append(f"{p}:{i}: sensitive import denied: {target}")
+
+    if errs:
+        for e in errs:
+            print(f"[log-sensitive-imports][error] {e}")
+        return 1
+    print("[log-sensitive-imports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_macro_bench_pkg.sh
+++ b/tools/lint_macro_bench_pkg.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"; OUT_DIR="$ROOT_DIR/target/bench"; mkdir -p "$OUT_DIR"
+start="$(date +%s%3N)"; rg --files "$ROOT_DIR/src/vitte/packages/lint" >/dev/null 2>&1 || true; end="$(date +%s%3N)"; ms=$((end-start))
+cat > "$OUT_DIR/lint_bench_macro.out" <<EOT
+bench:lint_bulk_warm_cold
+measured_ms:$ms
+p50_ms:$ms
+p95_ms:$ms
+p99_ms:$ms
+EOT
+echo "[lint-macro-bench] wrote $OUT_DIR/lint_bench_macro.out"

--- a/tools/lint_modules_use_as_strict.py
+++ b/tools/lint_modules_use_as_strict.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    roots = [
+        repo / "tests/modules/contracts/core",
+        repo / "tests/modules/import_matrix",
+    ]
+    errs: list[str] = []
+
+    for root in roots:
+        if not root.exists():
+            continue
+        for p in root.rglob("*.vit"):
+            for i, raw in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+                line = raw.strip()
+                if not line.startswith("use "):
+                    continue
+                if " as " not in line:
+                    errs.append(f"{p}:{i}: strict import requires alias: 'use ... as ...'")
+    if errs:
+        for e in errs:
+            print(f"[modules-use-as-strict][error] {e}")
+        return 1
+    print("[modules-use-as-strict] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_no_side_effects_generic.py
+++ b/tools/lint_no_side_effects_generic.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, re
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--roots", required=True, help="comma separated roots")
+    ap.add_argument("--tag", default="no-side-effects-generic")
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    errs: list[str] = []
+    entry_re = re.compile(r"^\s*entry\s+")
+    for root_s in [r.strip() for r in args.roots.split(",") if r.strip()]:
+        root = repo / root_s
+        if not root.exists():
+            continue
+        for p in root.rglob("*.vit"):
+            for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), 1):
+                if entry_re.match(line):
+                    errs.append(f"{p}:{i}: entry forbidden")
+    if errs:
+        for e in errs:
+            print(f"[{args.tag}][error] {e}")
+        return 1
+    print(f"[{args.tag}] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_plugin_manifest.py
+++ b/tools/lint_plugin_manifest.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "plugins/plugin.toml"
+SCHEMA_V1 = ROOT / "plugins/abi/plugin_payload_schema_v1.json"
+SCHEMA_V2 = ROOT / "plugins/abi/plugin_payload_schema_v2.json"
+
+
+def commands_from_cpp(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    txt = path.read_text(encoding="utf-8", errors="ignore")
+    m = re.search(r"const char\* commands_csv\(\)\s*\{\s*return\s*\"(.*?)\";", txt, re.S)
+    if not m:
+        return set()
+    raw = m.group(1).replace('"\n           "', "")
+    return {x.strip() for x in raw.split(",") if x.strip()}
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+
+
+def main() -> int:
+    errs = []
+    if not MANIFEST.exists():
+        print(f"[plugin-manifest][error] missing {MANIFEST}")
+        return 1
+
+    data = tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
+    if data.get("abi") not in {"v1", "v2"}:
+        errs.append("manifest abi must be v1 or v2")
+
+    lib = ROOT / str(data.get("library", ""))
+    if not lib.exists():
+        errs.append(f"manifest library missing: {lib}")
+
+    manifest_cmds = data.get("command", [])
+    if not isinstance(manifest_cmds, list) or not manifest_cmds:
+        errs.append("manifest command entries missing")
+        manifest_cmds = []
+
+    declared = set()
+    for c in manifest_cmds:
+        name = c.get("name", "")
+        sch = c.get("payload_schema", "")
+        perms = c.get("permissions", [])
+        if not name:
+            errs.append("empty command name in manifest")
+            continue
+        declared.add(name)
+        if sch not in {"v1", "v2"}:
+            errs.append(f"{name}: payload_schema must be v1 or v2")
+        if not isinstance(perms, list) or not perms:
+            errs.append(f"{name}: permissions required")
+
+    cpp_cmds = commands_from_cpp(lib)
+    if not cpp_cmds:
+        errs.append("unable to parse commands_csv from plugin source")
+
+    missing_in_cpp = sorted(declared - cpp_cmds)
+    if missing_in_cpp:
+        errs.append("commands declared in plugin.toml but not in commands_csv: " + ",".join(missing_in_cpp[:20]))
+
+    s1 = set(read_json(SCHEMA_V1).get("commands", []))
+    s2 = set(read_json(SCHEMA_V2).get("commands", []))
+    warns = []
+    for c in manifest_cmds:
+        name = c.get("name", "")
+        sch = c.get("payload_schema", "")
+        if sch == "v1" and name not in s1:
+            warns.append(f"{name}: not present in payload schema v1")
+        if sch == "v2" and name not in s2:
+            warns.append(f"{name}: not present in payload schema v2")
+
+    if errs:
+        for e in errs:
+            print(f"[plugin-manifest][error] {e}")
+        return 1
+    for w in warns:
+        print(f"[plugin-manifest][warn] {w}")
+
+    print(f"[plugin-manifest] OK commands={len(declared)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_plugin_sandbox_permissions.py
+++ b/tools/lint_plugin_sandbox_permissions.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "plugins/plugin.toml"
+POLICY = ROOT / "plugins/plugin_sandbox_permissions.json"
+
+
+def main() -> int:
+    errs = []
+    if not MANIFEST.exists() or not POLICY.exists():
+        print("[plugin-sandbox][error] missing plugin.toml or plugin_sandbox_permissions.json")
+        return 1
+
+    m = tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
+    p = json.loads(POLICY.read_text(encoding="utf-8"))
+
+    allowed = set(p.get("allowed_permissions", []))
+    cmd_policy = p.get("commands", {})
+
+    for cmd in m.get("command", []):
+        name = cmd.get("name", "")
+        perms = set(cmd.get("permissions", []))
+        if not name:
+            errs.append("manifest command with empty name")
+            continue
+        if name not in cmd_policy:
+            errs.append(f"{name}: missing in sandbox policy map")
+            continue
+        policy_perms = set(cmd_policy[name])
+        if not perms.issubset(allowed):
+            errs.append(f"{name}: unknown permissions in manifest")
+        if not policy_perms.issubset(allowed):
+            errs.append(f"{name}: unknown permissions in policy")
+        if perms != policy_perms:
+            errs.append(f"{name}: manifest permissions != policy permissions")
+        if "process" in name and "process:exec" not in perms:
+            errs.append(f"{name}: expected process:exec")
+        if "http" in name and "net:outbound" not in perms and "doctor" in name:
+            errs.append(f"{name}: expected net:outbound for http diagnostics")
+
+    if errs:
+        for e in errs:
+            print(f"[plugin-sandbox][error] {e}")
+        return 1
+    print(f"[plugin-sandbox] OK commands={len(m.get('command', []))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_process_alias_pkg.py
+++ b/tools/lint_process_alias_pkg.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    roots=[repo/'src/vitte/packages/process', repo/'tests/process', repo/'tests/modules/contracts/process']
+    errs=[]
+    for root in roots:
+        if not root.exists():
+            continue
+        for p in root.rglob('*.vit'):
+            for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+                m=USE.match(l)
+                if m and not m.group(2).endswith('_pkg'):
+                    errs.append(f'{p}:{i}: alias must end with _pkg')
+    if errs:
+        for e in errs:
+            print(f'[process-alias-pkg-lint][error] {e}')
+        return 1
+    print('[process-alias-pkg-lint] OK')
+    return 0
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tools/lint_process_compat_contracts.py
+++ b/tools/lint_process_compat_contracts.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def read_set(p: Path):
+    if not p.exists(): return set()
+    return {l.strip() for l in p.read_text(encoding='utf-8').splitlines() if l.strip()}
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    root=repo/'tests/modules/contracts/process'
+    cur=read_set(root/'process.exports')
+    exp=read_set(root/'process.facade.api')
+    pub=read_set(root/'process.exports.public')
+    errs=[]
+    removed=sorted(exp-cur)
+    if removed: errs.append('breaking removals detected: '+', '.join(removed))
+    if cur!=pub: errs.append('process.exports and process.exports.public diverge')
+    if errs:
+        for e in errs: print(f'[process-compat-contracts][error] {e}')
+        return 1
+    print('[process-compat-contracts] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_process_export_naming.py
+++ b/tools/lint_process_export_naming.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+NAME=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    p=repo/'tests/modules/contracts/process/process.exports'
+    if not p.exists():
+        print(f'[process-export-naming][error] missing {p}')
+        return 1
+    errs=[]
+    for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+        t=l.strip()
+        if t and not NAME.match(t): errs.append(f'{p}:{i}: invalid {t}')
+    if errs:
+        for e in errs: print(f'[process-export-naming][error] {e}')
+        return 1
+    print('[process-export-naming] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_process_mod_contracts.py
+++ b/tools/lint_process_mod_contracts.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+DIAG_PREFIX='VITTE-P'
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    mod=repo/'src/vitte/packages/process/mod.vit'
+    txt=mod.read_text(encoding='utf-8') if mod.exists() else ''
+    errs=[]
+    if 'PREAMBLE (API stable facade)' not in txt: errs.append('missing PREAMBLE')
+    if '<<< ROLE-CONTRACT' not in txt: errs.append('missing ROLE-CONTRACT')
+    if 'use vitte/process/internal/runtime as process_runtime_pkg' not in txt: errs.append('missing internal bridge alias')
+    for k in ('versioning:','api_surface_stable:','diagnostics:'):
+        if k not in txt: errs.append(f'missing {k}')
+    if DIAG_PREFIX not in txt: errs.append('missing diagnostics prefix')
+    if 'entry ' in txt: errs.append('entry forbidden')
+    name_re=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+    for ln in txt.splitlines():
+        m=re.match(r'\s*(pick|form|proc)\s+([A-Za-z_][A-Za-z0-9_]*)',ln)
+        if m and not name_re.match(m.group(2)): errs.append(f'invalid export name {m.group(2)}')
+    if errs:
+        for e in errs: print(f'[process-mod-lint][error] {e}')
+        return 1
+    print('[process-mod-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_process_no_internal_exports.py
+++ b/tools/lint_process_no_internal_exports.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+from pathlib import Path
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    p = repo / 'tests/modules/contracts/process/process.exports.internal'
+    if not p.exists():
+        print(f'[process-no-internal-exports][error] missing snapshot: {p}')
+        return 1
+    if p.read_text(encoding='utf-8').strip():
+        print(f'[process-no-internal-exports][error] {p}: must stay empty')
+        return 1
+    print('[process-no-internal-exports] OK')
+    return 0
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/lint_process_no_side_effects.py
+++ b/tools/lint_process_no_side_effects.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1] / 'src/vitte/packages/process'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            if l.strip().startswith('entry '):
+                errs.append(f'{p}:{i}: entry forbidden')
+    if errs:
+        for e in errs:
+            print(f'[process-no-side-effects][error] {e}')
+        return 1
+    print('[process-no-side-effects] OK')
+    return 0
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tools/lint_process_security.py
+++ b/tools/lint_process_security.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main()->int:
+    repo=Path(__file__).resolve().parents[1]
+    txt=(repo/'src/vitte/packages/process/mod.vit').read_text(encoding='utf-8')
+    rt=(repo/'src/vitte/packages/process/internal/runtime.vit').read_text(encoding='utf-8')
+    errs=[]
+    for n in ['validate_config','VITTE-P0011','VITTE-P0013','VITTE-P0014','allow_shell forbidden on core']:
+        if n not in txt:
+            errs.append(f'missing mod.{n}')
+    for n in ['shell_exec_pattern','command_allowlisted','command_denylisted','env_valid','args_valid']:
+        if n not in rt:
+            errs.append(f'missing runtime.{n}')
+    if errs:
+        for e in errs: print(f'[process-security-lint][error] {e}')
+        return 1
+    print('[process-security-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_process_sensitive_imports.py
+++ b/tools/lint_process_sensitive_imports.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import json
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+SENSITIVE={'vitte/ffi','vitte/net'}
+
+def read_allow(path: Path):
+    if not path.exists(): return set()
+    out=set()
+    for l in path.read_text(encoding='utf-8').splitlines():
+        t=l.strip()
+        if t and not t.startswith('#'): out.add(t)
+    return out
+
+def read_global_allow(repo: Path):
+    p = repo / 'tools/allowlist_policy.json'
+    if not p.exists():
+        return set()
+    try:
+        data = json.loads(p.read_text(encoding='utf-8'))
+    except Exception:
+        return set()
+    return set(data.get('sensitive_import_allowlist', []))
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    allow=read_allow(repo/'tests/modules/contracts/process/process_sensitive_imports.allow') | read_global_allow(repo)
+    root=repo/'src/vitte/packages/process'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        rel=p.relative_to(repo).as_posix()
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if not m: continue
+            t=m.group(1)
+            if t in SENSITIVE and f'{rel}:{t}' not in allow:
+                errs.append(f'{p}:{i}: sensitive import denied: {t}')
+    if errs:
+        for e in errs: print(f'[process-sensitive-imports][error] {e}')
+        return 1
+    print('[process-sensitive-imports] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_profile_matrix_pkg.sh
+++ b/tools/lint_profile_matrix_pkg.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"; BIN="${BIN:-$ROOT_DIR/bin/vitte}"
+if [ ! -x "$BIN" ]; then echo "[lint-profile-matrix] warning: missing $BIN, skipping"; exit 0; fi
+for src in "$ROOT_DIR/tests/lint/lint_profile_strict.vit" "$ROOT_DIR/tests/lint/vitte_lint_smoke.vit"; do
+  "$BIN" check --lang=en "$src" >/tmp/vitte-lint-profile.out 2>&1 || { cat /tmp/vitte-lint-profile.out >&2 || true; echo "[lint-profile-matrix][error] failed $src" >&2; exit 1; }
+done
+echo "[lint-profile-matrix] OK"

--- a/tools/lint_rule_ownership.json
+++ b/tools/lint_rule_ownership.json
@@ -1,0 +1,32 @@
+{
+  "alias-pkg": {
+    "owner": "@vitte/qa",
+    "rationale": "Aliases must remain deterministic and grep-friendly.",
+    "false_positive_policy": "Allow manual override only for generated code paths."
+  },
+  "no-side-effects": {
+    "owner": "@vitte/qa",
+    "rationale": "Import-time purity is required for predictable compile/runtime.",
+    "false_positive_policy": "Documented allowlist only."
+  },
+  "sensitive-imports": {
+    "owner": "@vitte/security",
+    "rationale": "Sensitive imports require explicit policy ownership.",
+    "false_positive_policy": "Require allowlist entry with owner."
+  },
+  "export-naming": {
+    "owner": "@vitte/style",
+    "rationale": "Stable naming conventions reduce API churn and migration cost.",
+    "false_positive_policy": "Temporary exception only during deprecation window."
+  },
+  "facade-thin": {
+    "owner": "@vitte/core",
+    "rationale": "Facade files must stay orchestration-only.",
+    "false_positive_policy": "Package-level mode warn/error in facade_packages.json."
+  },
+  "diag-namespace": {
+    "owner": "@vitte/core",
+    "rationale": "Diagnostic ownership must stay package-local.",
+    "false_positive_policy": "None; must be fixed at source."
+  }
+}

--- a/tools/lint_smoke_pkg.sh
+++ b/tools/lint_smoke_pkg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"; BIN="${BIN:-$ROOT_DIR/bin/vitte}"; SRC="${SRC:-$ROOT_DIR/tests/lint/vitte_lint_smoke.vit}"
+if [ ! -x "$BIN" ]; then echo "[lint-smoke] warning: missing $BIN, skipping"; exit 0; fi
+if [ ! -f "$SRC" ]; then echo "[lint-smoke][error] missing $SRC" >&2; exit 1; fi
+if "$BIN" check --lang=en "$SRC" >/tmp/vitte-lint-smoke.out 2>&1; then echo "[lint-smoke] OK $SRC"; exit 0; fi
+cat /tmp/vitte-lint-smoke.out >&2 || true; echo "[lint-smoke][error] failed for $SRC" >&2; exit 1

--- a/tools/lint_std_alias_pkg.py
+++ b/tools/lint_std_alias_pkg.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+USE_RE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    roots = [repo / "src/vitte/packages/std", repo / "tests/modules/contracts/std", repo / "tests/std"]
+    errs: list[str] = []
+
+    for root in roots:
+        if not root.exists():
+            continue
+        for p in root.rglob("*.vit"):
+            for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+                m = USE_RE.match(line)
+                if not m:
+                    continue
+                alias = m.group(2)
+                if not alias.endswith("_pkg"):
+                    errs.append(f"{p}:{i}: alias must end with _pkg (got {alias})")
+
+    if errs:
+        for e in errs:
+            print(f"[std-alias-pkg-lint][error] {e}")
+        return 1
+    print("[std-alias-pkg-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_std_compat_contracts.py
+++ b/tools/lint_std_compat_contracts.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_set(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/std/std.exports"
+    facade = repo / "tests/modules/contracts/std/std.facade.api"
+    public = repo / "tests/modules/contracts/std/std.exports.public"
+
+    current = read_set(exports)
+    expected = read_set(facade)
+    public_set = read_set(public)
+
+    errs: list[str] = []
+    removed = sorted(expected - current)
+    if removed:
+        errs.append(f"breaking removals detected: {', '.join(removed)}")
+
+    if current != public_set:
+        errs.append("std.exports and std.exports.public diverge")
+
+    if errs:
+        for e in errs:
+            print(f"[std-compat-contracts][error] {e}")
+        return 1
+
+    print("[std-compat-contracts] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_std_export_naming.py
+++ b/tools/lint_std_export_naming.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+NAME_RE = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    exports = repo / "tests/modules/contracts/std/std.exports"
+    if not exports.exists():
+        print(f"[std-export-naming][error] missing {exports}")
+        return 1
+
+    errs: list[str] = []
+    for i, raw in enumerate(exports.read_text(encoding="utf-8").splitlines(), start=1):
+        name = raw.strip()
+        if not name:
+            continue
+        if not NAME_RE.match(name):
+            errs.append(f"{exports}:{i}: invalid export name: {name}")
+
+    if errs:
+        for e in errs:
+            print(f"[std-export-naming][error] {e}")
+        return 1
+    print("[std-export-naming] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_std_graph.py
+++ b/tools/lint_std_graph.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+USE_RE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+DENY_PREFIXES = ("vitte/app", "vitte/apps", "vitte/features", "vitte/ide")
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/std"
+    errs: list[str] = []
+
+    for p in root.rglob("*.vit"):
+        text = p.read_text(encoding="utf-8")
+        for i, line in enumerate(text.splitlines(), start=1):
+            m = USE_RE.match(line)
+            if not m:
+                continue
+            target = m.group(1)
+            if target.startswith(DENY_PREFIXES):
+                errs.append(f"{p}:{i}: std must not depend on app/features: {target}")
+
+    if errs:
+        for e in errs:
+            print(f"[std-graph-lint][error] {e}")
+        return 1
+    print("[std-graph-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_std_mod_contracts.py
+++ b/tools/lint_std_mod_contracts.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DIAG_PREFIX = "VITTE-S"
+
+
+def non_comment_non_empty(text: str) -> list[str]:
+    out: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    mod = repo / "src/vitte/packages/std/mod.vit"
+    if not mod.exists():
+        print(f"[std-mod-lint][error] missing file: {mod}")
+        return 1
+
+    text = mod.read_text(encoding="utf-8")
+    lines = non_comment_non_empty(text)
+    errs: list[str] = []
+
+    if "PREAMBLE (API stable facade)" not in text:
+        errs.append(f"{mod}: missing PREAMBLE block")
+    if "<<< ROLE-CONTRACT" not in text:
+        errs.append(f"{mod}: missing ROLE-CONTRACT block")
+    if any(line.startswith("entry ") for line in lines):
+        errs.append(f"{mod}: import-time side effect risk: 'entry' is forbidden")
+
+    required = (
+        "versioning:",
+        "api_surface_stable:",
+        "boundary:",
+        "input_contract:",
+        "output_contract:",
+        "diagnostics:",
+    )
+    for key in required:
+        if key not in text:
+            errs.append(f"{mod}: ROLE-CONTRACT missing '{key}'")
+
+    if DIAG_PREFIX not in text:
+        errs.append(f"{mod}: diagnostics namespace must reference {DIAG_PREFIX}")
+
+    export_names: list[str] = []
+    pats = (
+        re.compile(r"^pick\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^form\s+([A-Za-z_][A-Za-z0-9_]*)"),
+        re.compile(r"^proc\s+([A-Za-z_][A-Za-z0-9_]*)"),
+    )
+    for line in lines:
+        for pat in pats:
+            m = pat.match(line)
+            if m:
+                export_names.append(m.group(1))
+                break
+
+    if not export_names:
+        errs.append(f"{mod}: no public exports found")
+
+    snake_or_pascal = re.compile(r"^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$")
+    for name in export_names:
+        if not snake_or_pascal.match(name):
+            errs.append(f"{mod}: exported name '{name}' violates naming convention")
+
+    if errs:
+        for e in errs:
+            print(f"[std-mod-lint][error] {e}")
+        return 1
+    print("[std-mod-lint] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_std_no_internal_exports.py
+++ b/tools/lint_std_no_internal_exports.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    mod = repo / "src/vitte/packages/std/mod.vit"
+    internal_snap = repo / "tests/modules/contracts/std/std.exports.internal"
+    errors: list[str] = []
+
+    if not mod.exists():
+        errors.append(f"missing file: {mod}")
+    else:
+        txt = mod.read_text(encoding="utf-8")
+        if "internal/" in txt:
+            errors.append(f"{mod}: public facade must not import internal modules")
+
+    if not internal_snap.exists():
+        errors.append(f"missing snapshot: {internal_snap}")
+    else:
+        if internal_snap.read_text(encoding="utf-8").strip():
+            errors.append(f"{internal_snap}: must stay empty")
+
+    if errors:
+        for e in errors:
+            print(f"[std-no-internal-exports][error] {e}")
+        return 1
+    print("[std-no-internal-exports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_std_no_side_effects.py
+++ b/tools/lint_std_no_side_effects.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/std"
+    errs: list[str] = []
+    for p in root.rglob("*.vit"):
+        for i, raw in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1):
+            line = raw.strip()
+            if line.startswith("#"):
+                continue
+            if line.startswith("entry "):
+                errs.append(f"{p}:{i}: entry is forbidden (no side effects at import time)")
+    if errs:
+        for e in errs:
+            print(f"[std-no-side-effects][error] {e}")
+        return 1
+    print("[std-no-side-effects] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_std_sensitive_imports.py
+++ b/tools/lint_std_sensitive_imports.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+USE_RE = re.compile(r"^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)")
+SENSITIVE = {"vitte/ffi", "vitte/process", "vitte/net"}
+
+
+def read_allowlist(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            out.add(line)
+    return out
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src/vitte/packages/std"
+    allow = read_allowlist(repo / "tests/modules/contracts/std/std_sensitive_imports.allow")
+    errs: list[str] = []
+
+    for p in root.rglob("*.vit"):
+        rel = p.relative_to(repo).as_posix()
+        text = p.read_text(encoding="utf-8")
+        for i, line in enumerate(text.splitlines(), start=1):
+            m = USE_RE.match(line)
+            if not m:
+                continue
+            target = m.group(1)
+            if target in SENSITIVE and f"{rel}:{target}" not in allow:
+                errs.append(f"{p}:{i}: sensitive import denied without allowlist entry: {target}")
+
+    if errs:
+        for e in errs:
+            print(f"[std-sensitive-imports][error] {e}")
+        return 1
+    print("[std-sensitive-imports] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_test_alias_pkg.py
+++ b/tools/lint_test_alias_pkg.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    root=repo/'src/vitte/packages/test'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if m and not m.group(2).endswith('_pkg'):
+                errs.append(f'{p}:{i}: alias must end with _pkg')
+    if errs:
+        for e in errs: print(f'[test-alias-pkg][error] {e}')
+        return 1
+    print('[test-alias-pkg] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_test_compat_contracts.py
+++ b/tools/lint_test_compat_contracts.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def read_set(p: Path):
+    if not p.exists(): return set()
+    return {l.strip() for l in p.read_text(encoding='utf-8').splitlines() if l.strip()}
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    root=repo/'tests/modules/contracts/test'
+    cur=read_set(root/'test.exports')
+    exp=read_set(root/'test.facade.api')
+    pub=read_set(root/'test.exports.public')
+    errs=[]
+    removed=sorted(exp-cur)
+    if removed: errs.append('breaking removals detected: '+', '.join(removed))
+    if cur!=pub: errs.append('test.exports and test.exports.public diverge')
+    if errs:
+        for e in errs: print(f'[test-compat-contracts][error] {e}')
+        return 1
+    print('[test-compat-contracts] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_test_export_naming.py
+++ b/tools/lint_test_export_naming.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+NAME=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    path=repo/'tests/modules/contracts/test/test.exports'
+    if not path.exists():
+        print(f'[test-export-naming][error] missing {path}')
+        return 1
+    errs=[]
+    for i,l in enumerate(path.read_text(encoding='utf-8').splitlines(),1):
+        t=l.strip()
+        if t and not NAME.match(t): errs.append(f'{path}:{i}: invalid {t}')
+    if errs:
+        for e in errs: print(f'[test-export-naming][error] {e}')
+        return 1
+    print('[test-export-naming] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_test_mod_contracts.py
+++ b/tools/lint_test_mod_contracts.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+DIAG_PREFIX='VITTE-T'
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    mod=repo/'src/vitte/packages/test/mod.vit'
+    txt=mod.read_text(encoding='utf-8') if mod.exists() else ''
+    errs=[]
+    if 'PREAMBLE (API stable facade)' not in txt: errs.append('missing PREAMBLE')
+    if '<<< ROLE-CONTRACT' not in txt: errs.append('missing ROLE-CONTRACT')
+    if 'use vitte/test/internal/' not in txt: errs.append('missing internal bridge aliases')
+    for k in ('versioning:','api_surface_stable:','diagnostics:'):
+        if k not in txt: errs.append(f'missing {k}')
+    if DIAG_PREFIX not in txt: errs.append('missing diagnostics prefix')
+    if 'entry ' in txt: errs.append('entry forbidden')
+    name_re=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+    for ln in txt.splitlines():
+        m=re.match(r'\s*(pick|form|proc)\s+([A-Za-z_][A-Za-z0-9_]*)',ln)
+        if m and not name_re.match(m.group(2)): errs.append(f'invalid export name {m.group(2)}')
+    if errs:
+        for e in errs: print(f'[test-mod-lint][error] {e}')
+        return 1
+    print('[test-mod-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_test_no_internal_exports.py
+++ b/tools/lint_test_no_internal_exports.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    p = repo / 'tests/modules/contracts/test/test.exports.internal'
+    if not p.exists():
+        print(f'[test-no-internal-exports][error] missing snapshot: {p}')
+        return 1
+    if p.read_text(encoding='utf-8').strip():
+        print(f'[test-no-internal-exports][error] {p}: must stay empty')
+        return 1
+    print('[test-no-internal-exports] OK')
+    return 0
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/lint_test_no_side_effects.py
+++ b/tools/lint_test_no_side_effects.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1] / 'src/vitte/packages/test'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            if l.strip().startswith('entry '):
+                errs.append(f'{p}:{i}: entry forbidden')
+    if errs:
+        for e in errs:
+            print(f'[test-no-side-effects][error] {e}')
+        return 1
+    print('[test-no-side-effects] OK')
+    return 0
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tools/lint_test_security.py
+++ b/tools/lint_test_security.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main()->int:
+    repo=Path(__file__).resolve().parents[1]
+    txt=(repo/'src/vitte/packages/test/mod.vit').read_text(encoding='utf-8')
+    itxt=(repo/'src/vitte/packages/test/internal/runner.vit').read_text(encoding='utf-8')
+    errs=[]
+    for need in ['TestMode','SnapshotConfig','FuzzConfig','BenchConfig','run_fuzz','run_bench']:
+        if need not in txt: errs.append(f'missing {need} in facade')
+    for need in ['VITTE-T0014','VITTE-T0015','diag_message','quickfix_for']:
+        if need not in itxt: errs.append(f'missing {need} in runtime')
+    if errs:
+        for e in errs: print(f'[test-security-lint][error] {e}')
+        return 1
+    print('[test-security-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_test_sensitive_imports.py
+++ b/tools/lint_test_sensitive_imports.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import json, re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+SENSITIVE={'vitte/ffi','vitte/net'}
+
+def read_allow(path: Path):
+    if not path.exists(): return set()
+    out=set()
+    for l in path.read_text(encoding='utf-8').splitlines():
+        t=l.strip()
+        if t and not t.startswith('#'): out.add(t)
+    return out
+
+def read_global_allow(repo: Path):
+    p = repo / 'tools/allowlist_policy.json'
+    if not p.exists(): return set()
+    try: data=json.loads(p.read_text(encoding='utf-8'))
+    except Exception: return set()
+    return set(data.get('sensitive_import_allowlist', []))
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    allow=read_allow(repo/'tests/modules/contracts/test/test_sensitive_imports.allow') | read_global_allow(repo)
+    root=repo/'src/vitte/packages/test'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        rel=p.relative_to(repo).as_posix()
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if not m: continue
+            t=m.group(1)
+            if t in SENSITIVE and f'{rel}:{t}' not in allow:
+                errs.append(f'{p}:{i}: sensitive import denied: {t}')
+    if errs:
+        for e in errs: print(f'[test-sensitive-imports][error] {e}')
+        return 1
+    print('[test-sensitive-imports] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_yaml_alias_pkg.py
+++ b/tools/lint_yaml_alias_pkg.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    root=repo/'src/vitte/packages/yaml'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if m and not m.group(2).endswith('_pkg'):
+                errs.append(f'{p}:{i}: alias must end with _pkg')
+    if errs:
+        for e in errs: print(f'[yaml-alias-pkg][error] {e}')
+        return 1
+    print('[yaml-alias-pkg] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_yaml_compat_contracts.py
+++ b/tools/lint_yaml_compat_contracts.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def read_set(p: Path):
+    if not p.exists(): return set()
+    return {l.strip() for l in p.read_text(encoding='utf-8').splitlines() if l.strip()}
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    root=repo/'tests/modules/contracts/yaml'
+    cur=read_set(root/'yaml.exports')
+    exp=read_set(root/'yaml.facade.api')
+    pub=read_set(root/'yaml.exports.public')
+    errs=[]
+    removed=sorted(exp-cur)
+    if removed: errs.append('breaking removals detected: '+', '.join(removed))
+    if cur!=pub: errs.append('yaml.exports and yaml.exports.public diverge')
+    if errs:
+        for e in errs: print(f'[yaml-compat-contracts][error] {e}')
+        return 1
+    print('[yaml-compat-contracts] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_yaml_export_naming.py
+++ b/tools/lint_yaml_export_naming.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+NAME=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    path=repo/'tests/modules/contracts/yaml/yaml.exports'
+    if not path.exists():
+        print(f'[yaml-export-naming][error] missing {path}')
+        return 1
+    errs=[]
+    for i,l in enumerate(path.read_text(encoding='utf-8').splitlines(),1):
+        t=l.strip()
+        if t and not NAME.match(t): errs.append(f'{path}:{i}: invalid {t}')
+    if errs:
+        for e in errs: print(f'[yaml-export-naming][error] {e}')
+        return 1
+    print('[yaml-export-naming] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_yaml_mod_contracts.py
+++ b/tools/lint_yaml_mod_contracts.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+DIAG_PREFIX='VITTE-Y'
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    mod=repo/'src/vitte/packages/yaml/mod.vit'
+    txt=mod.read_text(encoding='utf-8') if mod.exists() else ''
+    errs=[]
+    if 'PREAMBLE (API stable facade)' not in txt: errs.append('missing PREAMBLE')
+    if '<<< ROLE-CONTRACT' not in txt: errs.append('missing ROLE-CONTRACT')
+    if 'use vitte/yaml/internal/runtime as yaml_runtime_pkg' not in txt: errs.append('missing internal bridge alias')
+    for k in ('versioning:','api_surface_stable:','diagnostics:'):
+        if k not in txt: errs.append(f'missing {k}')
+    if DIAG_PREFIX not in txt: errs.append('missing diagnostics prefix')
+    if 'entry ' in txt: errs.append('entry forbidden')
+    name_re=re.compile(r'^([a-z][a-z0-9_]*|[A-Z][A-Za-z0-9]*)$')
+    for ln in txt.splitlines():
+        m=re.match(r'\s*(pick|form|proc)\s+([A-Za-z_][A-Za-z0-9_]*)',ln)
+        if m and not name_re.match(m.group(2)): errs.append(f'invalid export name {m.group(2)}')
+    if errs:
+        for e in errs: print(f'[yaml-mod-lint][error] {e}')
+        return 1
+    print('[yaml-mod-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_yaml_no_internal_exports.py
+++ b/tools/lint_yaml_no_internal_exports.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+from pathlib import Path
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[1]
+    p = repo / 'tests/modules/contracts/yaml/yaml.exports.internal'
+    if not p.exists():
+        print(f'[yaml-no-internal-exports][error] missing snapshot: {p}')
+        return 1
+    if p.read_text(encoding='utf-8').strip():
+        print(f'[yaml-no-internal-exports][error] {p}: must stay empty')
+        return 1
+    print('[yaml-no-internal-exports] OK')
+    return 0
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/lint_yaml_no_side_effects.py
+++ b/tools/lint_yaml_no_side_effects.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1] / 'src/vitte/packages/yaml'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            if l.strip().startswith('entry '):
+                errs.append(f'{p}:{i}: entry forbidden')
+    if errs:
+        for e in errs:
+            print(f'[yaml-no-side-effects][error] {e}')
+        return 1
+    print('[yaml-no-side-effects] OK')
+    return 0
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tools/lint_yaml_security.py
+++ b/tools/lint_yaml_security.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+def main()->int:
+    repo=Path(__file__).resolve().parents[1]
+    txt=(repo/'src/vitte/packages/yaml/mod.vit').read_text(encoding='utf-8')
+    itxt=(repo/'src/vitte/packages/yaml/internal/runtime.vit').read_text(encoding='utf-8')
+    errs=[]
+    for need in ['safe_load','allow_tags','max_bytes','max_depth','max_nodes','parse_stream','write_stream']:
+        if need not in txt: errs.append(f'missing {need} in facade')
+    for need in ['VITTE-Y0005','VITTE-Y0010','validate_parse_input','quickfix_for']:
+        if need not in itxt: errs.append(f'missing {need} in runtime')
+    if errs:
+        for e in errs: print(f'[yaml-security-lint][error] {e}')
+        return 1
+    print('[yaml-security-lint] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/lint_yaml_sensitive_imports.py
+++ b/tools/lint_yaml_sensitive_imports.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import json
+import re
+from pathlib import Path
+USE=re.compile(r'^\s*use\s+([^\s]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)')
+SENSITIVE={'vitte/ffi','vitte/net','vitte/process'}
+
+def read_allow(path: Path):
+    if not path.exists(): return set()
+    out=set()
+    for l in path.read_text(encoding='utf-8').splitlines():
+        t=l.strip()
+        if t and not t.startswith('#'): out.add(t)
+    return out
+
+def read_global_allow(repo: Path):
+    p = repo / 'tools/allowlist_policy.json'
+    if not p.exists():
+        return set()
+    try:
+        data = json.loads(p.read_text(encoding='utf-8'))
+    except Exception:
+        return set()
+    return set(data.get('sensitive_import_allowlist', []))
+
+def main() -> int:
+    repo=Path(__file__).resolve().parents[1]
+    allow=read_allow(repo/'tests/modules/contracts/yaml/yaml_sensitive_imports.allow') | read_global_allow(repo)
+    root=repo/'src/vitte/packages/yaml'
+    errs=[]
+    for p in root.rglob('*.vit'):
+        rel=p.relative_to(repo).as_posix()
+        for i,l in enumerate(p.read_text(encoding='utf-8').splitlines(),1):
+            m=USE.match(l)
+            if not m: continue
+            t=m.group(1)
+            if t in SENSITIVE and f'{rel}:{t}' not in allow:
+                errs.append(f'{p}:{i}: sensitive import denied: {t}')
+    if errs:
+        for e in errs: print(f'[yaml-sensitive-imports][error] {e}')
+        return 1
+    print('[yaml-sensitive-imports] OK'); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tools/log_contract_diff.sh
+++ b/tools/log_contract_diff.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+python3 "$ROOT_DIR/tools/lint_log_compat_contracts.py"

--- a/tools/log_contract_snapshots.sh
+++ b/tools/log_contract_snapshots.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+LOG_DIR="${LOG_DIR:-$ROOT_DIR/tests/modules/contracts/log}"
+UPDATE=0
+
+log() { printf "[log-contract-snapshots] %s\n" "$*"; }
+die() { printf "[log-contract-snapshots][error] %s\n" "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    *) die "unknown option: $1" ;;
+  esac
+  shift
+done
+
+[ -d "$LOG_DIR" ] || die "missing dir: $LOG_DIR"
+
+ALL="$LOG_DIR/log.exports"
+PUB="$LOG_DIR/log.exports.public"
+INT="$LOG_DIR/log.exports.internal"
+SHA="$LOG_DIR/log.exports.sha256"
+FACADE="$LOG_DIR/log.facade.api"
+FACADE_SHA="$LOG_DIR/log.facade.api.sha256"
+
+for f in "$ALL" "$PUB" "$INT"; do
+  [ -f "$f" ] || die "missing snapshot file: $f"
+done
+
+if [ "$UPDATE" -eq 1 ]; then
+  sha="$(sha256sum "$ALL" | awk '{print $1}')"
+  printf "%s\n" "$sha" > "$SHA"
+  "$ROOT_DIR/tools/log_facade_snapshot.sh" --update
+  log "updated $SHA"
+  exit 0
+fi
+
+[ -f "$SHA" ] || die "missing hash file: $SHA"
+
+if ! diff -u "$ALL" "$PUB" >/dev/null 2>&1; then
+  diff -u "$ALL" "$PUB" || true
+  die "log.exports and log.exports.public diverge"
+fi
+
+if [ -s "$INT" ]; then
+  die "log.exports.internal must stay empty"
+fi
+
+if ! diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null 2>&1; then
+  die "log.exports must be sorted"
+fi
+
+[ -f "$FACADE" ] || die "missing facade snapshot: $FACADE"
+[ -f "$FACADE_SHA" ] || die "missing facade hash: $FACADE_SHA"
+"$ROOT_DIR/tools/log_facade_snapshot.sh"
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$ALL" | awk '{print $1}')"
+if [ "$expected" != "$actual" ]; then
+  die "sha mismatch expected=$expected got=$actual"
+fi
+
+log "OK"

--- a/tools/log_facade_snapshot.sh
+++ b/tools/log_facade_snapshot.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/log/log.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/log/log.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/log/log.facade.api.sha256"
+UPDATE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    *) echo "[log-facade-snapshot][error] unknown arg: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[ -f "$SRC" ] || { echo "[log-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+
+if [ "$UPDATE" -eq 1 ]; then
+  cp "$tmp" "$OUT"
+  sha256sum "$OUT" | awk '{print $1}' > "$SHA"
+  echo "[log-facade-snapshot] updated"
+  exit 0
+fi
+
+[ -f "$OUT" ] || { echo "[log-facade-snapshot][error] missing $OUT (run --update)" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[log-facade-snapshot][error] missing $SHA (run --update)" >&2; exit 1; }
+
+diff -u "$OUT" "$tmp" >/dev/null || {
+  diff -u "$OUT" "$tmp" || true
+  echo "[log-facade-snapshot][error] log facade snapshot mismatch" >&2
+  exit 1
+}
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$OUT" | awk '{print $1}')"
+[ "$expected" = "$actual" ] || {
+  echo "[log-facade-snapshot][error] sha mismatch expected=$expected got=$actual" >&2
+  exit 1
+}
+
+echo "[log-facade-snapshot] OK"

--- a/tools/migration_assistant_contracts.py
+++ b/tools/migration_assistant_contracts.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+
+
+def read_set(p: Path):
+    return {l.strip() for l in p.read_text(encoding="utf-8").splitlines() if l.strip()} if p.exists() else set()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--old", required=True)
+    ap.add_argument("--new", required=True)
+    args = ap.parse_args()
+
+    old = read_set(Path(args.old))
+    new = read_set(Path(args.new))
+    removed = sorted(old - new)
+    added = sorted(new - old)
+    report = {
+        "schema_version": "1.0",
+        "removed": removed,
+        "added": added,
+        "patch_hints": [],
+    }
+    print("[migration-assistant] summary")
+    if removed:
+        print("removed:")
+        for r in removed:
+            print(f"- {r} -> suggestion: keep wrapper/deprecate before removal")
+            report["patch_hints"].append(
+                {
+                    "kind": "wrapper",
+                    "symbol": r,
+                    "hint": "add temporary deprecated wrapper in facade mod.vit",
+                }
+            )
+    if added:
+        print("added:")
+        for a in added:
+            print(f"- {a} -> suggestion: add docs/tests/snapshot update")
+            report["patch_hints"].append(
+                {
+                    "kind": "docs",
+                    "symbol": a,
+                    "hint": "update docs/<pkg>/API_INDEX.md with usage/contre-exemple",
+                }
+            )
+    if not removed and not added:
+        print("no api delta")
+
+    out = Path("target/reports/migration_assistant.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"[migration-assistant] wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/modules_contract_snapshots.sh
+++ b/tools/modules_contract_snapshots.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 BIN="${BIN:-$ROOT_DIR/bin/vitte}"
 BASE_DIR="$ROOT_DIR/tests/modules/contracts"
-CRITICAL_MODULES=(abi http db core actor)
+CRITICAL_MODULES=(abi http db core actor alerts ast)
 UPDATE=0
 ALLOW_BREAKING=0
 CURRENT_VERSION="${CURRENT_VERSION:-}"
@@ -175,9 +175,20 @@ PY
     fi
     if [ -n "$removed" ]; then
       printf "[modules-contract-snapshots] removed (%s/%s):\n%s\n" "$mod" "$scope" "$removed"
-      if [ "$current_major" = "$baseline_major" ] && [ "$ALLOW_BREAKING" -ne 1 ]; then
-        die "breaking export removal in '$mod' requires major bump (baseline=$BASELINE_VERSION current=$CURRENT_VERSION)"
+      removed_file="$tmp_root/$mod.$scope.removed.txt"
+      printf "%s\n" "$removed" > "$removed_file"
+      export_policy_args=(
+        --module "$mod"
+        --scope "$scope"
+        --current-version "$CURRENT_VERSION"
+        --baseline-version "$BASELINE_VERSION"
+        --removed-file "$removed_file"
+      )
+      if [ "$ALLOW_BREAKING" -eq 1 ]; then
+        export_policy_args+=(--allow-breaking)
       fi
+      python3 "$ROOT_DIR/tools/lint_export_policy.py" "${export_policy_args[@]}" || \
+        die "breaking export removal in '$mod' requires major bump (baseline=$BASELINE_VERSION current=$CURRENT_VERSION)"
     fi
     diff -u "$old" "$new" || true
     die "exports snapshot mismatch for module '$mod' scope '$scope' (run with --update if intended)"

--- a/tools/process_contract_diff.sh
+++ b/tools/process_contract_diff.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+python3 "$ROOT_DIR/tools/lint_process_compat_contracts.py"

--- a/tools/process_contract_snapshots.sh
+++ b/tools/process_contract_snapshots.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+DIR="$ROOT_DIR/tests/modules/contracts/process"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[process-contract-snapshots][error] unknown $1" >&2; exit 1;; esac; shift; done
+ALL="$DIR/process.exports"; PUB="$DIR/process.exports.public"; INT="$DIR/process.exports.internal"; SHA="$DIR/process.exports.sha256"
+for f in "$ALL" "$PUB" "$INT"; do [ -f "$f" ] || { echo "[process-contract-snapshots][error] missing $f" >&2; exit 1; }; done
+if [ "$UPDATE" -eq 1 ]; then sha256sum "$ALL"|awk '{print $1}'>$SHA; "$ROOT_DIR/tools/process_facade_snapshot.sh" --update; echo "[process-contract-snapshots] updated"; exit 0; fi
+[ -f "$SHA" ] || { echo "[process-contract-snapshots][error] missing $SHA" >&2; exit 1; }
+diff -u "$ALL" "$PUB" >/dev/null || { diff -u "$ALL" "$PUB" || true; echo "[process-contract-snapshots][error] public diverge" >&2; exit 1; }
+[ ! -s "$INT" ] || { echo "[process-contract-snapshots][error] internal snapshot must be empty" >&2; exit 1; }
+diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null || { echo "[process-contract-snapshots][error] exports must be sorted" >&2; exit 1; }
+"$ROOT_DIR/tools/process_facade_snapshot.sh"
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$ALL"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[process-contract-snapshots][error] sha mismatch" >&2; exit 1; }
+echo "[process-contract-snapshots] OK"

--- a/tools/process_facade_snapshot.sh
+++ b/tools/process_facade_snapshot.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/process/process.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/process/process.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/process/process.facade.api.sha256"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[process-facade-snapshot][error] unknown arg: $1" >&2; exit 1;; esac; shift; done
+[ -f "$SRC" ] || { echo "[process-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+if [ "$UPDATE" -eq 1 ]; then cp "$tmp" "$OUT"; sha256sum "$OUT"|awk '{print $1}'>$SHA; echo "[process-facade-snapshot] updated"; exit 0; fi
+[ -f "$OUT" ] || { echo "[process-facade-snapshot][error] missing $OUT" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[process-facade-snapshot][error] missing $SHA" >&2; exit 1; }
+diff -u "$OUT" "$tmp" >/dev/null || { diff -u "$OUT" "$tmp" || true; echo "[process-facade-snapshot][error] mismatch" >&2; exit 1; }
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$OUT"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[process-facade-snapshot][error] sha mismatch" >&2; exit 1; }
+echo "[process-facade-snapshot] OK"

--- a/tools/quickfix_schema_snapshots.py
+++ b/tools/quickfix_schema_snapshots.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / 'tools/facade_packages.json'
+
+
+def write_schema(pkg: str, version: str, required_meta: bool) -> None:
+    cdir = ROOT / f'tests/modules/contracts/{pkg}'
+    cdir.mkdir(parents=True, exist_ok=True)
+    suffix = 'v2' if required_meta else 'v1'
+    out = cdir / f'{pkg}.quickfix.schema.{suffix}.json'
+    payload = {
+        'schema_version': version,
+        'package': f'vitte/{pkg}',
+        'commands': [
+            'quickfix_preview',
+            'quickfix_apply'
+        ],
+        'required_keys': ['code', 'payload'] + (['meta'] if required_meta else [])
+    }
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding='utf-8'))
+    for ent in cfg['packages']:
+        p = ent['name']
+        write_schema(p, 'v1', False)
+        write_schema(p, 'v2', True)
+    print('[quickfix-schema] generated package quickfix schemas v1/v2')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/semantic_contract_tests.sh
+++ b/tools/semantic_contract_tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+BIN="${BIN:-$ROOT_DIR/bin/vitte}"
+if [ ! -x "$BIN" ]; then
+  echo "[semantic-contract-tests] warning: missing $BIN, skipping"
+  exit 0
+fi
+for src in \
+  "$ROOT_DIR/tests/http/table/http_table_critical_apis.vit" \
+  "$ROOT_DIR/tests/process/table/process_table_critical_apis.vit" \
+  "$ROOT_DIR/tests/db/table/db_table_critical_apis.vit" \
+  "$ROOT_DIR/tests/json/table/json_table_critical_apis.vit" \
+  "$ROOT_DIR/tests/yaml/table/yaml_table_critical_apis.vit" \
+  "$ROOT_DIR/tests/test/table/test_table_critical_apis.vit" \
+  "$ROOT_DIR/tests/lint/table/lint_table_critical_apis.vit"; do
+  [ -f "$src" ] || continue
+  "$BIN" check --lang=en "$src" >/tmp/vitte-semantic-contract.out 2>&1 || {
+    cat /tmp/vitte-semantic-contract.out >&2 || true
+    echo "[semantic-contract-tests][error] failed: $src" >&2
+    exit 1
+  }
+  echo "[semantic-contract-tests] OK $src"
+done

--- a/tools/std_contract_diff.sh
+++ b/tools/std_contract_diff.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+python3 "$ROOT_DIR/tools/lint_std_compat_contracts.py"

--- a/tools/std_contract_snapshots.sh
+++ b/tools/std_contract_snapshots.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+STD_DIR="${STD_DIR:-$ROOT_DIR/tests/modules/contracts/std}"
+UPDATE=0
+
+log() { printf "[std-contract-snapshots] %s\n" "$*"; }
+die() { printf "[std-contract-snapshots][error] %s\n" "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    *) die "unknown option: $1" ;;
+  esac
+  shift
+done
+
+[ -d "$STD_DIR" ] || die "missing dir: $STD_DIR"
+
+ALL="$STD_DIR/std.exports"
+PUB="$STD_DIR/std.exports.public"
+INT="$STD_DIR/std.exports.internal"
+SHA="$STD_DIR/std.exports.sha256"
+FACADE="$STD_DIR/std.facade.api"
+FACADE_SHA="$STD_DIR/std.facade.api.sha256"
+
+for f in "$ALL" "$PUB" "$INT"; do
+  [ -f "$f" ] || die "missing snapshot file: $f"
+done
+
+if [ "$UPDATE" -eq 1 ]; then
+  sha="$(sha256sum "$ALL" | awk '{print $1}')"
+  printf "%s\n" "$sha" > "$SHA"
+  "$ROOT_DIR/tools/std_facade_snapshot.sh" --update
+  log "updated $SHA"
+  exit 0
+fi
+
+[ -f "$SHA" ] || die "missing hash file: $SHA"
+
+if ! diff -u "$ALL" "$PUB" >/dev/null 2>&1; then
+  diff -u "$ALL" "$PUB" || true
+  die "std.exports and std.exports.public diverge"
+fi
+
+if [ -s "$INT" ]; then
+  die "std.exports.internal must stay empty"
+fi
+
+if ! diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null 2>&1; then
+  die "std.exports must be sorted"
+fi
+
+[ -f "$FACADE" ] || die "missing facade snapshot: $FACADE"
+[ -f "$FACADE_SHA" ] || die "missing facade hash: $FACADE_SHA"
+"$ROOT_DIR/tools/std_facade_snapshot.sh"
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$ALL" | awk '{print $1}')"
+if [ "$expected" != "$actual" ]; then
+  die "sha mismatch expected=$expected got=$actual"
+fi
+
+log "OK"

--- a/tools/std_facade_snapshot.sh
+++ b/tools/std_facade_snapshot.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/std/std.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/std/std.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/std/std.facade.api.sha256"
+UPDATE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1 ;;
+    *) echo "[std-facade-snapshot][error] unknown arg: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[ -f "$SRC" ] || { echo "[std-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+
+if [ "$UPDATE" -eq 1 ]; then
+  cp "$tmp" "$OUT"
+  sha256sum "$OUT" | awk '{print $1}' > "$SHA"
+  echo "[std-facade-snapshot] updated"
+  exit 0
+fi
+
+[ -f "$OUT" ] || { echo "[std-facade-snapshot][error] missing $OUT (run --update)" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[std-facade-snapshot][error] missing $SHA (run --update)" >&2; exit 1; }
+
+diff -u "$OUT" "$tmp" >/dev/null || {
+  diff -u "$OUT" "$tmp" || true
+  echo "[std-facade-snapshot][error] std facade snapshot mismatch" >&2
+  exit 1
+}
+
+expected="$(tr -d '\n' < "$SHA")"
+actual="$(sha256sum "$OUT" | awk '{print $1}')"
+[ "$expected" = "$actual" ] || {
+  echo "[std-facade-snapshot][error] sha mismatch expected=$expected got=$actual" >&2
+  exit 1
+}
+
+echo "[std-facade-snapshot] OK"

--- a/tools/templates/ROLE_CONTRACT.template
+++ b/tools/templates/ROLE_CONTRACT.template
@@ -1,0 +1,19 @@
+<<< ROLE-CONTRACT
+package: vitte/<package>
+owner: @vitte/<team>
+stability: stable
+since: 1.0.0
+deprecated_in: -
+role: facade publique stable et additive
+input_contract: input explicite et valide
+output_contract: output stable et deterministic
+boundary: implementation privee sous vitte/<package>/internal/*
+versioning: additive-only, no breaking removals in stable
+api_surface_stable: true
+diagnostics: VITTE-X0001..VITTE-X0099
+compat_policy: additive-only
+internal_exports: forbidden
+api_version: v1
+compat_layer: none
+removal_policy: major-only
+>>>

--- a/tools/test_breaking_removal_table.py
+++ b/tools/test_breaking_removal_table.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / 'tools/facade_packages.json'
+
+
+def read_set(p: Path):
+    return {l.strip() for l in p.read_text(encoding='utf-8').splitlines() if l.strip()} if p.exists() else set()
+
+
+def main() -> int:
+    cfg = json.loads(CFG.read_text(encoding='utf-8'))
+    errs=[]
+    for ent in cfg['packages']:
+        pkg=ent['name']
+        cdir=ROOT/f'tests/modules/contracts/{pkg}'
+        baseline=read_set(cdir/f'{pkg}.facade.api')
+        current=read_set(cdir/f'{pkg}.exports')
+        removed=sorted(baseline-current)
+        if removed:
+            errs.append(f'{pkg}: removed exports: {", ".join(removed)}')
+        print(f'[breaking-removal-table] {pkg}: baseline={len(baseline)} current={len(current)} removed={len(removed)}')
+    if errs:
+        for e in errs:
+            print(f'[breaking-removal-table][error] {e}')
+        return 1
+    print('[breaking-removal-table] OK')
+    return 0
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tools/test_contract_diff.sh
+++ b/tools/test_contract_diff.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 "$(cd "$(dirname "$0")/.." && pwd)/tools/lint_test_compat_contracts.py"

--- a/tools/test_contract_snapshots.sh
+++ b/tools/test_contract_snapshots.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+DIR="$ROOT_DIR/tests/modules/contracts/test"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[test-contract-snapshots][error] unknown $1" >&2; exit 1;; esac; shift; done
+ALL="$DIR/test.exports"; PUB="$DIR/test.exports.public"; INT="$DIR/test.exports.internal"; SHA="$DIR/test.exports.sha256"
+for f in "$ALL" "$PUB" "$INT"; do [ -f "$f" ] || { echo "[test-contract-snapshots][error] missing $f" >&2; exit 1; }; done
+if [ "$UPDATE" -eq 1 ]; then sha256sum "$ALL"|awk '{print $1}'>$SHA; "$ROOT_DIR/tools/test_facade_snapshot.sh" --update; echo "[test-contract-snapshots] updated"; exit 0; fi
+[ -f "$SHA" ] || { echo "[test-contract-snapshots][error] missing $SHA" >&2; exit 1; }
+diff -u "$ALL" "$PUB" >/dev/null || { diff -u "$ALL" "$PUB" || true; echo "[test-contract-snapshots][error] public diverge" >&2; exit 1; }
+[ ! -s "$INT" ] || { echo "[test-contract-snapshots][error] internal snapshot must be empty" >&2; exit 1; }
+diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null || { echo "[test-contract-snapshots][error] exports must be sorted" >&2; exit 1; }
+"$ROOT_DIR/tools/test_facade_snapshot.sh"
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$ALL"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[test-contract-snapshots][error] sha mismatch" >&2; exit 1; }
+echo "[test-contract-snapshots] OK"

--- a/tools/test_facade_snapshot.sh
+++ b/tools/test_facade_snapshot.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/test/test.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/test/test.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/test/test.facade.api.sha256"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[test-facade-snapshot][error] unknown arg: $1" >&2; exit 1;; esac; shift; done
+[ -f "$SRC" ] || { echo "[test-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+if [ "$UPDATE" -eq 1 ]; then cp "$tmp" "$OUT"; sha256sum "$OUT"|awk '{print $1}'>$SHA; echo "[test-facade-snapshot] updated"; exit 0; fi
+[ -f "$OUT" ] || { echo "[test-facade-snapshot][error] missing $OUT" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[test-facade-snapshot][error] missing $SHA" >&2; exit 1; }
+diff -u "$OUT" "$tmp" >/dev/null || { diff -u "$OUT" "$tmp" || true; echo "[test-facade-snapshot][error] mismatch" >&2; exit 1; }
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$OUT"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[test-facade-snapshot][error] sha mismatch" >&2; exit 1; }
+echo "[test-facade-snapshot] OK"

--- a/tools/yaml_contract_diff.sh
+++ b/tools/yaml_contract_diff.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 "$(cd "$(dirname "$0")/.." && pwd)/tools/lint_yaml_compat_contracts.py"

--- a/tools/yaml_contract_snapshots.sh
+++ b/tools/yaml_contract_snapshots.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+DIR="$ROOT_DIR/tests/modules/contracts/yaml"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[yaml-contract-snapshots][error] unknown $1" >&2; exit 1;; esac; shift; done
+ALL="$DIR/yaml.exports"; PUB="$DIR/yaml.exports.public"; INT="$DIR/yaml.exports.internal"; SHA="$DIR/yaml.exports.sha256"
+for f in "$ALL" "$PUB" "$INT"; do [ -f "$f" ] || { echo "[yaml-contract-snapshots][error] missing $f" >&2; exit 1; }; done
+if [ "$UPDATE" -eq 1 ]; then sha256sum "$ALL"|awk '{print $1}'>$SHA; "$ROOT_DIR/tools/yaml_facade_snapshot.sh" --update; echo "[yaml-contract-snapshots] updated"; exit 0; fi
+[ -f "$SHA" ] || { echo "[yaml-contract-snapshots][error] missing $SHA" >&2; exit 1; }
+diff -u "$ALL" "$PUB" >/dev/null || { diff -u "$ALL" "$PUB" || true; echo "[yaml-contract-snapshots][error] public diverge" >&2; exit 1; }
+[ ! -s "$INT" ] || { echo "[yaml-contract-snapshots][error] internal snapshot must be empty" >&2; exit 1; }
+diff -u <(LC_ALL=C sort "$ALL") "$ALL" >/dev/null || { echo "[yaml-contract-snapshots][error] exports must be sorted" >&2; exit 1; }
+"$ROOT_DIR/tools/yaml_facade_snapshot.sh"
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$ALL"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[yaml-contract-snapshots][error] sha mismatch" >&2; exit 1; }
+echo "[yaml-contract-snapshots] OK"

--- a/tools/yaml_facade_snapshot.sh
+++ b/tools/yaml_facade_snapshot.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="$ROOT_DIR/tests/modules/contracts/yaml/yaml.exports"
+OUT="$ROOT_DIR/tests/modules/contracts/yaml/yaml.facade.api"
+SHA="$ROOT_DIR/tests/modules/contracts/yaml/yaml.facade.api.sha256"
+UPDATE=0
+while [ $# -gt 0 ]; do case "$1" in --update) UPDATE=1;; *) echo "[yaml-facade-snapshot][error] unknown arg: $1" >&2; exit 1;; esac; shift; done
+[ -f "$SRC" ] || { echo "[yaml-facade-snapshot][error] missing $SRC" >&2; exit 1; }
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+LC_ALL=C sort "$SRC" > "$tmp"
+if [ "$UPDATE" -eq 1 ]; then cp "$tmp" "$OUT"; sha256sum "$OUT"|awk '{print $1}'>$SHA; echo "[yaml-facade-snapshot] updated"; exit 0; fi
+[ -f "$OUT" ] || { echo "[yaml-facade-snapshot][error] missing $OUT" >&2; exit 1; }
+[ -f "$SHA" ] || { echo "[yaml-facade-snapshot][error] missing $SHA" >&2; exit 1; }
+diff -u "$OUT" "$tmp" >/dev/null || { diff -u "$OUT" "$tmp" || true; echo "[yaml-facade-snapshot][error] mismatch" >&2; exit 1; }
+expected="$(tr -d '\n' < "$SHA")"; actual="$(sha256sum "$OUT"|awk '{print $1}')"
+[ "$expected" = "$actual" ] || { echo "[yaml-facade-snapshot][error] sha mismatch" >&2; exit 1; }
+echo "[yaml-facade-snapshot] OK"


### PR DESCRIPTION
## Summary
Split from the original tools-all work: this PR delivers the contracts and lint governance foundation for package facades and CI policy checks.

## Included
- Contract tooling
  - snapshot generation/update, facade snapshots, contract diff helpers
  - lockfile generation and contract dashboard support
- Lint tooling
  - global policy lints (facade-thin, ROLE-CONTRACT, diagnostic namespace ownership)
  - package-specific lint suites (alias/use-as, no side effects, naming, sensitive imports, security checks)
  - diagnostics stability and quickfix schema snapshots
- Governance metadata
  - `tools/LINTS.md` refresh
  - `tools/facade_packages.json`
  - `tools/templates/ROLE_CONTRACT.template`

## Goal
Provide enforceable API/governance guardrails before release and packaging.
