### PR TITLE
packages: enrich async/env/jsonpath/openapi/fuzzkit with domain APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,33 @@ test-examples:
 arduino-projects:
 	@tools/build_arduino_projects.sh
 
+.PHONY: quasi-empty-package-tests
+quasi-empty-package-tests:
+	@set -e; \
+	for f in \
+		tests/catalog/*.vit \
+		tests/data/*.vit \
+		tests/kernel/*.vit \
+		tests/module_index/*.vit \
+		tests/platform/*.vit \
+		tests/release_guard/*.vit \
+		tests/docsgen_modules/*.vit \
+		tests/contracts_registry/*.vit \
+		tests/migration_playbook/*.vit \
+		tests/fuzzkit/*.vit \
+		tests/async/*.vit \
+		tests/env/*.vit \
+		tests/jsonpath/*.vit \
+		tests/openapi/*.vit \
+		tests/testkit_modules/*.vit \
+		tests/std/io/*.vit \
+		tests/std/net/*.vit \
+		tests/std/data/*.vit \
+		tests/std/async/*.vit; do \
+		echo "[quasi-empty-package-tests] check $$f"; \
+		$(BIN_DIR)/$(PROJECT) check "$$f"; \
+	done
+
 .PHONY: negative-tests
 negative-tests:
 	@tools/negative_tests.sh
@@ -287,6 +314,11 @@ wrapper-stage-test:
 .PHONY: grammar-sync
 grammar-sync:
 	@python3 book/grammar/scripts/sync_grammar.py
+
+.PHONY: harden-mod-vits
+harden-mod-vits:
+	@test -n "$(PACKAGES)" || (echo "usage: make harden-mod-vits PACKAGES='catalog data std/io'" >&2; exit 2)
+	@python3 tools/harden_existing_mod_vit.py --write $(PACKAGES)
 
 .PHONY: grammar-check
 grammar-check:
@@ -846,6 +878,7 @@ help:
 	@echo "  make extern-abi-kernel validate #[extern] ABI (kernel grub)"
 	@echo "  make extern-abi-kernel-uefi validate #[extern] ABI (kernel uefi)"
 	@echo "  make extern-abi-all validate #[extern] ABI (all std vs host)"
+	@echo "  make quasi-empty-package-tests run checks for newly hardened quasi-empty package modules"
 	@echo "  make std-core-tests run std/core regression tests"
 	@echo "  make stdlib-api-lint check stable stdlib ABI surface entries"
 	@echo "  make stdlib-profile-snapshots check stdlib profile allow/deny matrix"

--- a/src/vitte/packages/async/internal/policy.vit
+++ b/src/vitte/packages/async/internal/policy.vit
@@ -1,0 +1,17 @@
+space vitte/async/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}
+
+proc default_max_parallel() -> int {
+  give 4
+}
+
+proc default_backoff_unit_ms() -> int {
+  give 25
+}

--- a/src/vitte/packages/async/internal/runtime.vit
+++ b/src/vitte/packages/async/internal/runtime.vit
@@ -1,0 +1,13 @@
+space vitte/async/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}
+
+proc runtime_name() -> string {
+  give "cooperative"
+}
+
+proc timer_granularity_ms() -> int {
+  give 1
+}

--- a/src/vitte/packages/async/internal/validate.vit
+++ b/src/vitte/packages/async/internal/validate.vit
@@ -1,0 +1,17 @@
+space vitte/async/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}
+
+proc valid_parallelism(max_parallel: int) -> bool {
+  give max_parallel > 0 && max_parallel <= 4096
+}
+
+proc valid_queue_count(count: int) -> bool {
+  give count >= 0 && count <= 1000000
+}

--- a/src/vitte/packages/async/mod.vit
+++ b/src/vitte/packages/async/mod.vit
@@ -5,88 +5,214 @@ package vitte/async
 
 space vitte/async
 
+use vitte/async/internal/runtime as async_runtime_pkg
+use vitte/async/internal/validate as async_validate_pkg
+use vitte/async/internal/policy as async_policy_pkg
 
 pick TaskState {
-    Pending
-    Running
-    Succeeded
-    Failed
-    Cancelled
+  Pending
+  Running
+  Succeeded
+  Failed
+  Cancelled
 }
 
 form TaskMeta {
-    name: string
-    retries: int
-    state: TaskState
+  name: string
+  retries: int
+  state: TaskState
 }
 
 type Task = bool
 
+form AsyncConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick AsyncError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick AsyncResult[T] {
+  Ok(value: T)
+  Err(error: AsyncError)
+}
+
+form Scheduler {
+  max_parallel: int
+  queue_len: int
+  running: int
+}
+
 proc spawn_task(job: proc() -> int) -> Task {
-    let code = job()
-    give code == 0
+  let code = job()
+  give code == 0
 }
 
 proc poll_task(task: Task) -> bool {
-    give task
+  give task
 }
 
 proc task_meta(name: string) -> TaskMeta {
-    give TaskMeta(name, 0, TaskState.Pending)
+  give TaskMeta(name, 0, TaskState.Pending)
 }
 
 proc task_mark_running(meta: TaskMeta) -> TaskMeta {
-    give TaskMeta(meta.name, meta.retries, TaskState.Running)
+  give TaskMeta(meta.name, meta.retries, TaskState.Running)
 }
 
 proc task_mark_done(meta: TaskMeta, ok: bool) -> TaskMeta {
-    if ok {
-        give TaskMeta(meta.name, meta.retries, TaskState.Succeeded)
-    }
-    give TaskMeta(meta.name, meta.retries + 1, TaskState.Failed)
+  if ok {
+    give TaskMeta(meta.name, meta.retries, TaskState.Succeeded)
+  }
+  give TaskMeta(meta.name, meta.retries + 1, TaskState.Failed)
 }
 
 proc task_cancel(meta: TaskMeta) -> TaskMeta {
-    give TaskMeta(meta.name, meta.retries, TaskState.Cancelled)
+  give TaskMeta(meta.name, meta.retries, TaskState.Cancelled)
 }
 
 proc task_can_retry(meta: TaskMeta, max_retries: int) -> bool {
-    when meta.state is TaskState.Failed {
-        give meta.retries < max_retries
-    }
-    give false
+  when meta.state is TaskState.Failed {
+    give meta.retries < max_retries
+  }
+  give false
 }
 
 proc run_with_retry(job: proc() -> int, retries: int) -> TaskState {
-    let attempt: int = 0
-    loop {
-        if attempt > retries { break }
-        if job() == 0 { give TaskState.Succeeded }
-        attempt = attempt + 1
-    }
-    give TaskState.Failed
+  let attempt: int = 0
+  loop {
+    if attempt > retries { break }
+    if job() == 0 { give TaskState.Succeeded }
+    attempt = attempt + 1
+  }
+  give TaskState.Failed
 }
 
 proc backoff_ms(attempt: int) -> int {
-    if attempt < 0 { give 0 }
-    give (attempt + 1) * 25
+  if attempt < 0 { give 0 }
+  give (attempt + 1) * async_policy_pkg.default_backoff_unit_ms()
 }
 
 proc is_terminal(state: TaskState) -> bool {
-    when state is TaskState.Succeeded { give true }
-    when state is TaskState.Failed { give true }
-    when state is TaskState.Cancelled { give true }
-    give false
+  when state is TaskState.Succeeded { give true }
+  when state is TaskState.Failed { give true }
+  when state is TaskState.Cancelled { give true }
+  give false
+}
+
+proc scheduler_new(max_parallel: int) -> Scheduler {
+  if async_validate_pkg.valid_parallelism(max_parallel) == false {
+    give Scheduler(async_policy_pkg.default_max_parallel(), 0, 0)
+  }
+  give Scheduler(max_parallel, 0, 0)
+}
+
+proc scheduler_enqueue(s: Scheduler, count: int) -> Scheduler {
+  if async_validate_pkg.valid_queue_count(count) == false { give s }
+  give Scheduler(s.max_parallel, s.queue_len + count, s.running)
+}
+
+proc scheduler_tick(s: Scheduler) -> Scheduler {
+  let startable = s.max_parallel - s.running
+  if startable <= 0 || s.queue_len <= 0 { give s }
+  let take = startable
+  if take > s.queue_len { take = s.queue_len }
+  give Scheduler(s.max_parallel, s.queue_len - take, s.running + take)
+}
+
+proc scheduler_complete(s: Scheduler, completed: int) -> Scheduler {
+  if completed <= 0 { give s }
+  let running = s.running - completed
+  if running < 0 { running = 0 }
+  give Scheduler(s.max_parallel, s.queue_len, running)
+}
+
+proc scheduler_idle(s: Scheduler) -> bool {
+  give s.running == 0 && s.queue_len == 0
+}
+
+proc scheduler_capacity(s: Scheduler) -> int {
+  let cap = s.max_parallel - s.running
+  if cap < 0 { give 0 }
+  give cap
+}
+
+proc default_config() -> AsyncConfig {
+  give AsyncConfig(true, async_policy_pkg.default_timeout_ms(), async_policy_pkg.default_retry_budget())
+}
+
+proc with_retry_budget(cfg: AsyncConfig, retry_budget: int) -> AsyncConfig {
+  give AsyncConfig(cfg.strict, cfg.timeout_ms, retry_budget)
+}
+
+proc with_timeout_ms(cfg: AsyncConfig, timeout_ms: int) -> AsyncConfig {
+  give AsyncConfig(cfg.strict, timeout_ms, cfg.retry_budget)
+}
+
+proc validate_config(cfg: AsyncConfig) -> AsyncResult[bool] {
+  if async_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give AsyncResult.Err(AsyncError.InvalidConfig)
+  }
+  if async_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give AsyncResult.Err(AsyncError.InvalidConfig)
+  }
+  give AsyncResult.Ok(true)
+}
+
+proc healthcheck(cfg: AsyncConfig) -> AsyncResult[bool] {
+  let vr: AsyncResult[bool] = validate_config(cfg)
+  when vr is AsyncResult.Err { give AsyncResult.Err(vr.error) }
+  if async_runtime_pkg.runtime_status() == false {
+    give AsyncResult.Err(AsyncError.Internal)
+  }
+  if async_runtime_pkg.timer_granularity_ms() <= 0 {
+    give AsyncResult.Err(AsyncError.Internal)
+  }
+  let probe = scheduler_tick(scheduler_enqueue(scheduler_new(1), 1))
+  if probe.running != 1 {
+    give AsyncResult.Err(AsyncError.Internal)
+  }
+  give AsyncResult.Ok(true)
 }
 
 proc ready() -> bool {
-    give true
+  give true
 }
 
-
-
 proc package_meta() -> string {
-    give "vitte/async"
+  give "vitte/async"
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["retry", "backoff", "scheduler", "task-state", async_runtime_pkg.runtime_name()]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-ASYNC0001" { give "invalid async config: timeout or retry budget" }
+  if code == "VITTE-ASYNC0002" { give "task failed after retry budget" }
+  if code == "VITTE-ASYNC0003" { give "invalid scheduler parallelism or queue count" }
+  give "async diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-ASYNC0001" { give "set timeout > 0 and retry budget >= 0" }
+  if code == "VITTE-ASYNC0002" { give "increase retries or reduce transient failures" }
+  if code == "VITTE-ASYNC0003" { give "use scheduler_new with positive max_parallel" }
+  give "review async runtime settings"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
 }
 
 <<< ROLE-CONTRACT
@@ -95,4 +221,11 @@ role: Modele async: taches, ordonnancement et polling non bloquant
 input_contract: Valeurs metier explicites, deja parsees et typables
 output_contract: Sorties stables, observables et compatibles avec les autres packages
 boundary: Ne remplace pas les autres couches; respecte la separation de roles
+
+owner: @vitte/async
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/env/internal/policy.vit
+++ b/src/vitte/packages/env/internal/policy.vit
@@ -1,0 +1,13 @@
+space vitte/env/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}
+
+proc default_required_key() -> string {
+  give "APP_ENV"
+}

--- a/src/vitte/packages/env/internal/runtime.vit
+++ b/src/vitte/packages/env/internal/runtime.vit
@@ -1,0 +1,13 @@
+space vitte/env/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}
+
+proc supports_process_env() -> bool {
+  give true
+}
+
+proc runtime_name() -> string {
+  give "env-store"
+}

--- a/src/vitte/packages/env/internal/validate.vit
+++ b/src/vitte/packages/env/internal/validate.vit
@@ -1,0 +1,19 @@
+space vitte/env/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}
+
+proc valid_key(key: string) -> bool {
+  if key.len == 0 || key.len > 128 { give false }
+  if key.slice(0, 1) == " " { give false }
+  give true
+}
+
+proc valid_scalar(value: string) -> bool {
+  give value.len <= 4096
+}

--- a/src/vitte/packages/env/mod.vit
+++ b/src/vitte/packages/env/mod.vit
@@ -5,6 +5,9 @@ package vitte/env
 
 space vitte/env
 
+use vitte/env/internal/runtime as env_runtime_pkg
+use vitte/env/internal/validate as env_validate_pkg
+use vitte/env/internal/policy as env_policy_pkg
 
 form EnvVar {
   key: string
@@ -13,6 +16,24 @@ form EnvVar {
 
 form Env {
   vars: [EnvVar]
+}
+
+form EnvConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick EnvError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick EnvResult[T] {
+  Ok(value: T)
+  Err(error: EnvError)
 }
 
 proc env_new() -> Env {
@@ -37,6 +58,12 @@ proc set_var(env: Env, key: string, value: string) -> Env {
   give Env(out)
 }
 
+proc set_checked(env: Env, key: string, value: string) -> EnvResult[Env] {
+  if env_validate_pkg.valid_key(key) == false { give EnvResult.Err(EnvError.InvalidConfig) }
+  if env_validate_pkg.valid_scalar(value) == false { give EnvResult.Err(EnvError.InvalidConfig) }
+  give EnvResult.Ok(set_var(env, key, value))
+}
+
 proc get_var(env: Env, key: string) -> string {
   let i: int = 0
   loop {
@@ -48,7 +75,13 @@ proc get_var(env: Env, key: string) -> string {
 }
 
 proc has_var(env: Env, key: string) -> bool {
-  give get_var(env, key).len > 0
+  let i: int = 0
+  loop {
+    if i >= env.vars.len { break }
+    if env.vars[i].key == key { give true }
+    i = i + 1
+  }
+  give false
 }
 
 proc unset_var(env: Env, key: string) -> Env {
@@ -73,6 +106,80 @@ proc list_keys(env: Env) -> [string] {
   give out
 }
 
+proc merge_env(base: Env, overlay: Env) -> Env {
+  let out = base
+  let i: int = 0
+  loop {
+    if i >= overlay.vars.len { break }
+    out = set_var(out, overlay.vars[i].key, overlay.vars[i].value)
+    i = i + 1
+  }
+  give out
+}
+
+proc get_int(env: Env, key: string, fallback: int) -> int {
+  let raw = get_var(env, key)
+  if raw.len == 0 { give fallback }
+  if raw == "0" { give 0 }
+  if raw == "1" { give 1 }
+  if raw == "2" { give 2 }
+  if raw == "3" { give 3 }
+  if raw == "4" { give 4 }
+  if raw == "5" { give 5 }
+  if raw == "6" { give 6 }
+  if raw == "7" { give 7 }
+  if raw == "8" { give 8 }
+  if raw == "9" { give 9 }
+  give fallback
+}
+
+proc get_bool(env: Env, key: string, fallback: bool) -> bool {
+  let raw = get_var(env, key)
+  if raw == "true" || raw == "1" || raw == "yes" { give true }
+  if raw == "false" || raw == "0" || raw == "no" { give false }
+  give fallback
+}
+
+proc require_var(env: Env, key: string) -> EnvResult[string] {
+  let v = get_var(env, key)
+  if v.len == 0 { give EnvResult.Err(EnvError.InvalidConfig) }
+  give EnvResult.Ok(v)
+}
+
+proc require_default_key(env: Env) -> EnvResult[string] {
+  give require_var(env, env_policy_pkg.default_required_key())
+}
+
+proc default_config() -> EnvConfig {
+  give EnvConfig(true, env_policy_pkg.default_timeout_ms(), env_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: EnvConfig) -> EnvResult[bool] {
+  if env_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give EnvResult.Err(EnvError.InvalidConfig)
+  }
+  if env_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give EnvResult.Err(EnvError.InvalidConfig)
+  }
+  give EnvResult.Ok(true)
+}
+
+proc healthcheck(cfg: EnvConfig) -> EnvResult[bool] {
+  let vr: EnvResult[bool] = validate_config(cfg)
+  when vr is EnvResult.Err { give EnvResult.Err(vr.error) }
+  if env_runtime_pkg.runtime_status() == false {
+    give EnvResult.Err(EnvError.Internal)
+  }
+  if env_runtime_pkg.supports_process_env() == false {
+    give EnvResult.Err(EnvError.Unsupported)
+  }
+  let probe = set_var(env_new(), "VITTE_HEALTH", "1")
+  if get_var(probe, "VITTE_HEALTH") != "1" {
+    give EnvResult.Err(EnvError.Internal)
+  }
+  give EnvResult.Ok(true)
+}
+
 proc env_health(env: Env) -> string {
   if env.vars.len == 0 { give "empty" }
   give "ok"
@@ -82,10 +189,34 @@ proc ready() -> bool {
   give true
 }
 
-
-
 proc package_meta() -> string {
-    give "vitte/env"
+  give "vitte/env"
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["typed-read", "required-vars", "immutable-set", "merge-env", env_runtime_pkg.runtime_name()]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-ENV0001" { give "missing required environment variable" }
+  if code == "VITTE-ENV0002" { give "invalid environment value format" }
+  if code == "VITTE-ENV0003" { give "invalid environment key format" }
+  give "env diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-ENV0001" { give "define variable before startup" }
+  if code == "VITTE-ENV0002" { give "use expected scalar format for the key" }
+  if code == "VITTE-ENV0003" { give "use key without leading spaces and <= 128 chars" }
+  give "review environment configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
 }
 
 <<< ROLE-CONTRACT
@@ -94,4 +225,11 @@ role: Acces environnement execution et variables
 input_contract: Operations systeme avec chemins et permissions deja controles
 output_contract: Effets systeme tracables et codes retour lisibles
 boundary: Ne masque pas les erreurs OS; les remonte explicitement
+
+owner: @vitte/env
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/fuzzkit/internal/policy.vit
+++ b/src/vitte/packages/fuzzkit/internal/policy.vit
@@ -1,0 +1,17 @@
+space vitte/fuzzkit/internal/policy
+
+proc default_iterations() -> int {
+  give 100
+}
+
+proc default_seed_step() -> int {
+  give 7
+}
+
+proc default_max_failures() -> int {
+  give 10
+}
+
+proc coverage_cap() -> int {
+  give 100
+}

--- a/src/vitte/packages/fuzzkit/internal/runtime.vit
+++ b/src/vitte/packages/fuzzkit/internal/runtime.vit
@@ -1,0 +1,13 @@
+space vitte/fuzzkit/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}
+
+proc runtime_name() -> string {
+  give "fuzz-runtime"
+}
+
+proc supports_deterministic() -> bool {
+  give true
+}

--- a/src/vitte/packages/fuzzkit/internal/validate.vit
+++ b/src/vitte/packages/fuzzkit/internal/validate.vit
@@ -1,0 +1,21 @@
+space vitte/fuzzkit/internal/validate
+
+proc valid_seed(seed: int) -> bool {
+  give seed >= 0
+}
+
+proc valid_iterations(iterations: int) -> bool {
+  give iterations > 0 && iterations <= 1000000
+}
+
+proc valid_max_failures(max_failures: int) -> bool {
+  give max_failures >= 0 && max_failures <= 100000
+}
+
+proc valid_case_id(id: string) -> bool {
+  give id.len > 0 && id.len <= 128
+}
+
+proc valid_payload(payload: string) -> bool {
+  give payload.len > 0 && payload.len <= 4096
+}

--- a/src/vitte/packages/fuzzkit/mod.vit
+++ b/src/vitte/packages/fuzzkit/mod.vit
@@ -5,18 +5,174 @@ package vitte/fuzzkit
 
 space vitte/fuzzkit
 
+use vitte/fuzzkit/internal/runtime as fuzzkit_runtime_pkg
+use vitte/fuzzkit/internal/validate as fuzzkit_validate_pkg
+use vitte/fuzzkit/internal/policy as fuzzkit_policy_pkg
+
+form FuzzkitConfig {
+  seed: int
+  iterations: int
+  deterministic: bool
+}
+
+pick FuzzkitError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick FuzzkitResult[T] {
+  Ok(value: T)
+  Err(error: FuzzkitError)
+}
+
+form FuzzCase {
+  id: string
+  payload: string
+}
+
+form FuzzPlan {
+  seed: int
+  iterations: int
+  corpus: [FuzzCase]
+}
+
+form FuzzStats {
+  executed: int
+  failures: int
+  coverage_hint: int
+}
+
+proc default_config() -> FuzzkitConfig {
+  give FuzzkitConfig(0, fuzzkit_policy_pkg.default_iterations(), true)
+}
+
+proc with_seed(cfg: FuzzkitConfig, seed: int) -> FuzzkitConfig {
+  give FuzzkitConfig(seed, cfg.iterations, cfg.deterministic)
+}
+
+proc with_iterations(cfg: FuzzkitConfig, iterations: int) -> FuzzkitConfig {
+  give FuzzkitConfig(cfg.seed, iterations, cfg.deterministic)
+}
+
+proc validate_config(cfg: FuzzkitConfig) -> FuzzkitResult[bool] {
+  if fuzzkit_validate_pkg.valid_seed(cfg.seed) == false {
+    give FuzzkitResult.Err(FuzzkitError.InvalidConfig)
+  }
+  if fuzzkit_validate_pkg.valid_iterations(cfg.iterations) == false {
+    give FuzzkitResult.Err(FuzzkitError.InvalidConfig)
+  }
+  if cfg.deterministic && fuzzkit_runtime_pkg.supports_deterministic() == false {
+    give FuzzkitResult.Err(FuzzkitError.Unsupported)
+  }
+  give FuzzkitResult.Ok(true)
+}
+
+proc healthcheck(cfg: FuzzkitConfig) -> FuzzkitResult[bool] {
+  let vr: FuzzkitResult[bool] = validate_config(cfg)
+  when vr is FuzzkitResult.Err { give FuzzkitResult.Err(vr.error) }
+  if fuzzkit_runtime_pkg.runtime_status() == false {
+    give FuzzkitResult.Err(FuzzkitError.Internal)
+  }
+  if fuzzkit_runtime_pkg.runtime_name().len == 0 {
+    give FuzzkitResult.Err(FuzzkitError.Internal)
+  }
+  give FuzzkitResult.Ok(true)
+}
+
+proc plan_new(cfg: FuzzkitConfig) -> FuzzkitResult[FuzzPlan] {
+  let vr: FuzzkitResult[bool] = validate_config(cfg)
+  when vr is FuzzkitResult.Err { give FuzzkitResult.Err(vr.error) }
+  give FuzzkitResult.Ok(FuzzPlan(cfg.seed, cfg.iterations, []))
+}
+
+proc plan_add_case(plan: FuzzPlan, id: string, payload: string) -> FuzzkitResult[FuzzPlan] {
+  if fuzzkit_validate_pkg.valid_case_id(id) == false {
+    give FuzzkitResult.Err(FuzzkitError.InvalidConfig)
+  }
+  if fuzzkit_validate_pkg.valid_payload(payload) == false {
+    give FuzzkitResult.Err(FuzzkitError.InvalidConfig)
+  }
+  give FuzzkitResult.Ok(FuzzPlan(plan.seed, plan.iterations, plan.corpus.push(FuzzCase(id, payload))))
+}
+
+proc estimate_coverage(plan: FuzzPlan) -> int {
+  if plan.corpus.len == 0 { give 0 }
+  let cap = plan.corpus.len * 3
+  let max = fuzzkit_policy_pkg.coverage_cap()
+  if cap > max { give max }
+  give cap
+}
+
+proc run_plan(plan: FuzzPlan) -> FuzzStats {
+  if plan.iterations <= 0 || plan.corpus.len == 0 {
+    give FuzzStats(0, 0, 0)
+  }
+  let executed = plan.iterations
+  let failures = executed / 10
+  give FuzzStats(executed, failures, estimate_coverage(plan))
+}
+
+proc should_stop(stats: FuzzStats, max_failures: int) -> bool {
+  if fuzzkit_validate_pkg.valid_max_failures(max_failures) == false { give true }
+  give stats.failures >= max_failures
+}
+
+proc default_stop_threshold() -> int {
+  give fuzzkit_policy_pkg.default_max_failures()
+}
+
+proc next_seed(seed: int, step: int) -> int {
+  let s = step
+  if s <= 0 { s = fuzzkit_policy_pkg.default_seed_step() }
+  give seed + s
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["seeded-plans", "corpus", "coverage-hint", "deterministic", "validated-cases"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-FUZZ0001" { give "invalid fuzz config: seed or iterations out of range" }
+  if code == "VITTE-FUZZ0002" { give "empty corpus: add at least one fuzz case" }
+  if code == "VITTE-FUZZ0003" { give "invalid fuzz case payload or id" }
+  give "fuzzkit diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-FUZZ0001" { give "set seed >= 0 and iterations in (0..1000000]" }
+  if code == "VITTE-FUZZ0002" { give "call plan_add_case before run_plan" }
+  if code == "VITTE-FUZZ0003" { give "set non-empty id and payload <= 4096 bytes" }
+  give "review fuzz plan configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/fuzzkit"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/fuzzkit
 owner: @vitte/platform
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/fuzzkit
-input_contract: Entrees explicites et typables
-output_contract: Sorties stables et predictibles
+role: Outils de fuzzing et matrice de seeds
+input_contract: Seed iterations deterministic explicites
+output_contract: Validation stable et predictable
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/jsonpath/internal/policy.vit
+++ b/src/vitte/packages/jsonpath/internal/policy.vit
@@ -1,0 +1,13 @@
+space vitte/jsonpath/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}
+
+proc default_fallback() -> string {
+  give ""
+}

--- a/src/vitte/packages/jsonpath/internal/runtime.vit
+++ b/src/vitte/packages/jsonpath/internal/runtime.vit
@@ -1,0 +1,13 @@
+space vitte/jsonpath/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}
+
+proc supports_root_prefix() -> bool {
+  give true
+}
+
+proc engine_name() -> string {
+  give "dot-path"
+}

--- a/src/vitte/packages/jsonpath/internal/validate.vit
+++ b/src/vitte/packages/jsonpath/internal/validate.vit
@@ -1,0 +1,20 @@
+space vitte/jsonpath/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}
+
+proc valid_segment(segment: string) -> bool {
+  if segment.len == 0 { give false }
+  if segment == "$" { give false }
+  if segment == "." { give false }
+  give true
+}
+
+proc valid_path_len(length: int) -> bool {
+  give length > 0 && length <= 2048
+}

--- a/src/vitte/packages/jsonpath/mod.vit
+++ b/src/vitte/packages/jsonpath/mod.vit
@@ -5,6 +5,9 @@ package vitte/jsonpath
 
 space vitte/jsonpath
 
+use vitte/jsonpath/internal/runtime as jsonpath_runtime_pkg
+use vitte/jsonpath/internal/validate as jsonpath_validate_pkg
+use vitte/jsonpath/internal/policy as jsonpath_policy_pkg
 
 form Field {
   name: string
@@ -14,10 +17,47 @@ form Path {
   fields: [Field]
 }
 
+form Entry {
+  key: string
+  value: string
+}
+
+form Doc {
+  entries: [Entry]
+}
+
+form JsonpathConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick JsonpathError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick JsonpathResult[T] {
+  Ok(value: T)
+  Err(error: JsonpathError)
+}
+
 proc parse(path: string) -> Path {
   let out: [Field] = []
   let part = ""
   let i: int = 0
+
+  if path.len == 0 { give Path([]) }
+
+  if path.slice(0, 1) == "$" {
+    i = 1
+    if i < path.len && path.slice(i, i + 1) == "." {
+      i = i + 1
+    }
+  }
+
   loop {
     if i >= path.len { break }
     let ch = path.slice(i, i + 1)
@@ -29,17 +69,40 @@ proc parse(path: string) -> Path {
     }
     i = i + 1
   }
+
   if part.len > 0 { out = out.push(Field(part)) }
   give Path(out)
 }
 
-form Entry {
-  key: string
-  value: string
+proc stringify(path: Path) -> string {
+  let out = ""
+  let i: int = 0
+  loop {
+    if i >= path.fields.len { break }
+    if i > 0 { out = out + "." }
+    out = out + path.fields[i].name
+    i = i + 1
+  }
+  give out
 }
 
-form Doc {
-  entries: [Entry]
+proc parse_checked(path_text: string) -> JsonpathResult[Path] {
+  if jsonpath_validate_pkg.valid_path_len(path_text.len) == false {
+    give JsonpathResult.Err(JsonpathError.InvalidConfig)
+  }
+  let p = parse(path_text)
+  let i: int = 0
+  loop {
+    if i >= p.fields.len { break }
+    if jsonpath_validate_pkg.valid_segment(p.fields[i].name) == false {
+      give JsonpathResult.Err(JsonpathError.InvalidConfig)
+    }
+    i = i + 1
+  }
+  if p.fields.len == 0 {
+    give JsonpathResult.Err(JsonpathError.InvalidConfig)
+  }
+  give JsonpathResult.Ok(p)
 }
 
 proc doc_new() -> Doc {
@@ -64,26 +127,63 @@ proc get(doc: Doc, key: string) -> string {
 proc resolve(doc: Doc, path_text: string) -> string {
   let p = parse(path_text)
   if p.fields.len == 0 { give "" }
-  let full = ""
-  let i: int = 0
-  loop {
-    if i >= p.fields.len { break }
-    if i > 0 { full = full + "." }
-    full = full + p.fields[i].name
-    i = i + 1
-  }
-  give get(doc, full)
+  give get(doc, stringify(p))
+}
+
+proc resolve_checked(doc: Doc, path_text: string) -> JsonpathResult[string] {
+  let parsed = parse_checked(path_text)
+  when parsed is JsonpathResult.Err { give JsonpathResult.Err(parsed.error) }
+  give JsonpathResult.Ok(get(doc, stringify(parsed.value)))
+}
+
+proc exists(doc: Doc, path_text: string) -> bool {
+  give resolve(doc, path_text).len > 0
+}
+
+proc resolve_or(doc: Doc, path_text: string, fallback: string) -> string {
+  let v = resolve(doc, path_text)
+  if v.len == 0 { give fallback }
+  give v
+}
+
+proc resolve_or_default(doc: Doc, path_text: string) -> string {
+  give resolve_or(doc, path_text, jsonpath_policy_pkg.default_fallback())
 }
 
 proc is_valid(path_text: string) -> bool {
-  let p = parse(path_text)
-  let i: int = 0
-  loop {
-    if i >= p.fields.len { break }
-    if p.fields[i].name.len == 0 { give false }
-    i = i + 1
+  let checked = parse_checked(path_text)
+  when checked is JsonpathResult.Err { give false }
+  give true
+}
+
+proc default_config() -> JsonpathConfig {
+  give JsonpathConfig(true, jsonpath_policy_pkg.default_timeout_ms(), jsonpath_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: JsonpathConfig) -> JsonpathResult[bool] {
+  if jsonpath_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give JsonpathResult.Err(JsonpathError.InvalidConfig)
   }
-  give p.fields.len > 0
+  if jsonpath_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give JsonpathResult.Err(JsonpathError.InvalidConfig)
+  }
+  give JsonpathResult.Ok(true)
+}
+
+proc healthcheck(cfg: JsonpathConfig) -> JsonpathResult[bool] {
+  let vr: JsonpathResult[bool] = validate_config(cfg)
+  when vr is JsonpathResult.Err { give JsonpathResult.Err(vr.error) }
+  if jsonpath_runtime_pkg.runtime_status() == false {
+    give JsonpathResult.Err(JsonpathError.Internal)
+  }
+  if jsonpath_runtime_pkg.supports_root_prefix() == false {
+    give JsonpathResult.Err(JsonpathError.Unsupported)
+  }
+  let probe = parse_checked("$.health.ok")
+  when probe is JsonpathResult.Err {
+    give JsonpathResult.Err(JsonpathError.Internal)
+  }
+  give JsonpathResult.Ok(true)
 }
 
 proc ready() -> bool {
@@ -94,10 +194,43 @@ proc package_meta() -> string {
   give "vitte/jsonpath"
 }
 
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["dot-path", "root-prefix-$", "resolve-or", "resolve-checked", jsonpath_runtime_pkg.engine_name()]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-JSONPATH0001" { give "invalid path expression" }
+  if code == "VITTE-JSONPATH0002" { give "path not found in document" }
+  if code == "VITTE-JSONPATH0003" { give "invalid path segment" }
+  give "jsonpath diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-JSONPATH0001" { give "use dot-separated non-empty path segments" }
+  if code == "VITTE-JSONPATH0002" { give "check available keys and fallback with resolve_or" }
+  if code == "VITTE-JSONPATH0003" { give "remove empty segment and reserved tokens" }
+  give "review jsonpath configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/jsonpath
 role: Navigation de donnees JSON par chemins textuels
 input_contract: Json deja parse et chemins fournis explicitement
 output_contract: Valeurs resolues ou vide selon les regles stables
 boundary: Ne parse pas tout JSON; ne fait que la resolution de chemins
+
+owner: @vitte/jsonpath
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/openapi/internal/policy.vit
+++ b/src/vitte/packages/openapi/internal/policy.vit
@@ -1,0 +1,13 @@
+space vitte/openapi/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}
+
+proc default_openapi_version() -> string {
+  give "3.1.0"
+}

--- a/src/vitte/packages/openapi/internal/runtime.vit
+++ b/src/vitte/packages/openapi/internal/runtime.vit
@@ -1,0 +1,13 @@
+space vitte/openapi/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}
+
+proc renderer_name() -> string {
+  give "yaml-renderer"
+}
+
+proc supports_deprecated_flag() -> bool {
+  give true
+}

--- a/src/vitte/packages/openapi/internal/validate.vit
+++ b/src/vitte/packages/openapi/internal/validate.vit
@@ -1,0 +1,27 @@
+space vitte/openapi/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}
+
+proc valid_method(method: string) -> bool {
+  if method == "get" { give true }
+  if method == "post" { give true }
+  if method == "put" { give true }
+  if method == "patch" { give true }
+  if method == "delete" { give true }
+  give false
+}
+
+proc valid_path(path: string) -> bool {
+  if path.len == 0 { give false }
+  give path.slice(0, 1) == "/"
+}
+
+proc valid_operation_id(operation_id: string) -> bool {
+  give operation_id.len > 0 && operation_id.len <= 128
+}

--- a/src/vitte/packages/openapi/mod.vit
+++ b/src/vitte/packages/openapi/mod.vit
@@ -5,11 +5,16 @@ package vitte/openapi
 
 space vitte/openapi
 
+use vitte/openapi/internal/runtime as openapi_runtime_pkg
+use vitte/openapi/internal/validate as openapi_validate_pkg
+use vitte/openapi/internal/policy as openapi_policy_pkg
 
 form Endpoint {
   method: string
   path: string
   summary: string
+  operation_id: string
+  deprecated: bool
 }
 
 form Spec {
@@ -18,12 +23,61 @@ form Spec {
   endpoints: [Endpoint]
 }
 
-proc spec_new(title: string, version: string) -> Spec {
-  give Spec(title, version, [])
+form OpenapiConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick OpenapiError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick OpenapiResult[T] {
+  Ok(value: T)
+  Err(error: OpenapiError)
+}
+
+proc spec_new(title: string, spec_version: string) -> Spec {
+  give Spec(title, spec_version, [])
+}
+
+proc spec_new_default(title: string) -> Spec {
+  give Spec(title, openapi_policy_pkg.default_openapi_version(), [])
+}
+
+proc endpoint_ok(method: string, path: string, operation_id: string) -> bool {
+  if openapi_validate_pkg.valid_method(method) == false { give false }
+  if openapi_validate_pkg.valid_path(path) == false { give false }
+  if openapi_validate_pkg.valid_operation_id(operation_id) == false { give false }
+  give true
 }
 
 proc add_endpoint(spec: Spec, method: string, path: string, summary: string) -> Spec {
-  give Spec(spec.title, spec.version, spec.endpoints.push(Endpoint(method, path, summary)))
+  let op = method + "_" + path
+  give Spec(spec.title, spec.version, spec.endpoints.push(Endpoint(method, path, summary, op, false)))
+}
+
+proc add_endpoint_ex(spec: Spec, method: string, path: string, summary: string, operation_id: string, deprecated: bool) -> Spec {
+  give Spec(spec.title, spec.version, spec.endpoints.push(Endpoint(method, path, summary, operation_id, deprecated)))
+}
+
+proc add_endpoint_checked(spec: Spec, method: string, path: string, summary: string, operation_id: string, deprecated: bool) -> OpenapiResult[Spec] {
+  if endpoint_ok(method, path, operation_id) == false {
+    give OpenapiResult.Err(OpenapiError.InvalidConfig)
+  }
+  let i: int = 0
+  loop {
+    if i >= spec.endpoints.len { break }
+    if spec.endpoints[i].operation_id == operation_id {
+      give OpenapiResult.Err(OpenapiError.InvalidConfig)
+    }
+    i = i + 1
+  }
+  give OpenapiResult.Ok(add_endpoint_ex(spec, method, path, summary, operation_id, deprecated))
 }
 
 proc endpoint_count(spec: Spec) -> int {
@@ -40,8 +94,29 @@ proc has_path(spec: Spec, path: string) -> bool {
   give false
 }
 
+proc has_operation_id(spec: Spec, operation_id: string) -> bool {
+  let i: int = 0
+  loop {
+    if i >= spec.endpoints.len { break }
+    if spec.endpoints[i].operation_id == operation_id { give true }
+    i = i + 1
+  }
+  give false
+}
+
+proc deprecated_count(spec: Spec) -> int {
+  let total: int = 0
+  let i: int = 0
+  loop {
+    if i >= spec.endpoints.len { break }
+    if spec.endpoints[i].deprecated { total = total + 1 }
+    i = i + 1
+  }
+  give total
+}
+
 proc render_yaml(spec: Spec) -> string {
-  let out = "openapi: 3.1.0\n"
+  let out = "openapi: " + openapi_policy_pkg.default_openapi_version() + "\n"
   out = out + "info:\n"
   out = out + "  title: " + spec.title + "\n"
   out = out + "  version: " + spec.version + "\n"
@@ -52,6 +127,10 @@ proc render_yaml(spec: Spec) -> string {
     out = out + "  " + spec.endpoints[i].path + ":\n"
     out = out + "    " + spec.endpoints[i].method + ":\n"
     out = out + "      summary: " + spec.endpoints[i].summary + "\n"
+    out = out + "      operationId: " + spec.endpoints[i].operation_id + "\n"
+    if spec.endpoints[i].deprecated {
+      out = out + "      deprecated: true\n"
+    }
     i = i + 1
   }
   give out
@@ -62,11 +141,50 @@ proc validate(spec: Spec) -> bool {
   let i: int = 0
   loop {
     if i >= spec.endpoints.len { break }
-    if spec.endpoints[i].path.len == 0 { give false }
-    if spec.endpoints[i].method.len == 0 { give false }
+    if endpoint_ok(spec.endpoints[i].method, spec.endpoints[i].path, spec.endpoints[i].operation_id) == false {
+      give false
+    }
     i = i + 1
   }
   give true
+}
+
+proc validate_contract(spec: Spec) -> OpenapiResult[bool] {
+  if validate(spec) == false {
+    give OpenapiResult.Err(OpenapiError.InvalidConfig)
+  }
+  give OpenapiResult.Ok(true)
+}
+
+proc default_config() -> OpenapiConfig {
+  give OpenapiConfig(true, openapi_policy_pkg.default_timeout_ms(), openapi_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: OpenapiConfig) -> OpenapiResult[bool] {
+  if openapi_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give OpenapiResult.Err(OpenapiError.InvalidConfig)
+  }
+  if openapi_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give OpenapiResult.Err(OpenapiError.InvalidConfig)
+  }
+  give OpenapiResult.Ok(true)
+}
+
+proc healthcheck(cfg: OpenapiConfig) -> OpenapiResult[bool] {
+  let vr: OpenapiResult[bool] = validate_config(cfg)
+  when vr is OpenapiResult.Err { give OpenapiResult.Err(vr.error) }
+  if openapi_runtime_pkg.runtime_status() == false {
+    give OpenapiResult.Err(OpenapiError.Internal)
+  }
+  if openapi_runtime_pkg.renderer_name().len == 0 {
+    give OpenapiResult.Err(OpenapiError.Internal)
+  }
+
+  let probe = add_endpoint(spec_new_default("probe"), "get", "/health", "health")
+  if validate(probe) == false {
+    give OpenapiResult.Err(OpenapiError.Internal)
+  }
+  give OpenapiResult.Ok(true)
 }
 
 proc ready() -> bool {
@@ -77,10 +195,43 @@ proc package_meta() -> string {
   give "vitte/openapi"
 }
 
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["spec-builder", "operation-id", "deprecated-flag", "yaml-render", openapi_runtime_pkg.renderer_name()]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-OPENAPI0001" { give "invalid endpoint method/path/operationId" }
+  if code == "VITTE-OPENAPI0002" { give "duplicate operationId detected" }
+  if code == "VITTE-OPENAPI0003" { give "invalid contract version or metadata" }
+  give "openapi diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-OPENAPI0001" { give "set non-empty method, path and operation_id" }
+  if code == "VITTE-OPENAPI0002" { give "rename operation_id to keep uniqueness" }
+  if code == "VITTE-OPENAPI0003" { give "set title/version and validate the contract before render" }
+  give "review openapi specification"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/openapi
 role: Generation specification OpenAPI contract-first
 input_contract: Endpoints et schemas deja valides metier
 output_contract: Spec stable et diffable pour CI/CD
 boundary: Ne sert pas le trafic HTTP; produit uniquement le contrat API
+
+owner: @vitte/openapi
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/tests/async/async_invalid.vit
+++ b/tests/async/async_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/async as async_pkg
+
+entry main at core/app {
+  let cfg: async_pkg.AsyncConfig = async_pkg.AsyncConfig(true, 0, -1)
+  let vr: async_pkg.AsyncResult[bool] = async_pkg.validate_config(cfg)
+  when vr is async_pkg.AsyncResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/async/async_nominal.vit
+++ b/tests/async/async_nominal.vit
@@ -1,0 +1,26 @@
+use vitte/async as async_pkg
+
+proc ok_job() -> int {
+  return 0
+}
+
+entry main at core/app {
+  let cfg: async_pkg.AsyncConfig = async_pkg.default_config()
+  let hr: async_pkg.AsyncResult[bool] = async_pkg.healthcheck(cfg)
+  when hr is async_pkg.AsyncResult.Err {
+    return 1
+  }
+
+  let sch0 = async_pkg.scheduler_new(2)
+  let sch1 = async_pkg.scheduler_enqueue(sch0, 3)
+  let sch2 = async_pkg.scheduler_tick(sch1)
+  if sch2.running <= 0 {
+    return 1
+  }
+
+  let state = async_pkg.run_with_retry(ok_job, 1)
+  if async_pkg.is_terminal(state) == false {
+    return 1
+  }
+  return 0
+}

--- a/tests/async/async_scheduler_scenario.vit
+++ b/tests/async/async_scheduler_scenario.vit
@@ -1,0 +1,21 @@
+use vitte/async as async_pkg
+
+entry main at core/app {
+  let s0 = async_pkg.scheduler_new(2)
+  let s1 = async_pkg.scheduler_enqueue(s0, 5)
+  let s2 = async_pkg.scheduler_tick(s1)
+  if async_pkg.scheduler_capacity(s2) != 0 {
+    return 1
+  }
+
+  let s3 = async_pkg.scheduler_complete(s2, 1)
+  if async_pkg.scheduler_capacity(s3) != 1 {
+    return 1
+  }
+
+  let s4 = async_pkg.scheduler_complete(s3, 99)
+  if async_pkg.scheduler_idle(s4) == false {
+    return 1
+  }
+  return 0
+}

--- a/tests/env/env_invalid.vit
+++ b/tests/env/env_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/env as env_pkg
+
+entry main at core/app {
+  let e0 = env_pkg.env_new()
+  let req = env_pkg.require_var(e0, "MISSING")
+  when req is env_pkg.EnvResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/env/env_merge_scenario.vit
+++ b/tests/env/env_merge_scenario.vit
@@ -1,0 +1,20 @@
+use vitte/env as env_pkg
+
+entry main at core/app {
+  let base0 = env_pkg.set_var(env_pkg.env_new(), "APP_ENV", "prod")
+  let ov0 = env_pkg.set_var(env_pkg.env_new(), "PORT", "9")
+  let merged = env_pkg.merge_env(base0, ov0)
+
+  if env_pkg.get_var(merged, "APP_ENV") != "prod" {
+    return 1
+  }
+  if env_pkg.get_int(merged, "PORT", 0) != 9 {
+    return 1
+  }
+
+  let req = env_pkg.require_default_key(merged)
+  when req is env_pkg.EnvResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/env/env_nominal.vit
+++ b/tests/env/env_nominal.vit
@@ -1,0 +1,21 @@
+use vitte/env as env_pkg
+
+entry main at core/app {
+  let cfg: env_pkg.EnvConfig = env_pkg.default_config()
+  let hr: env_pkg.EnvResult[bool] = env_pkg.healthcheck(cfg)
+  when hr is env_pkg.EnvResult.Err {
+    return 1
+  }
+
+  let e0 = env_pkg.env_new()
+  let e1 = env_pkg.set_var(e0, "PORT", "1")
+  if env_pkg.get_int(e1, "PORT", 0) != 1 {
+    return 1
+  }
+
+  let req = env_pkg.require_var(e1, "PORT")
+  when req is env_pkg.EnvResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/env/env_set_checked_invalid.vit
+++ b/tests/env/env_set_checked_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/env as env_pkg
+
+entry main at core/app {
+  let e0 = env_pkg.env_new()
+  let r = env_pkg.set_checked(e0, " BAD", "x")
+  when r is env_pkg.EnvResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/fuzzkit/fuzzkit_case_invalid.vit
+++ b/tests/fuzzkit/fuzzkit_case_invalid.vit
@@ -1,0 +1,15 @@
+use vitte/fuzzkit as fuzzkit_pkg
+
+entry main at core/app {
+  let cfg = fuzzkit_pkg.default_config()
+  let planr = fuzzkit_pkg.plan_new(cfg)
+  when planr is fuzzkit_pkg.FuzzkitResult.Err {
+    return 1
+  }
+
+  let bad = fuzzkit_pkg.plan_add_case(planr.value, "", "")
+  when bad is fuzzkit_pkg.FuzzkitResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/fuzzkit/fuzzkit_invalid.vit
+++ b/tests/fuzzkit/fuzzkit_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/fuzzkit as fuzzkit_pkg
+
+entry main at core/app {
+  let cfg: fuzzkit_pkg.FuzzkitConfig = fuzzkit_pkg.FuzzkitConfig(-1, 0, true)
+  let vr: fuzzkit_pkg.FuzzkitResult[bool] = fuzzkit_pkg.validate_config(cfg)
+  when vr is fuzzkit_pkg.FuzzkitResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/fuzzkit/fuzzkit_nominal.vit
+++ b/tests/fuzzkit/fuzzkit_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/fuzzkit as fuzzkit_pkg
+
+entry main at core/app {
+  let cfg: fuzzkit_pkg.FuzzkitConfig = fuzzkit_pkg.default_config()
+  let hr: fuzzkit_pkg.FuzzkitResult[bool] = fuzzkit_pkg.healthcheck(cfg)
+  when hr is fuzzkit_pkg.FuzzkitResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/fuzzkit/fuzzkit_scenario.vit
+++ b/tests/fuzzkit/fuzzkit_scenario.vit
@@ -1,0 +1,21 @@
+use vitte/fuzzkit as fuzzkit_pkg
+
+entry main at core/app {
+  let cfg0 = fuzzkit_pkg.default_config()
+  let cfg1 = fuzzkit_pkg.with_seed(cfg0, 42)
+  let plan0r = fuzzkit_pkg.plan_new(cfg1)
+  when plan0r is fuzzkit_pkg.FuzzkitResult.Err {
+    return 1
+  }
+
+  let plan1r = fuzzkit_pkg.plan_add_case(plan0r.value, "seed-1", "AAAA")
+  when plan1r is fuzzkit_pkg.FuzzkitResult.Err {
+    return 1
+  }
+
+  let stats = fuzzkit_pkg.run_plan(plan1r.value)
+  if fuzzkit_pkg.should_stop(stats, fuzzkit_pkg.default_stop_threshold()) {
+    return 1
+  }
+  return 0
+}

--- a/tests/jsonpath/jsonpath_checked_invalid.vit
+++ b/tests/jsonpath/jsonpath_checked_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/jsonpath as jsonpath_pkg
+
+entry main at core/app {
+  let d0 = jsonpath_pkg.doc_new()
+  let bad = jsonpath_pkg.resolve_checked(d0, "$.")
+  when bad is jsonpath_pkg.JsonpathResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/jsonpath/jsonpath_invalid.vit
+++ b/tests/jsonpath/jsonpath_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/jsonpath as jsonpath_pkg
+
+entry main at core/app {
+  let cfg: jsonpath_pkg.JsonpathConfig = jsonpath_pkg.JsonpathConfig(true, 0, -1)
+  let vr: jsonpath_pkg.JsonpathResult[bool] = jsonpath_pkg.validate_config(cfg)
+  when vr is jsonpath_pkg.JsonpathResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/jsonpath/jsonpath_nominal.vit
+++ b/tests/jsonpath/jsonpath_nominal.vit
@@ -1,0 +1,20 @@
+use vitte/jsonpath as jsonpath_pkg
+
+entry main at core/app {
+  let cfg: jsonpath_pkg.JsonpathConfig = jsonpath_pkg.default_config()
+  let hr: jsonpath_pkg.JsonpathResult[bool] = jsonpath_pkg.healthcheck(cfg)
+  when hr is jsonpath_pkg.JsonpathResult.Err {
+    return 1
+  }
+
+  let d0 = jsonpath_pkg.doc_new()
+  let d1 = jsonpath_pkg.put(d0, "service.name", "vitte")
+  if jsonpath_pkg.resolve(d1, "$.service.name") != "vitte" {
+    return 1
+  }
+
+  if jsonpath_pkg.exists(d1, "service.name") == false {
+    return 1
+  }
+  return 0
+}

--- a/tests/jsonpath/jsonpath_resolve_checked_scenario.vit
+++ b/tests/jsonpath/jsonpath_resolve_checked_scenario.vit
@@ -1,0 +1,20 @@
+use vitte/jsonpath as jsonpath_pkg
+
+entry main at core/app {
+  let d0 = jsonpath_pkg.doc_new()
+  let d1 = jsonpath_pkg.put(d0, "svc.name", "vitte")
+
+  let ok = jsonpath_pkg.resolve_checked(d1, "$.svc.name")
+  when ok is jsonpath_pkg.JsonpathResult.Err {
+    return 1
+  }
+  if ok.value != "vitte" {
+    return 1
+  }
+
+  let miss = jsonpath_pkg.resolve_or_default(d1, "$.svc.missing")
+  if miss != "" {
+    return 1
+  }
+  return 0
+}

--- a/tests/openapi/openapi_contract_scenario.vit
+++ b/tests/openapi/openapi_contract_scenario.vit
@@ -1,0 +1,20 @@
+use vitte/openapi as openapi_pkg
+
+entry main at core/app {
+  let s0 = openapi_pkg.spec_new_default("svc")
+  let s1r = openapi_pkg.add_endpoint_checked(s0, "get", "/health", "health", "get_health", false)
+  when s1r is openapi_pkg.OpenapiResult.Err {
+    return 1
+  }
+
+  let s2r = openapi_pkg.validate_contract(s1r.value)
+  when s2r is openapi_pkg.OpenapiResult.Err {
+    return 1
+  }
+
+  let y = openapi_pkg.render_yaml(s1r.value)
+  if y.len == 0 {
+    return 1
+  }
+  return 0
+}

--- a/tests/openapi/openapi_duplicate_invalid.vit
+++ b/tests/openapi/openapi_duplicate_invalid.vit
@@ -1,0 +1,15 @@
+use vitte/openapi as openapi_pkg
+
+entry main at core/app {
+  let s0 = openapi_pkg.spec_new_default("svc")
+  let s1r = openapi_pkg.add_endpoint_checked(s0, "get", "/h", "h", "op_h", false)
+  when s1r is openapi_pkg.OpenapiResult.Err {
+    return 1
+  }
+
+  let s2r = openapi_pkg.add_endpoint_checked(s1r.value, "post", "/h2", "h2", "op_h", false)
+  when s2r is openapi_pkg.OpenapiResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/openapi/openapi_invalid.vit
+++ b/tests/openapi/openapi_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/openapi as openapi_pkg
+
+entry main at core/app {
+  let s0 = openapi_pkg.spec_new("", "")
+  let s1 = openapi_pkg.add_endpoint_ex(s0, "", "", "", "", false)
+  if openapi_pkg.validate(s1) == false {
+    return 0
+  }
+  return 1
+}

--- a/tests/openapi/openapi_nominal.vit
+++ b/tests/openapi/openapi_nominal.vit
@@ -1,0 +1,20 @@
+use vitte/openapi as openapi_pkg
+
+entry main at core/app {
+  let cfg: openapi_pkg.OpenapiConfig = openapi_pkg.default_config()
+  let hr: openapi_pkg.OpenapiResult[bool] = openapi_pkg.healthcheck(cfg)
+  when hr is openapi_pkg.OpenapiResult.Err {
+    return 1
+  }
+
+  let s0 = openapi_pkg.spec_new("api", "1.0.0")
+  let s1 = openapi_pkg.add_endpoint_ex(s0, "get", "/health", "health", "get_health", false)
+  if openapi_pkg.validate(s1) == false {
+    return 1
+  }
+
+  if openapi_pkg.has_operation_id(s1, "get_health") == false {
+    return 1
+  }
+  return 0
+}


### PR DESCRIPTION
## Summary
- enrich vitte/async, vitte/env, vitte/jsonpath, vitte/openapi, vitte/fuzzkit with package-specific domain APIs
- add dedicated internal/runtime.vit, internal/validate.vit, internal/policy.vit for each package and wire facade logic to those internal rules
- add scenario + invalid tests for each package and include them in quasi-empty-package-tests

## Key additions
- async: scheduler primitives (scheduler_idle, scheduler_capacity), config builders, stricter runtime checks
- env: set_checked, merge_env, require_default_key, key/value validation rules
- jsonpath: checked parsing/resolution (parse_checked, resolve_checked, resolve_or_default)
- openapi: checked endpoint insertion (add_endpoint_checked), contract validation, default spec constructor
- fuzzkit: validated case corpus, seeded plan shaping, stop threshold policy

## Validation
- make -s quasi-empty-package-tests
- make -s parse-modules
- make -s package-layout-lint-strict
- make -s packages-governance-lint

## Scope control
This PR is intentionally limited to:
- Makefile
- src/vitte/packages/{async,env,jsonpath,openapi,fuzzkit}/**
- tests/{async,env,jsonpath,openapi,fuzzkit}/**