### PR TITLE
fix(tools): unblock modules snapshots and package governance checks

### DIFF
--- a/src/vitte/packages/process/compat/OWNERS
+++ b/src/vitte/packages/process/compat/OWNERS
@@ -1,0 +1,1 @@
+@vitte/process

--- a/src/vitte/packages/process/compat/info.vit
+++ b/src/vitte/packages/process/compat/info.vit
@@ -1,0 +1,25 @@
+<<<
+info.vit
+package vitte/process/compat
+>>>
+
+<<< PACKAGE-META
+owner: @vitte/process
+stability: stable
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/process/compat
+
+proc package_name() -> string {
+    give "process/compat"
+}
+
+proc package_tag() -> string {
+    give "vitte/process/compat"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/std/async/OWNERS
+++ b/src/vitte/packages/std/async/OWNERS
@@ -1,0 +1,1 @@
+@vitte/std

--- a/src/vitte/packages/std/async/info.vit
+++ b/src/vitte/packages/std/async/info.vit
@@ -1,0 +1,25 @@
+<<<
+info.vit
+package vitte/std/async
+>>>
+
+<<< PACKAGE-META
+owner: @vitte/std
+stability: stable
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/std/async
+
+proc package_name() -> string {
+    give "std/async"
+}
+
+proc package_tag() -> string {
+    give "vitte/std/async"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/std/base/OWNERS
+++ b/src/vitte/packages/std/base/OWNERS
@@ -1,0 +1,1 @@
+@vitte/std

--- a/src/vitte/packages/std/data/OWNERS
+++ b/src/vitte/packages/std/data/OWNERS
@@ -1,0 +1,1 @@
+@vitte/std

--- a/src/vitte/packages/std/data/info.vit
+++ b/src/vitte/packages/std/data/info.vit
@@ -1,0 +1,25 @@
+<<<
+info.vit
+package vitte/std/data
+>>>
+
+<<< PACKAGE-META
+owner: @vitte/std
+stability: stable
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/std/data
+
+proc package_name() -> string {
+    give "std/data"
+}
+
+proc package_tag() -> string {
+    give "vitte/std/data"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/std/io/OWNERS
+++ b/src/vitte/packages/std/io/OWNERS
@@ -1,0 +1,1 @@
+@vitte/std

--- a/src/vitte/packages/std/io/info.vit
+++ b/src/vitte/packages/std/io/info.vit
@@ -1,0 +1,25 @@
+<<<
+info.vit
+package vitte/std/io
+>>>
+
+<<< PACKAGE-META
+owner: @vitte/std
+stability: stable
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/std/io
+
+proc package_name() -> string {
+    give "std/io"
+}
+
+proc package_tag() -> string {
+    give "vitte/std/io"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/std/net/OWNERS
+++ b/src/vitte/packages/std/net/OWNERS
@@ -1,0 +1,1 @@
+@vitte/std

--- a/src/vitte/packages/std/net/info.vit
+++ b/src/vitte/packages/std/net/info.vit
@@ -1,0 +1,25 @@
+<<<
+info.vit
+package vitte/std/net
+>>>
+
+<<< PACKAGE-META
+owner: @vitte/std
+stability: stable
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/std/net
+
+proc package_name() -> string {
+    give "std/net"
+}
+
+proc package_tag() -> string {
+    give "vitte/std/net"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/tests/modules/snapshots/mod_doctor_alias_ambiguous_as_core.diagjson.must
+++ b/tests/modules/snapshots/mod_doctor_alias_ambiguous_as_core.diagjson.must
@@ -1,4 +1,15 @@
 [doctor] unused alias: core
-[doctor] export collision in __root__: symbol 'package_meta' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'err' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'panic_guard' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'quickfix_apply' from vitte/db and vitte/core
 [doctor] export collision in __root__: symbol 'ready' from vitte/db and vitte/core
-[doctor] issues: 3
+[doctor] export collision in __root__: symbol 'package_meta' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'doctor_status' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_message' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'api_version' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_quickfix' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'assert_or_err' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'quickfix_preview' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_doc_url' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'ok' from vitte/db and vitte/core
+[doctor] issues: 14

--- a/tests/modules/snapshots/mod_doctor_alias_ambiguous_as_core.must
+++ b/tests/modules/snapshots/mod_doctor_alias_ambiguous_as_core.must
@@ -1,4 +1,15 @@
 [doctor] unused alias: core
-[doctor] export collision in __root__: symbol 'package_meta' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'err' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'panic_guard' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'quickfix_apply' from vitte/db and vitte/core
 [doctor] export collision in __root__: symbol 'ready' from vitte/db and vitte/core
-[doctor] issues: 3
+[doctor] export collision in __root__: symbol 'package_meta' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'doctor_status' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_message' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'api_version' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_quickfix' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'assert_or_err' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'quickfix_preview' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_doc_url' from vitte/db and vitte/core
+[doctor] export collision in __root__: symbol 'ok' from vitte/db and vitte/core
+[doctor] issues: 14

--- a/tests/modules/snapshots/mod_doctor_alias_ambiguous_as_mod.diagjson.must
+++ b/tests/modules/snapshots/mod_doctor_alias_ambiguous_as_mod.diagjson.must
@@ -1,5 +1,15 @@
 [doctor] unused alias: mod
-[doctor] export collision in __root__: symbol 'package_meta' from vitte/http and vitte/core
-[doctor] export collision in __root__: symbol 'ok' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'err' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'panic_guard' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'quickfix_apply' from vitte/http and vitte/core
 [doctor] export collision in __root__: symbol 'ready' from vitte/http and vitte/core
-[doctor] issues: 4
+[doctor] export collision in __root__: symbol 'package_meta' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'doctor_status' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_message' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'api_version' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_quickfix' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'assert_or_err' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'quickfix_preview' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_doc_url' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'ok' from vitte/http and vitte/core
+[doctor] issues: 14

--- a/tests/modules/snapshots/mod_doctor_alias_ambiguous_as_mod.must
+++ b/tests/modules/snapshots/mod_doctor_alias_ambiguous_as_mod.must
@@ -1,5 +1,15 @@
 [doctor] unused alias: mod
-[doctor] export collision in __root__: symbol 'package_meta' from vitte/http and vitte/core
-[doctor] export collision in __root__: symbol 'ok' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'err' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'panic_guard' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'quickfix_apply' from vitte/http and vitte/core
 [doctor] export collision in __root__: symbol 'ready' from vitte/http and vitte/core
-[doctor] issues: 4
+[doctor] export collision in __root__: symbol 'package_meta' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'doctor_status' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_message' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'api_version' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_quickfix' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'assert_or_err' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'quickfix_preview' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'diagnostics_doc_url' from vitte/http and vitte/core
+[doctor] export collision in __root__: symbol 'ok' from vitte/http and vitte/core
+[doctor] issues: 14

--- a/tests/modules/snapshots/packages/packages_gate.diagjson.must
+++ b/tests/modules/snapshots/packages/packages_gate.diagjson.must
@@ -1,27 +1,61 @@
-[package-layout-lint] scanned packages: 113
+[package-layout-lint] scanned packages: 125
 [package-layout-lint] OK (warnings: 0)
-[packages-governance-lint] scanned modules: 115
+[packages-governance-lint] scanned modules: 134
 [packages-governance-lint] OK
-[module-naming-lint] scanned modules: 115
+[no-std-lint] scanned files: 309
+[no-std-lint] allowlist entries: 0
+[no-std-lint] OK
+[module-naming-lint] scanned modules: 134
 [module-naming-lint] OK
-[legacy-import-lint] scanned files: 433
+[legacy-import-lint] scanned files: 599
 [legacy-import-lint] allowlist entries: 5 (budget: 5)
 [legacy-import-lint] OK
+[critical-runtime-matrix] profiles=core,system,desktop,arduino modules=abi,core,db,http
+[critical-runtime-matrix] OK
+[new-public-snapshots] BASE_REF not set; skipping check
 [modules-cache-perf] OK
 modules-report
-fixtures: 115
-unique_modules: 1
-edges: 0
+fixtures: 134
+unique_modules: 12
+edges: 11
 cycles: 0
 critical_cycles: 0
-fanout_median: 0
-fanin_median: 0
-max_depth: 0
+fanout_median: 0.0
+fanin_median: 1.0
+max_depth: 3
 fanout_top:
-  __root__: imports=0
+  vitte/process/internal/runtime: imports=7
+  __root__: imports=1
+  vitte/process/compat: imports=1
+  vitte/crypto: imports=0
+  vitte/process/internal/capture: imports=0
+  vitte/process/internal/policy: imports=0
+  vitte/process/internal/signal: imports=0
+  vitte/process/internal/spawn: imports=0
+  vitte/process/internal/telemetry: imports=0
+  vitte/process/internal/validate: imports=0
 fanin_top:
+  vitte/crypto: fanin=1
+  vitte/process/compat: fanin=1
+  vitte/process/internal/capture: fanin=1
+  vitte/process/internal/policy: fanin=1
+  vitte/process/internal/runtime: fanin=1
+  vitte/process/internal/signal: fanin=1
+  vitte/process/internal/spawn: fanin=1
+  vitte/process/internal/telemetry: fanin=1
+  vitte/process/internal/validate: fanin=1
+  vitte/process/internal/wait: fanin=1
 loc_top:
-  __root__: loc=459
+  __root__: loc=1908
+  vitte/process/internal/runtime: loc=188
+  vitte/std/base: loc=115
+  vitte/crypto: loc=89
+  vitte/process/compat: loc=88
+  vitte/process/internal/validate: loc=60
+  vitte/process/internal/policy: loc=49
+  vitte/process/internal/spawn: loc=40
+  vitte/process/internal/wait: loc=25
+  vitte/process/internal/capture: loc=17
 cycle_samples:
   none
 cycles_by_severity:
@@ -29,7 +63,17 @@ cycles_by_severity:
 critical_cycle_samples:
   none
 potential_collisions:
-  none
+  src/vitte/packages/process/mod.vit: symbol='command_allowlisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='command_denylisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='shell_exec_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='shell_injection_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='args_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='contains' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='cwd_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='env_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='has_control_chars' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='policy_hash' owners=vitte/process/internal/runtime,vitte/process/internal/spawn
+  src/vitte/packages/process/mod.vit: symbol='starts_with' owners=vitte/process/internal/runtime,vitte/process/internal/validate
 high_frequency_symbols:
   none
 [modules-report] wrote target/reports/packages_modules_report.txt

--- a/tests/modules/snapshots/packages/packages_gate.must
+++ b/tests/modules/snapshots/packages/packages_gate.must
@@ -1,27 +1,61 @@
-[package-layout-lint] scanned packages: 113
+[package-layout-lint] scanned packages: 125
 [package-layout-lint] OK (warnings: 0)
-[packages-governance-lint] scanned modules: 115
+[packages-governance-lint] scanned modules: 134
 [packages-governance-lint] OK
-[module-naming-lint] scanned modules: 115
+[no-std-lint] scanned files: 309
+[no-std-lint] allowlist entries: 0
+[no-std-lint] OK
+[module-naming-lint] scanned modules: 134
 [module-naming-lint] OK
-[legacy-import-lint] scanned files: 433
+[legacy-import-lint] scanned files: 599
 [legacy-import-lint] allowlist entries: 5 (budget: 5)
 [legacy-import-lint] OK
+[critical-runtime-matrix] profiles=core,system,desktop,arduino modules=abi,core,db,http
+[critical-runtime-matrix] OK
+[new-public-snapshots] BASE_REF not set; skipping check
 [modules-cache-perf] OK
 modules-report
-fixtures: 115
-unique_modules: 1
-edges: 0
+fixtures: 134
+unique_modules: 12
+edges: 11
 cycles: 0
 critical_cycles: 0
-fanout_median: 0
-fanin_median: 0
-max_depth: 0
+fanout_median: 0.0
+fanin_median: 1.0
+max_depth: 3
 fanout_top:
-  __root__: imports=0
+  vitte/process/internal/runtime: imports=7
+  __root__: imports=1
+  vitte/process/compat: imports=1
+  vitte/crypto: imports=0
+  vitte/process/internal/capture: imports=0
+  vitte/process/internal/policy: imports=0
+  vitte/process/internal/signal: imports=0
+  vitte/process/internal/spawn: imports=0
+  vitte/process/internal/telemetry: imports=0
+  vitte/process/internal/validate: imports=0
 fanin_top:
+  vitte/crypto: fanin=1
+  vitte/process/compat: fanin=1
+  vitte/process/internal/capture: fanin=1
+  vitte/process/internal/policy: fanin=1
+  vitte/process/internal/runtime: fanin=1
+  vitte/process/internal/signal: fanin=1
+  vitte/process/internal/spawn: fanin=1
+  vitte/process/internal/telemetry: fanin=1
+  vitte/process/internal/validate: fanin=1
+  vitte/process/internal/wait: fanin=1
 loc_top:
-  __root__: loc=459
+  __root__: loc=1908
+  vitte/process/internal/runtime: loc=188
+  vitte/std/base: loc=115
+  vitte/crypto: loc=89
+  vitte/process/compat: loc=88
+  vitte/process/internal/validate: loc=60
+  vitte/process/internal/policy: loc=49
+  vitte/process/internal/spawn: loc=40
+  vitte/process/internal/wait: loc=25
+  vitte/process/internal/capture: loc=17
 cycle_samples:
   none
 cycles_by_severity:
@@ -29,7 +63,17 @@ cycles_by_severity:
 critical_cycle_samples:
   none
 potential_collisions:
-  none
+  src/vitte/packages/process/mod.vit: symbol='command_allowlisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='command_denylisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='shell_exec_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='shell_injection_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='args_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='contains' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='cwd_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='env_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='has_control_chars' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='policy_hash' owners=vitte/process/internal/runtime,vitte/process/internal/spawn
+  src/vitte/packages/process/mod.vit: symbol='starts_with' owners=vitte/process/internal/runtime,vitte/process/internal/validate
 high_frequency_symbols:
   none
 [modules-report] wrote target/reports/packages_modules_report.txt

--- a/tests/modules/snapshots/packages/packages_report.diagjson.must
+++ b/tests/modules/snapshots/packages/packages_report.diagjson.must
@@ -1,17 +1,45 @@
 modules-report
-fixtures: 115
-unique_modules: 1
-edges: 0
+fixtures: 134
+unique_modules: 12
+edges: 11
 cycles: 0
 critical_cycles: 0
-fanout_median: 0
-fanin_median: 0
-max_depth: 0
+fanout_median: 0.0
+fanin_median: 1.0
+max_depth: 3
 fanout_top:
-  __root__: imports=0
+  vitte/process/internal/runtime: imports=7
+  __root__: imports=1
+  vitte/process/compat: imports=1
+  vitte/crypto: imports=0
+  vitte/process/internal/capture: imports=0
+  vitte/process/internal/policy: imports=0
+  vitte/process/internal/signal: imports=0
+  vitte/process/internal/spawn: imports=0
+  vitte/process/internal/telemetry: imports=0
+  vitte/process/internal/validate: imports=0
 fanin_top:
+  vitte/crypto: fanin=1
+  vitte/process/compat: fanin=1
+  vitte/process/internal/capture: fanin=1
+  vitte/process/internal/policy: fanin=1
+  vitte/process/internal/runtime: fanin=1
+  vitte/process/internal/signal: fanin=1
+  vitte/process/internal/spawn: fanin=1
+  vitte/process/internal/telemetry: fanin=1
+  vitte/process/internal/validate: fanin=1
+  vitte/process/internal/wait: fanin=1
 loc_top:
-  __root__: loc=459
+  __root__: loc=1908
+  vitte/process/internal/runtime: loc=188
+  vitte/std/base: loc=115
+  vitte/crypto: loc=89
+  vitte/process/compat: loc=88
+  vitte/process/internal/validate: loc=60
+  vitte/process/internal/policy: loc=49
+  vitte/process/internal/spawn: loc=40
+  vitte/process/internal/wait: loc=25
+  vitte/process/internal/capture: loc=17
 cycle_samples:
   none
 cycles_by_severity:
@@ -19,7 +47,17 @@ cycles_by_severity:
 critical_cycle_samples:
   none
 potential_collisions:
-  none
+  src/vitte/packages/process/mod.vit: symbol='command_allowlisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='command_denylisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='shell_exec_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='shell_injection_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='args_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='contains' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='cwd_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='env_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='has_control_chars' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='policy_hash' owners=vitte/process/internal/runtime,vitte/process/internal/spawn
+  src/vitte/packages/process/mod.vit: symbol='starts_with' owners=vitte/process/internal/runtime,vitte/process/internal/validate
 high_frequency_symbols:
   none
 [modules-report] wrote target/reports/packages_modules_report.txt

--- a/tests/modules/snapshots/packages/packages_report.must
+++ b/tests/modules/snapshots/packages/packages_report.must
@@ -1,17 +1,45 @@
 modules-report
-fixtures: 115
-unique_modules: 1
-edges: 0
+fixtures: 134
+unique_modules: 12
+edges: 11
 cycles: 0
 critical_cycles: 0
-fanout_median: 0
-fanin_median: 0
-max_depth: 0
+fanout_median: 0.0
+fanin_median: 1.0
+max_depth: 3
 fanout_top:
-  __root__: imports=0
+  vitte/process/internal/runtime: imports=7
+  __root__: imports=1
+  vitte/process/compat: imports=1
+  vitte/crypto: imports=0
+  vitte/process/internal/capture: imports=0
+  vitte/process/internal/policy: imports=0
+  vitte/process/internal/signal: imports=0
+  vitte/process/internal/spawn: imports=0
+  vitte/process/internal/telemetry: imports=0
+  vitte/process/internal/validate: imports=0
 fanin_top:
+  vitte/crypto: fanin=1
+  vitte/process/compat: fanin=1
+  vitte/process/internal/capture: fanin=1
+  vitte/process/internal/policy: fanin=1
+  vitte/process/internal/runtime: fanin=1
+  vitte/process/internal/signal: fanin=1
+  vitte/process/internal/spawn: fanin=1
+  vitte/process/internal/telemetry: fanin=1
+  vitte/process/internal/validate: fanin=1
+  vitte/process/internal/wait: fanin=1
 loc_top:
-  __root__: loc=459
+  __root__: loc=1908
+  vitte/process/internal/runtime: loc=188
+  vitte/std/base: loc=115
+  vitte/crypto: loc=89
+  vitte/process/compat: loc=88
+  vitte/process/internal/validate: loc=60
+  vitte/process/internal/policy: loc=49
+  vitte/process/internal/spawn: loc=40
+  vitte/process/internal/wait: loc=25
+  vitte/process/internal/capture: loc=17
 cycle_samples:
   none
 cycles_by_severity:
@@ -19,7 +47,17 @@ cycles_by_severity:
 critical_cycle_samples:
   none
 potential_collisions:
-  none
+  src/vitte/packages/process/mod.vit: symbol='command_allowlisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='command_denylisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='shell_exec_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='shell_injection_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
+  src/vitte/packages/process/mod.vit: symbol='args_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='contains' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='cwd_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='env_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='has_control_chars' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  src/vitte/packages/process/mod.vit: symbol='policy_hash' owners=vitte/process/internal/runtime,vitte/process/internal/spawn
+  src/vitte/packages/process/mod.vit: symbol='starts_with' owners=vitte/process/internal/runtime,vitte/process/internal/validate
 high_frequency_symbols:
   none
 [modules-report] wrote target/reports/packages_modules_report.txt

--- a/tools/packages_contract_snapshots.sh
+++ b/tools/packages_contract_snapshots.sh
@@ -47,7 +47,7 @@ for mod in "${CRITICAL[@]}"; do
   snap_hash="$mod_snap_dir/$mod.exports.sha256"
 
   raw_json="$tmp_root/$mod.module-index.json"
-  out="$($BIN check --lang=en --dump-module-index "$src" 2>&1)"
+  out="$($BIN check --lang=en --allow-internal --dump-module-index "$src" 2>&1)"
   printf "%s\n" "$out" > "$raw_json"
 
   gen_all="$tmp_root/$mod.exports"


### PR DESCRIPTION
## Summary
Fix failing module snapshot and package governance checks introduced by recent package facade/internal expansion.

## What changed
- `tools/packages_contract_snapshots.sh`
  - run module-index extraction with `--allow-internal`
  - prevents false failures when facade modules import `internal/*`
- Snapshot updates (doctor/package reports)
  - refresh ambiguous alias doctor snapshots for expanded collision set
  - refresh package gate/report snapshots after package count and module graph changes
- Package metadata completion
  - add missing `OWNERS` and `info.vit` for new subpackages:
    - `src/vitte/packages/process/compat`
    - `src/vitte/packages/std/{async,base,data,io,net}`

## Why
Without these updates, `make modules-snapshots` failed due to:
- outdated expected snapshot needles
- governance lint failures for missing package metadata
- contract snapshot tool rejecting internal imports in facade checks

## Validation
- `make -s packages-governance-lint` ✅
- `make -s packages-contract-snapshots` ✅
- `make -s modules-snapshots` ✅
