### PR TITLE
fix(ci): handle missing debian-deps.sh in GitHub workflows

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Install build deps
         run: |
           sudo apt-get update
-          source toolchain/scripts/install/debian-deps.sh
-          sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          if [ -f toolchain/scripts/install/debian-deps.sh ]; then
+            source toolchain/scripts/install/debian-deps.sh
+            sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          else
+            sudo apt-get install -y clang g++ make pkg-config libssl-dev libcurl4-openssl-dev python3 python3-pip jq zsh fish
+          fi
 
       - name: Build
         run: make build

--- a/.github/workflows/modules-report-pr.yml
+++ b/.github/workflows/modules-report-pr.yml
@@ -22,8 +22,12 @@ jobs:
       - name: Install build deps
         run: |
           sudo apt-get update
-          source toolchain/scripts/install/debian-deps.sh
-          sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          if [ -f toolchain/scripts/install/debian-deps.sh ]; then
+            source toolchain/scripts/install/debian-deps.sh
+            sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          else
+            sudo apt-get install -y clang g++ make pkg-config libssl-dev libcurl4-openssl-dev python3 python3-pip jq zsh fish
+          fi
 
       - name: Build
         run: make build

--- a/.github/workflows/modules-snapshots-pr.yml
+++ b/.github/workflows/modules-snapshots-pr.yml
@@ -21,8 +21,12 @@ jobs:
       - name: Install build deps
         run: |
           sudo apt-get update
-          source toolchain/scripts/install/debian-deps.sh
-          sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          if [ -f toolchain/scripts/install/debian-deps.sh ]; then
+            source toolchain/scripts/install/debian-deps.sh
+            sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          else
+            sudo apt-get install -y clang g++ make pkg-config libssl-dev libcurl4-openssl-dev python3 python3-pip jq zsh fish
+          fi
 
       - name: Build
         run: make build

--- a/.github/workflows/modules-weekly-v3.yml
+++ b/.github/workflows/modules-weekly-v3.yml
@@ -22,8 +22,12 @@ jobs:
       - name: Install build deps
         run: |
           sudo apt-get update
-          source toolchain/scripts/install/debian-deps.sh
-          sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          if [ -f toolchain/scripts/install/debian-deps.sh ]; then
+            source toolchain/scripts/install/debian-deps.sh
+            sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          else
+            sudo apt-get install -y clang g++ make pkg-config libssl-dev libcurl4-openssl-dev python3 python3-pip jq zsh fish
+          fi
 
       - name: Build
         run: make build
@@ -44,8 +48,12 @@ jobs:
       - name: Install build deps
         run: |
           sudo apt-get update
-          source toolchain/scripts/install/debian-deps.sh
-          sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          if [ -f toolchain/scripts/install/debian-deps.sh ]; then
+            source toolchain/scripts/install/debian-deps.sh
+            sudo apt-get install -y "${DEBIAN_APT_BUILD_DEPS[@]}"
+          else
+            sudo apt-get install -y clang g++ make pkg-config libssl-dev libcurl4-openssl-dev python3 python3-pip jq zsh fish
+          fi
 
       - name: Build
         run: make build


### PR DESCRIPTION
## Summary
Fix GitHub Actions failures caused by sourcing a missing `toolchain/scripts/install/debian-deps.sh` file.

## Problem
Workflows failed at:
- `source toolchain/scripts/install/debian-deps.sh`
with:
- `No such file or directory`

## Solution
Add a defensive fallback in workflow install steps:
- if `toolchain/scripts/install/debian-deps.sh` exists:
  - source it and install `${DEBIAN_APT_BUILD_DEPS[@]}`
- else:
  - install a minimal explicit apt set:
    - `clang g++ make pkg-config libssl-dev libcurl4-openssl-dev python3 python3-pip jq zsh fish`

## Updated workflows
- `.github/workflows/all-tests.yml`
- `.github/workflows/modules-report-pr.yml`
- `.github/workflows/modules-snapshots-pr.yml`
- `.github/workflows/modules-weekly-v3.yml`

This keeps CI resilient across branches/PRs where the helper script may not be present.
