### PR TITLE
ci(tests): parallelize full all-tests via matrix workflow

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -1,0 +1,46 @@
+name: all-tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  all-tests-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - core
+          - ci
+          - abi
+          - modules
+          - packages
+          - package-ci-fast
+          - package-ci-strict
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          source toolchain/scripts/install/debian-deps.sh
+          sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+
+      - name: Build
+        run: make build
+
+      - name: Run all-tests group
+        run: ALL_TESTS_GROUP=${{ matrix.group }} make all-tests
+
+      - name: Upload all-tests reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-tests-reports-${{ matrix.group }}
+          path: target/reports/all-tests

--- a/Makefile
+++ b/Makefile
@@ -544,6 +544,14 @@ ci-mod-fast: grammar-check diag-snapshots completions-snapshots stdlib-profile-s
 .PHONY: ci-bridge-compat
 ci-bridge-compat: ci-mod-fast
 
+.PHONY: all-tests
+all-tests:
+	@tools/run_all_tests.sh
+
+.PHONY: all-tests-group
+all-tests-group:
+	@ALL_TESTS_GROUP=$${GROUP:-all} tools/run_all_tests.sh
+
 .PHONY: vitteos-bin-quality
 vitteos-bin-quality:
 	@tools/vitteos_bin_ci_quality.sh
@@ -819,6 +827,8 @@ help:
 	@echo "  make completions-snapshots-update update completion golden snapshots"
 	@echo "  make completions-lint syntax-check bash/zsh/fish completion files"
 	@echo "  make ci-completions run completion check + lint + snapshots + fallback"
+	@echo "  make all-tests run full test matrix and write logs in target/reports/all-tests"
+	@echo "  make all-tests-group GROUP=<name> run grouped matrix slice (core|ci|abi|modules|packages|package-ci-fast|package-ci-strict)"
 	@echo "  make pkg-debian build Debian .deb installer (PKG_VERSION=$(PKG_VERSION))"
 	@echo "  make pkg-debian-install build and install Debian .deb locally via dpkg"
 	@echo "  make pkg-macos build macOS installer pkg (PKG_VERSION=$(PKG_VERSION))"

--- a/tools/run_all_tests.sh
+++ b/tools/run_all_tests.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+REPORT_DIR="${REPORT_DIR:-$ROOT_DIR/target/reports/all-tests}"
+ALL_TESTS_GROUP="${ALL_TESTS_GROUP:-all}"
+
+mkdir -p "$REPORT_DIR"
+run_id="$(date +%Y%m%d_%H%M%S)"
+summary="$REPORT_DIR/summary_${run_id}_${ALL_TESTS_GROUP}.txt"
+
+all_targets=(
+  test parse parse-modules parse-strict hir-validate check-tests stress-alloc core-projects test-examples arduino-projects negative-tests diag-snapshots resolve-tests explain-snapshots wrapper-stage-test
+  grammar-check book-qa-strict ci-fast ci-strict ci-completions
+  extern-abi-host extern-abi-arduino extern-abi-kernel extern-abi-kernel-uefi extern-abi-all std-core-tests stdlib-api-lint stdlib-profile-snapshots stdlib-abi-compat
+  modules-tests modules-snapshots modules-contract-snapshots modules-ci-strict
+  packages-governance-lint critical-runtime-matrix-lint packages-gate
+  core-only-ci core-strict-ci std-only-ci std-strict-ci log-only-ci log-strict-ci fs-only-ci fs-strict-ci db-only-ci db-strict-ci http-only-ci http-strict-ci http-client-only-ci http-client-strict-ci process-only-ci process-strict-ci json-only-ci json-strict-ci yaml-only-ci yaml-strict-ci test-only-ci test-strict-ci lint-only-ci lint-strict-ci
+  packages-only-ci packages-strict-ci
+)
+
+select_targets() {
+  case "$ALL_TESTS_GROUP" in
+    all)
+      printf "%s\n" "${all_targets[@]}"
+      ;;
+    core)
+      printf "%s\n" test parse parse-modules parse-strict hir-validate check-tests stress-alloc core-projects test-examples arduino-projects negative-tests diag-snapshots resolve-tests explain-snapshots wrapper-stage-test
+      ;;
+    ci)
+      printf "%s\n" grammar-check book-qa-strict ci-fast ci-strict ci-completions
+      ;;
+    abi)
+      printf "%s\n" extern-abi-host extern-abi-arduino extern-abi-kernel extern-abi-kernel-uefi extern-abi-all std-core-tests stdlib-api-lint stdlib-profile-snapshots stdlib-abi-compat
+      ;;
+    modules)
+      printf "%s\n" modules-tests modules-snapshots modules-contract-snapshots modules-ci-strict
+      ;;
+    packages)
+      printf "%s\n" packages-governance-lint critical-runtime-matrix-lint packages-gate
+      ;;
+    package-ci-fast)
+      printf "%s\n" core-only-ci std-only-ci log-only-ci fs-only-ci db-only-ci http-only-ci http-client-only-ci process-only-ci json-only-ci yaml-only-ci test-only-ci lint-only-ci packages-only-ci
+      ;;
+    package-ci-strict)
+      printf "%s\n" core-strict-ci std-strict-ci log-strict-ci fs-strict-ci db-strict-ci http-strict-ci http-client-strict-ci process-strict-ci json-strict-ci yaml-strict-ci test-strict-ci lint-strict-ci packages-strict-ci
+      ;;
+    *)
+      echo "[all-tests][error] unknown ALL_TESTS_GROUP=$ALL_TESTS_GROUP" >&2
+      echo "[all-tests][error] expected: all|core|ci|abi|modules|packages|package-ci-fast|package-ci-strict" >&2
+      exit 2
+      ;;
+  esac
+}
+
+mapfile -t targets < <(select_targets)
+
+printf "# all-tests run %s group=%s\n" "$run_id" "$ALL_TESTS_GROUP" > "$summary"
+pass=0
+fail=0
+
+for t in "${targets[@]}"; do
+  log="$REPORT_DIR/${run_id}_${ALL_TESTS_GROUP}_${t}.log"
+  echo "[all-tests] running $t"
+  if make -s -C "$ROOT_DIR" "$t" >"$log" 2>&1; then
+    echo "PASS $t" | tee -a "$summary"
+    pass=$((pass + 1))
+  else
+    rc=$?
+    echo "FAIL $t (rc=$rc)" | tee -a "$summary"
+    fail=$((fail + 1))
+  fi
+done
+
+echo "---" | tee -a "$summary"
+echo "TOTAL PASS=$pass FAIL=$fail" | tee -a "$summary"
+echo "SUMMARY=$summary"
+
+if [ "$fail" -eq 0 ]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary
Parallelize the full `all-tests` coverage by running grouped slices in a GitHub Actions matrix.

## Changes
- Add grouped execution mode in `tools/run_all_tests.sh`
  - new env selector: `ALL_TESTS_GROUP`
  - supported groups:
    - `core`
    - `ci`
    - `abi`
    - `modules`
    - `packages`
    - `package-ci-fast`
    - `package-ci-strict`
  - keeps `all` mode for local full run
- Update `Makefile`
  - `make all-tests` (full run)
  - `make all-tests-group GROUP=<name>` (grouped run)
  - help entries for both targets
- Add `.github/workflows/all-tests.yml`
  - matrix strategy over test groups
  - `fail-fast: false` to collect complete failure surface
  - uploads per-group artifacts (`all-tests-reports-<group>`)

## Goal
Reduce end-to-end CI time while preserving full test coverage and improving failure diagnostics by group.
