### PR TITLE
packages: global hardening pass for remaining modules + arduino

### DIFF
--- a/src/vitte/packages/arduino/OWNERS
+++ b/src/vitte/packages/arduino/OWNERS
@@ -1,0 +1,1 @@
+@vitte/arduino

--- a/src/vitte/packages/arduino/gpio/OWNERS
+++ b/src/vitte/packages/arduino/gpio/OWNERS
@@ -1,0 +1,1 @@
+@vitte/arduino

--- a/src/vitte/packages/arduino/gpio/info.vit
+++ b/src/vitte/packages/arduino/gpio/info.vit
@@ -1,0 +1,24 @@
+<<<
+info.vit
+package vitte/arduino/gpio
+>>>
+<<< PACKAGE-META
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/arduino/gpio
+
+proc package_name() -> string {
+    give "gpio"
+}
+
+proc package_tag() -> string {
+    give "vitte/arduino/gpio"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/arduino/gpio/internal/policy.vit
+++ b/src/vitte/packages/arduino/gpio/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/arduino/gpio/internal/policy
+
+proc default_reset_input() -> bool {
+  give true
+}
+
+proc max_retry_budget() -> int {
+  give 3
+}

--- a/src/vitte/packages/arduino/gpio/internal/runtime.vit
+++ b/src/vitte/packages/arduino/gpio/internal/runtime.vit
@@ -1,0 +1,12 @@
+space vitte/arduino/gpio/internal/runtime
+
+proc runtime_write(pin: int, value: int) -> int {
+  let _ = pin
+  let _ = value
+  give 0
+}
+
+proc runtime_read(pin: int) -> int {
+  let _ = pin
+  give 0
+}

--- a/src/vitte/packages/arduino/gpio/internal/validate.vit
+++ b/src/vitte/packages/arduino/gpio/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/arduino/gpio/internal/validate
+
+use vitte/arduino as arduino_pkg
+
+proc valid_pin(profile: arduino_pkg.ArduinoProfile, pin: arduino_pkg.Pin) -> bool {
+  let r: arduino_pkg.ArduinoResult[bool] = arduino_pkg.validate_pin(profile, pin)
+  when r is arduino_pkg.ArduinoResult.Ok { give true }
+  give false
+}

--- a/src/vitte/packages/arduino/gpio/mod.vit
+++ b/src/vitte/packages/arduino/gpio/mod.vit
@@ -1,0 +1,120 @@
+<<<
+mod.vit
+package vitte/arduino/gpio
+>>>
+
+space vitte/arduino/gpio
+
+use vitte/arduino as arduino_pkg
+use vitte/arduino/gpio/internal/runtime as gpio_runtime_pkg
+use vitte/arduino/gpio/internal/validate as gpio_validate_pkg
+use vitte/arduino/gpio/internal/policy as gpio_policy_pkg
+
+pick PinMode {
+  Input
+  Output
+}
+
+pick PinState {
+  Low
+  High
+}
+
+pick PullMode {
+  None
+  Up
+}
+
+form GpioConfig {
+  profile: arduino_pkg.ArduinoProfile
+  default_mode: PinMode
+  pull_mode: PullMode
+  retry_budget: int
+}
+
+form GpioState {
+  cfg: GpioConfig
+  opened: bool
+  tx_count: int
+  rx_count: int
+  error_count: int
+}
+
+proc gpio_default_config() -> GpioConfig {
+  give GpioConfig(arduino_pkg.default_profile(), PinMode.Input, PullMode.None, gpio_policy_pkg.max_retry_budget())
+}
+
+proc gpio_with_profile(cfg: GpioConfig, profile: arduino_pkg.ArduinoProfile) -> GpioConfig {
+  give GpioConfig(profile, cfg.default_mode, cfg.pull_mode, cfg.retry_budget)
+}
+
+proc gpio_with_pullup(cfg: GpioConfig, enabled: bool) -> GpioConfig {
+  let pull_mode: PullMode = PullMode.None
+  if enabled { pull_mode = PullMode.Up }
+  give GpioConfig(cfg.profile, cfg.default_mode, pull_mode, cfg.retry_budget)
+}
+
+proc gpio_with_retry_budget(cfg: GpioConfig, retry_budget: int) -> GpioConfig {
+  give GpioConfig(cfg.profile, cfg.default_mode, cfg.pull_mode, retry_budget)
+}
+
+proc gpio_open(cfg: GpioConfig) -> GpioState {
+  give GpioState(cfg, true, 0, 0, 0)
+}
+
+proc gpio_close(st: GpioState) -> GpioState {
+  give GpioState(st.cfg, false, st.tx_count, st.rx_count, st.error_count)
+}
+
+proc gpio_write(st: GpioState, pin: arduino_pkg.Pin, state: PinState) -> arduino_pkg.ArduinoResult[GpioState] {
+  if gpio_validate_pkg.valid_pin(st.cfg.profile, pin) == false {
+    give arduino_pkg.err[GpioState](arduino_pkg.ArduinoError.InvalidPin)
+  }
+  let raw: int = 0
+  if state == PinState.High { raw = 1 }
+  let status: int = gpio_runtime_pkg.runtime_write(pin, raw)
+  if status != 0 {
+    give arduino_pkg.err[GpioState](arduino_pkg.ArduinoError.Unknown)
+  }
+  give arduino_pkg.ok[GpioState](GpioState(st.cfg, st.opened, st.tx_count + 1, st.rx_count, st.error_count))
+}
+
+proc gpio_read(st: GpioState, pin: arduino_pkg.Pin) -> arduino_pkg.ArduinoResult[PinState] {
+  let _ = st
+  if gpio_validate_pkg.valid_pin(st.cfg.profile, pin) == false {
+    give arduino_pkg.err[PinState](arduino_pkg.ArduinoError.InvalidPin)
+  }
+  let raw: int = gpio_runtime_pkg.runtime_read(pin)
+  if raw == 0 { give arduino_pkg.ok[PinState](PinState.Low) }
+  give arduino_pkg.ok[PinState](PinState.High)
+}
+
+# Compatibility wrappers
+proc pin_mode(pin: int, mode: PinMode) -> int {
+  let _ = pin
+  let _ = mode
+  give 0
+}
+
+proc digital_write(pin: int, state: PinState) -> int {
+  let _ = pin
+  let _ = state
+  give 0
+}
+
+proc package_meta() -> string {
+  give "vitte/arduino/gpio"
+}
+
+<<< ROLE-CONTRACT
+package: vitte/arduino/gpio
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+role: GPIO facade avec validation de pin et etats explicites
+input_contract: Pin profile mode state explicites
+output_contract: ArduinoResult typé, sans side effect implicite
+boundary: L acces hardware passe uniquement via internal/runtime
+compat_policy: additive-only
+>>>

--- a/src/vitte/packages/arduino/i2c/OWNERS
+++ b/src/vitte/packages/arduino/i2c/OWNERS
@@ -1,0 +1,1 @@
+@vitte/arduino

--- a/src/vitte/packages/arduino/i2c/info.vit
+++ b/src/vitte/packages/arduino/i2c/info.vit
@@ -1,0 +1,24 @@
+<<<
+info.vit
+package vitte/arduino/i2c
+>>>
+<<< PACKAGE-META
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/arduino/i2c
+
+proc package_name() -> string {
+    give "i2c"
+}
+
+proc package_tag() -> string {
+    give "vitte/arduino/i2c"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/arduino/i2c/internal/policy.vit
+++ b/src/vitte/packages/arduino/i2c/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/arduino/i2c/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 100
+}
+
+proc default_retry_budget() -> int {
+  give 2
+}

--- a/src/vitte/packages/arduino/i2c/internal/runtime.vit
+++ b/src/vitte/packages/arduino/i2c/internal/runtime.vit
@@ -1,0 +1,14 @@
+space vitte/arduino/i2c/internal/runtime
+
+proc runtime_write(addr: int, reg: int, value: int) -> int {
+  let _ = addr
+  let _ = reg
+  let _ = value
+  give 0
+}
+
+proc runtime_read(addr: int, reg: int) -> int {
+  let _ = addr
+  let _ = reg
+  give 0
+}

--- a/src/vitte/packages/arduino/i2c/internal/validate.vit
+++ b/src/vitte/packages/arduino/i2c/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/arduino/i2c/internal/validate
+
+use vitte/arduino as arduino_pkg
+
+proc valid_address(addr: arduino_pkg.Address7) -> bool {
+  let r: arduino_pkg.ArduinoResult[bool] = arduino_pkg.validate_address7(addr)
+  when r is arduino_pkg.ArduinoResult.Ok { give true }
+  give false
+}

--- a/src/vitte/packages/arduino/i2c/mod.vit
+++ b/src/vitte/packages/arduino/i2c/mod.vit
@@ -1,0 +1,100 @@
+<<<
+mod.vit
+package vitte/arduino/i2c
+>>>
+
+space vitte/arduino/i2c
+
+use vitte/arduino as arduino_pkg
+use vitte/arduino/i2c/internal/runtime as i2c_runtime_pkg
+use vitte/arduino/i2c/internal/validate as i2c_validate_pkg
+use vitte/arduino/i2c/internal/policy as i2c_policy_pkg
+
+form I2cConfig {
+  profile: arduino_pkg.ArduinoProfile
+  timeout_ms: arduino_pkg.Millis
+  retry_budget: int
+}
+
+form I2cBusState {
+  cfg: I2cConfig
+  opened: bool
+  tx_count: int
+  rx_count: int
+  timeout_count: int
+  error_count: int
+}
+
+proc i2c_default_config() -> I2cConfig {
+  give I2cConfig(arduino_pkg.default_profile(), i2c_policy_pkg.default_timeout_ms(), i2c_policy_pkg.default_retry_budget())
+}
+
+proc i2c_with_timeout(cfg: I2cConfig, timeout_ms: arduino_pkg.Millis) -> I2cConfig {
+  give I2cConfig(cfg.profile, timeout_ms, cfg.retry_budget)
+}
+
+proc i2c_with_retry_budget(cfg: I2cConfig, retry_budget: int) -> I2cConfig {
+  give I2cConfig(cfg.profile, cfg.timeout_ms, retry_budget)
+}
+
+proc i2c_open(cfg: I2cConfig) -> I2cBusState {
+  give I2cBusState(cfg, true, 0, 0, 0, 0)
+}
+
+proc i2c_close(st: I2cBusState) -> I2cBusState {
+  give I2cBusState(st.cfg, false, st.tx_count, st.rx_count, st.timeout_count, st.error_count)
+}
+
+proc i2c_write_register(st: I2cBusState, addr: arduino_pkg.Address7, reg: arduino_pkg.Register, value: int) -> arduino_pkg.ArduinoResult[I2cBusState] {
+  if i2c_validate_pkg.valid_address(addr) == false {
+    give arduino_pkg.err[I2cBusState](arduino_pkg.ArduinoError.InvalidAddress)
+  }
+  let status: int = i2c_runtime_pkg.runtime_write(addr, reg, value)
+  if status != 0 {
+    give arduino_pkg.err[I2cBusState](arduino_pkg.ArduinoError.BusBusy)
+  }
+  give arduino_pkg.ok[I2cBusState](I2cBusState(st.cfg, st.opened, st.tx_count + 1, st.rx_count, st.timeout_count, st.error_count))
+}
+
+proc i2c_read_register(st: I2cBusState, addr: arduino_pkg.Address7, reg: arduino_pkg.Register) -> arduino_pkg.ArduinoResult[int] {
+  let _ = st
+  if i2c_validate_pkg.valid_address(addr) == false {
+    give arduino_pkg.err[int](arduino_pkg.ArduinoError.InvalidAddress)
+  }
+  give arduino_pkg.ok[int](i2c_runtime_pkg.runtime_read(addr, reg))
+}
+
+# Compatibility wrappers
+proc begin() -> int { give 0 }
+proc begin_transmission(addr: int) -> int {
+  let _ = addr
+  give 0
+}
+proc end_transmission() -> int { give 0 }
+proc request_from(addr: int, count: int) -> int {
+  let _ = addr
+  let _ = count
+  give 0
+}
+proc read() -> int { give 0 }
+proc write(byte: int) -> int {
+  let _ = byte
+  give 1
+}
+
+proc package_meta() -> string {
+  give "vitte/arduino/i2c"
+}
+
+<<< ROLE-CONTRACT
+package: vitte/arduino/i2c
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+role: I2C facade avec timeouts et validation d adresses
+input_contract: Address7 register timeout explicites
+output_contract: ArduinoResult + erreurs actionnables VITTE-Axxxx
+boundary: Aucun acces direct hardware hors internal/runtime
+compat_policy: additive-only
+>>>

--- a/src/vitte/packages/arduino/info.vit
+++ b/src/vitte/packages/arduino/info.vit
@@ -1,0 +1,24 @@
+<<<
+info.vit
+package vitte/arduino
+>>>
+<<< PACKAGE-META
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/arduino
+
+proc package_name() -> string {
+    give "arduino"
+}
+
+proc package_tag() -> string {
+    give "vitte/arduino"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/arduino/mod.vit
+++ b/src/vitte/packages/arduino/mod.vit
@@ -1,0 +1,160 @@
+<<<
+mod.vit
+package vitte/arduino
+>>>
+
+space vitte/arduino
+
+type Pin = int
+type BaudRate = int
+type Millis = int
+type Address7 = int
+type Register = int
+
+pick ArduinoProfile {
+  Uno
+  Mega
+  Esp32
+}
+
+pick SpiMode {
+  Mode0
+  Mode1
+  Mode2
+  Mode3
+}
+
+pick BitOrder {
+  MsbFirst
+  LsbFirst
+}
+
+pick ArduinoError {
+  InvalidPin
+  InvalidAddress
+  InvalidBaudRate
+  BusBusy
+  Timeout
+  Unsupported
+  Conflict
+  Unknown
+}
+
+pick ArduinoResult[T] {
+  Ok(value: T)
+  Err(error: ArduinoError)
+}
+
+form ArduinoDiag {
+  code: string
+  message: string
+  context: string
+}
+
+proc ok[T](value: T) -> ArduinoResult[T] {
+  give ArduinoResult.Ok(value)
+}
+
+proc err[T](e: ArduinoError) -> ArduinoResult[T] {
+  give ArduinoResult.Err(e)
+}
+
+proc default_profile() -> ArduinoProfile {
+  give ArduinoProfile.Uno
+}
+
+proc supports_pwm(profile: ArduinoProfile, pin: Pin) -> bool {
+  if profile == ArduinoProfile.Uno {
+    give pin == 3 || pin == 5 || pin == 6 || pin == 9 || pin == 10 || pin == 11
+  }
+  if profile == ArduinoProfile.Mega {
+    give pin >= 2 && pin <= 13
+  }
+  if profile == ArduinoProfile.Esp32 {
+    give pin >= 0 && pin <= 19
+  }
+  give false
+}
+
+proc supports_i2c(profile: ArduinoProfile, addr_mode: string) -> bool {
+  let _ = profile
+  give addr_mode == "7bit"
+}
+
+proc max_spi_hz(profile: ArduinoProfile) -> int {
+  if profile == ArduinoProfile.Uno { give 8000000 }
+  if profile == ArduinoProfile.Mega { give 8000000 }
+  if profile == ArduinoProfile.Esp32 { give 40000000 }
+  give 1000000
+}
+
+proc validate_pin(profile: ArduinoProfile, pin: Pin) -> ArduinoResult[bool] {
+  if profile == ArduinoProfile.Uno {
+    if pin < 0 || pin > 19 { give err[bool](ArduinoError.InvalidPin) }
+    give ok[bool](true)
+  }
+  if profile == ArduinoProfile.Mega {
+    if pin < 0 || pin > 53 { give err[bool](ArduinoError.InvalidPin) }
+    give ok[bool](true)
+  }
+  if profile == ArduinoProfile.Esp32 {
+    if pin < 0 || pin > 39 { give err[bool](ArduinoError.InvalidPin) }
+    give ok[bool](true)
+  }
+  give err[bool](ArduinoError.Unsupported)
+}
+
+proc validate_address7(addr: Address7) -> ArduinoResult[bool] {
+  if addr < 0x08 || addr > 0x77 {
+    give err[bool](ArduinoError.InvalidAddress)
+  }
+  give ok[bool](true)
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-A0012" {
+    give "invalid pin for active board profile"
+  }
+  if code == "VITTE-A0013" {
+    give "invalid i2c address (expected 0x08..0x77)"
+  }
+  if code == "VITTE-A0020" {
+    give "operation timed out"
+  }
+  give "arduino diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-A0012" {
+    give "verify pin range and board profile"
+  }
+  if code == "VITTE-A0013" {
+    give "use a 7-bit i2c address in range 0x08..0x77"
+  }
+  give "review arduino module configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc diag(code: string, context: string) -> ArduinoDiag {
+  give ArduinoDiag(code, diagnostics_message(code), context)
+}
+
+proc package_meta() -> string {
+  give "vitte/arduino"
+}
+
+<<< ROLE-CONTRACT
+package: vitte/arduino
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+role: Facade arduino stable pour profils embarques
+input_contract: Pin baudrate timeout adresses explicites
+output_contract: Resultats ArduinoResult avec diagnostics VITTE-Axxxx
+boundary: Aucun acces hardware direct dans la facade
+compat_policy: additive-only
+>>>

--- a/src/vitte/packages/arduino/serial/OWNERS
+++ b/src/vitte/packages/arduino/serial/OWNERS
@@ -1,0 +1,1 @@
+@vitte/arduino

--- a/src/vitte/packages/arduino/serial/info.vit
+++ b/src/vitte/packages/arduino/serial/info.vit
@@ -1,0 +1,24 @@
+<<<
+info.vit
+package vitte/arduino/serial
+>>>
+<<< PACKAGE-META
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/arduino/serial
+
+proc package_name() -> string {
+    give "serial"
+}
+
+proc package_tag() -> string {
+    give "vitte/arduino/serial"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/arduino/serial/internal/policy.vit
+++ b/src/vitte/packages/arduino/serial/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/arduino/serial/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 50
+}

--- a/src/vitte/packages/arduino/serial/internal/runtime.vit
+++ b/src/vitte/packages/arduino/serial/internal/runtime.vit
@@ -1,0 +1,14 @@
+space vitte/arduino/serial/internal/runtime
+
+proc runtime_available() -> int {
+  give 0
+}
+
+proc runtime_read() -> int {
+  give -1
+}
+
+proc runtime_write(byte: int) -> int {
+  let _ = byte
+  give 1
+}

--- a/src/vitte/packages/arduino/serial/internal/validate.vit
+++ b/src/vitte/packages/arduino/serial/internal/validate.vit
@@ -1,0 +1,7 @@
+space vitte/arduino/serial/internal/validate
+
+proc valid_baud(baud: int) -> bool {
+  if baud <= 0 { give false }
+  if baud > 2000000 { give false }
+  give true
+}

--- a/src/vitte/packages/arduino/serial/mod.vit
+++ b/src/vitte/packages/arduino/serial/mod.vit
@@ -1,0 +1,96 @@
+<<<
+mod.vit
+package vitte/arduino/serial
+>>>
+
+space vitte/arduino/serial
+
+use vitte/arduino as arduino_pkg
+use vitte/arduino/serial/internal/runtime as serial_runtime_pkg
+use vitte/arduino/serial/internal/validate as serial_validate_pkg
+use vitte/arduino/serial/internal/policy as serial_policy_pkg
+
+form SerialConfig {
+  profile: arduino_pkg.ArduinoProfile
+  baud: arduino_pkg.BaudRate
+  timeout_ms: arduino_pkg.Millis
+}
+
+form SerialState {
+  cfg: SerialConfig
+  opened: bool
+  tx_count: int
+  rx_count: int
+  timeout_count: int
+  error_count: int
+}
+
+proc serial_default_config() -> SerialConfig {
+  give SerialConfig(arduino_pkg.default_profile(), 115200, serial_policy_pkg.default_timeout_ms())
+}
+
+proc serial_with_baud(cfg: SerialConfig, baud: arduino_pkg.BaudRate) -> SerialConfig {
+  give SerialConfig(cfg.profile, baud, cfg.timeout_ms)
+}
+
+proc serial_with_timeout(cfg: SerialConfig, timeout_ms: arduino_pkg.Millis) -> SerialConfig {
+  give SerialConfig(cfg.profile, cfg.baud, timeout_ms)
+}
+
+proc serial_open(cfg: SerialConfig) -> arduino_pkg.ArduinoResult[SerialState] {
+  if serial_validate_pkg.valid_baud(cfg.baud) == false {
+    give arduino_pkg.err[SerialState](arduino_pkg.ArduinoError.InvalidBaudRate)
+  }
+  give arduino_pkg.ok[SerialState](SerialState(cfg, true, 0, 0, 0, 0))
+}
+
+proc serial_close(st: SerialState) -> SerialState {
+  give SerialState(st.cfg, false, st.tx_count, st.rx_count, st.timeout_count, st.error_count)
+}
+
+proc serial_available(st: SerialState) -> int {
+  let _ = st
+  give serial_runtime_pkg.runtime_available()
+}
+
+proc serial_read(st: SerialState) -> arduino_pkg.ArduinoResult[int] {
+  let _ = st
+  give arduino_pkg.ok[int](serial_runtime_pkg.runtime_read())
+}
+
+proc serial_write(st: SerialState, byte: int) -> arduino_pkg.ArduinoResult[SerialState] {
+  let status: int = serial_runtime_pkg.runtime_write(byte)
+  if status <= 0 {
+    give arduino_pkg.err[SerialState](arduino_pkg.ArduinoError.Timeout)
+  }
+  give arduino_pkg.ok[SerialState](SerialState(st.cfg, st.opened, st.tx_count + 1, st.rx_count, st.timeout_count, st.error_count))
+}
+
+# Compatibility wrappers
+proc begin(baud: int) -> int {
+  let _ = baud
+  give 0
+}
+proc available() -> int { give 0 }
+proc read() -> int { give -1 }
+proc write(byte: int) -> int {
+  let _ = byte
+  give 1
+}
+
+proc package_meta() -> string {
+  give "vitte/arduino/serial"
+}
+
+<<< ROLE-CONTRACT
+package: vitte/arduino/serial
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+role: Serial facade avec baudrate typé et timeout explicite
+input_contract: Config serial immuable et budget timeout
+output_contract: ArduinoResult + compteurs observabilite low-cost
+boundary: Runtime hardware uniquement via internal/runtime
+compat_policy: additive-only
+>>>

--- a/src/vitte/packages/arduino/spi/OWNERS
+++ b/src/vitte/packages/arduino/spi/OWNERS
@@ -1,0 +1,1 @@
+@vitte/arduino

--- a/src/vitte/packages/arduino/spi/info.vit
+++ b/src/vitte/packages/arduino/spi/info.vit
@@ -1,0 +1,24 @@
+<<<
+info.vit
+package vitte/arduino/spi
+>>>
+<<< PACKAGE-META
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/arduino/spi
+
+proc package_name() -> string {
+    give "spi"
+}
+
+proc package_tag() -> string {
+    give "vitte/arduino/spi"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/arduino/spi/internal/policy.vit
+++ b/src/vitte/packages/arduino/spi/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/arduino/spi/internal/policy
+
+proc default_clock_hz() -> int {
+  give 1000000
+}

--- a/src/vitte/packages/arduino/spi/internal/runtime.vit
+++ b/src/vitte/packages/arduino/spi/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/arduino/spi/internal/runtime
+
+proc runtime_transfer(value: int) -> int {
+  give value
+}

--- a/src/vitte/packages/arduino/spi/internal/validate.vit
+++ b/src/vitte/packages/arduino/spi/internal/validate.vit
@@ -1,0 +1,5 @@
+space vitte/arduino/spi/internal/validate
+
+proc valid_clock_hz(clock_hz: int) -> bool {
+  give clock_hz > 0
+}

--- a/src/vitte/packages/arduino/spi/mod.vit
+++ b/src/vitte/packages/arduino/spi/mod.vit
@@ -1,0 +1,79 @@
+<<<
+mod.vit
+package vitte/arduino/spi
+>>>
+
+space vitte/arduino/spi
+
+use vitte/arduino as arduino_pkg
+use vitte/arduino/spi/internal/runtime as spi_runtime_pkg
+use vitte/arduino/spi/internal/validate as spi_validate_pkg
+use vitte/arduino/spi/internal/policy as spi_policy_pkg
+
+form SpiConfig {
+  profile: arduino_pkg.ArduinoProfile
+  mode: arduino_pkg.SpiMode
+  bit_order: arduino_pkg.BitOrder
+  clock_hz: int
+}
+
+form SpiBusState {
+  cfg: SpiConfig
+  opened: bool
+  tx_count: int
+  rx_count: int
+  error_count: int
+}
+
+proc spi_default_config() -> SpiConfig {
+  give SpiConfig(arduino_pkg.default_profile(), arduino_pkg.SpiMode.Mode0, arduino_pkg.BitOrder.MsbFirst, spi_policy_pkg.default_clock_hz())
+}
+
+proc spi_with_clock_hz(cfg: SpiConfig, clock_hz: int) -> SpiConfig {
+  give SpiConfig(cfg.profile, cfg.mode, cfg.bit_order, clock_hz)
+}
+
+proc spi_with_mode(cfg: SpiConfig, mode: arduino_pkg.SpiMode) -> SpiConfig {
+  give SpiConfig(cfg.profile, mode, cfg.bit_order, cfg.clock_hz)
+}
+
+proc spi_open(cfg: SpiConfig) -> arduino_pkg.ArduinoResult[SpiBusState] {
+  if spi_validate_pkg.valid_clock_hz(cfg.clock_hz) == false {
+    give arduino_pkg.err[SpiBusState](arduino_pkg.ArduinoError.Unsupported)
+  }
+  if cfg.clock_hz > arduino_pkg.max_spi_hz(cfg.profile) {
+    give arduino_pkg.err[SpiBusState](arduino_pkg.ArduinoError.Unsupported)
+  }
+  give arduino_pkg.ok[SpiBusState](SpiBusState(cfg, true, 0, 0, 0))
+}
+
+proc spi_close(st: SpiBusState) -> SpiBusState {
+  give SpiBusState(st.cfg, false, st.tx_count, st.rx_count, st.error_count)
+}
+
+proc spi_transfer(st: SpiBusState, value: int) -> arduino_pkg.ArduinoResult[int] {
+  let _ = st
+  give arduino_pkg.ok[int](spi_runtime_pkg.runtime_transfer(value))
+}
+
+# Compatibility wrapper
+proc transfer(byte: int) -> int {
+  give byte
+}
+
+proc package_meta() -> string {
+  give "vitte/arduino/spi"
+}
+
+<<< ROLE-CONTRACT
+package: vitte/arduino/spi
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+role: SPI facade typée (mode/ordre/clock)
+input_contract: Configuration SPI explicite et immuable
+output_contract: ArduinoResult avec controle de capabilities profil
+boundary: Les acces runtime restent sous internal/runtime
+compat_policy: additive-only
+>>>

--- a/src/vitte/packages/arduino/timer/OWNERS
+++ b/src/vitte/packages/arduino/timer/OWNERS
@@ -1,0 +1,1 @@
+@vitte/arduino

--- a/src/vitte/packages/arduino/timer/info.vit
+++ b/src/vitte/packages/arduino/timer/info.vit
@@ -1,0 +1,24 @@
+<<<
+info.vit
+package vitte/arduino/timer
+>>>
+<<< PACKAGE-META
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+>>>
+
+space vitte/arduino/timer
+
+proc package_name() -> string {
+    give "timer"
+}
+
+proc package_tag() -> string {
+    give "vitte/arduino/timer"
+}
+
+proc package_ready() -> bool {
+    give true
+}

--- a/src/vitte/packages/arduino/timer/internal/policy.vit
+++ b/src/vitte/packages/arduino/timer/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/arduino/timer/internal/policy
+
+proc max_delay_ms() -> int {
+  give 60000
+}

--- a/src/vitte/packages/arduino/timer/internal/runtime.vit
+++ b/src/vitte/packages/arduino/timer/internal/runtime.vit
@@ -1,0 +1,6 @@
+space vitte/arduino/timer/internal/runtime
+
+proc runtime_delay_ms(ms: int) -> int {
+  let _ = ms
+  give 0
+}

--- a/src/vitte/packages/arduino/timer/internal/validate.vit
+++ b/src/vitte/packages/arduino/timer/internal/validate.vit
@@ -1,0 +1,5 @@
+space vitte/arduino/timer/internal/validate
+
+proc valid_delay(ms: int) -> bool {
+  give ms >= 0
+}

--- a/src/vitte/packages/arduino/timer/mod.vit
+++ b/src/vitte/packages/arduino/timer/mod.vit
@@ -1,0 +1,48 @@
+<<<
+mod.vit
+package vitte/arduino/timer
+>>>
+
+space vitte/arduino/timer
+
+use vitte/arduino as arduino_pkg
+use vitte/arduino/timer/internal/runtime as timer_runtime_pkg
+use vitte/arduino/timer/internal/validate as timer_validate_pkg
+use vitte/arduino/timer/internal/policy as timer_policy_pkg
+
+proc timer_delay_ms(ms: arduino_pkg.Millis) -> arduino_pkg.ArduinoResult[bool] {
+  if timer_validate_pkg.valid_delay(ms) == false {
+    give arduino_pkg.err[bool](arduino_pkg.ArduinoError.Unsupported)
+  }
+  if ms > timer_policy_pkg.max_delay_ms() {
+    give arduino_pkg.err[bool](arduino_pkg.ArduinoError.Timeout)
+  }
+  let status: int = timer_runtime_pkg.runtime_delay_ms(ms)
+  if status != 0 {
+    give arduino_pkg.err[bool](arduino_pkg.ArduinoError.Unknown)
+  }
+  give arduino_pkg.ok[bool](true)
+}
+
+# Compatibility wrapper
+proc delay_ms(ms: int) -> int {
+  let _ = ms
+  give 0
+}
+
+proc package_meta() -> string {
+  give "vitte/arduino/timer"
+}
+
+<<< ROLE-CONTRACT
+package: vitte/arduino/timer
+owner: @vitte/arduino
+stability: experimental
+since: 3.0.0
+deprecated_in: -
+role: Timer facade avec delais valides et bornes claires
+input_contract: Delai explicite en millisecondes
+output_contract: ArduinoResult avec erreurs actionnables
+boundary: Timer hardware encapsule dans internal/runtime
+compat_policy: additive-only
+>>>

--- a/src/vitte/packages/catalog/internal/policy.vit
+++ b/src/vitte/packages/catalog/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/catalog/internal/policy
+
+proc default_max_entries() -> int {
+  give 1000
+}

--- a/src/vitte/packages/catalog/internal/runtime.vit
+++ b/src/vitte/packages/catalog/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/catalog/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/catalog/internal/validate.vit
+++ b/src/vitte/packages/catalog/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/catalog/internal/validate
+
+proc valid_catalog_name(name: string) -> bool {
+  give name.len > 0
+}
+
+proc valid_max_entries(max_entries: int) -> bool {
+  give max_entries > 0 && max_entries <= 100000
+}

--- a/src/vitte/packages/catalog/mod.vit
+++ b/src/vitte/packages/catalog/mod.vit
@@ -5,18 +5,91 @@ package vitte/catalog
 
 space vitte/catalog
 
+use vitte/catalog/internal/runtime as catalog_runtime_pkg
+use vitte/catalog/internal/validate as catalog_validate_pkg
+use vitte/catalog/internal/policy as catalog_policy_pkg
+
+form CatalogConfig {
+  catalog_name: string
+  strict: bool
+  max_entries: int
+}
+
+pick CatalogError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick CatalogResult[T] {
+  Ok(value: T)
+  Err(error: CatalogError)
+}
+
+proc default_config() -> CatalogConfig {
+  give CatalogConfig("default", true, catalog_policy_pkg.default_max_entries())
+}
+
+proc validate_config(cfg: CatalogConfig) -> CatalogResult[bool] {
+  if catalog_validate_pkg.valid_catalog_name(cfg.catalog_name) == false {
+    give CatalogResult.Err(CatalogError.InvalidConfig)
+  }
+  if catalog_validate_pkg.valid_max_entries(cfg.max_entries) == false {
+    give CatalogResult.Err(CatalogError.InvalidConfig)
+  }
+  give CatalogResult.Ok(true)
+}
+
+proc healthcheck(cfg: CatalogConfig) -> CatalogResult[bool] {
+  let vr: CatalogResult[bool] = validate_config(cfg)
+  when vr is CatalogResult.Err { give CatalogResult.Err(vr.error) }
+  if catalog_runtime_pkg.runtime_status() == false {
+    give CatalogResult.Err(CatalogError.Internal)
+  }
+  give CatalogResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["catalog-index", "strict-mode", "entry-budget"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-CAT0001" { give "invalid catalog configuration" }
+  give "catalog diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-CAT0001" { give "set non-empty catalog_name and valid max_entries" }
+  give "review catalog configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/catalog"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/catalog
 owner: @vitte/platform
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/catalog
-input_contract: Entrees explicites et typables
-output_contract: Sorties stables et predictibles
+role: Index de catalogues modules et metadonnees associees
+input_contract: Config explicite et typable
+output_contract: Validation stable et predictible
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/codegen/cranelift/internal/policy.vit
+++ b/src/vitte/packages/codegen/cranelift/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/codegen/cranelift/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/codegen/cranelift/internal/runtime.vit
+++ b/src/vitte/packages/codegen/cranelift/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/codegen/cranelift/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/codegen/cranelift/internal/validate.vit
+++ b/src/vitte/packages/codegen/cranelift/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/codegen/cranelift/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/codegen/cranelift/mod.vit
+++ b/src/vitte/packages/codegen/cranelift/mod.vit
@@ -5,6 +5,10 @@ package vitte/codegen/cranelift
 
 space vitte/codegen/cranelift
 
+use vitte/codegen/cranelift/internal/runtime as codegen_cranelift_runtime_pkg
+use vitte/codegen/cranelift/internal/validate as codegen_cranelift_validate_pkg
+use vitte/codegen/cranelift/internal/policy as codegen_cranelift_policy_pkg
+
 
 form ClifUnit {
   clif_path: string
@@ -41,10 +45,84 @@ proc package_meta() -> string {
   give "vitte/codegen/cranelift"
 }
 
+form CodegenCraneliftConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick CodegenCraneliftError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick CodegenCraneliftResult[T] {
+  Ok(value: T)
+  Err(error: CodegenCraneliftError)
+}
+
+proc default_config() -> CodegenCraneliftConfig {
+  give CodegenCraneliftConfig(true, codegen_cranelift_policy_pkg.default_timeout_ms(), codegen_cranelift_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: CodegenCraneliftConfig) -> CodegenCraneliftResult[bool] {
+  if codegen_cranelift_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give CodegenCraneliftResult.Err(CodegenCraneliftError.InvalidConfig)
+  }
+  if codegen_cranelift_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give CodegenCraneliftResult.Err(CodegenCraneliftError.InvalidConfig)
+  }
+  give CodegenCraneliftResult.Ok(true)
+}
+
+proc healthcheck(cfg: CodegenCraneliftConfig) -> CodegenCraneliftResult[bool] {
+  let vr: CodegenCraneliftResult[bool] = validate_config(cfg)
+  when vr is CodegenCraneliftResult.Err {
+    give CodegenCraneliftResult.Err(vr.error)
+  }
+  if codegen_cranelift_runtime_pkg.runtime_status() == false {
+    give CodegenCraneliftResult.Err(CodegenCraneliftError.Internal)
+  }
+  give CodegenCraneliftResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-CODEGENC0001" {
+    give "invalid package configuration"
+  }
+  give "codegen/cranelift diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/codegen/cranelift
 role: Construction de commandes backend Cranelift
 input_contract: CLIF et ISA explicites
 output_contract: Commande compile deterministe
 boundary: Pas d execution backend directe
+
+owner: @vitte/cranelift
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/codegen/gcc/internal/policy.vit
+++ b/src/vitte/packages/codegen/gcc/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/codegen/gcc/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/codegen/gcc/internal/runtime.vit
+++ b/src/vitte/packages/codegen/gcc/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/codegen/gcc/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/codegen/gcc/internal/validate.vit
+++ b/src/vitte/packages/codegen/gcc/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/codegen/gcc/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/codegen/gcc/mod.vit
+++ b/src/vitte/packages/codegen/gcc/mod.vit
@@ -5,6 +5,10 @@ package vitte/codegen/gcc
 
 space vitte/codegen/gcc
 
+use vitte/codegen/gcc/internal/runtime as codegen_gcc_runtime_pkg
+use vitte/codegen/gcc/internal/validate as codegen_gcc_validate_pkg
+use vitte/codegen/gcc/internal/policy as codegen_gcc_policy_pkg
+
 
 form CompileUnit {
   source_path: string
@@ -52,10 +56,84 @@ proc package_meta() -> string {
   give "vitte/codegen/gcc"
 }
 
+form CodegenGccConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick CodegenGccError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick CodegenGccResult[T] {
+  Ok(value: T)
+  Err(error: CodegenGccError)
+}
+
+proc default_config() -> CodegenGccConfig {
+  give CodegenGccConfig(true, codegen_gcc_policy_pkg.default_timeout_ms(), codegen_gcc_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: CodegenGccConfig) -> CodegenGccResult[bool] {
+  if codegen_gcc_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give CodegenGccResult.Err(CodegenGccError.InvalidConfig)
+  }
+  if codegen_gcc_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give CodegenGccResult.Err(CodegenGccError.InvalidConfig)
+  }
+  give CodegenGccResult.Ok(true)
+}
+
+proc healthcheck(cfg: CodegenGccConfig) -> CodegenGccResult[bool] {
+  let vr: CodegenGccResult[bool] = validate_config(cfg)
+  when vr is CodegenGccResult.Err {
+    give CodegenGccResult.Err(vr.error)
+  }
+  if codegen_gcc_runtime_pkg.runtime_status() == false {
+    give CodegenGccResult.Err(CodegenGccError.Internal)
+  }
+  give CodegenGccResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-CODEGENG0001" {
+    give "invalid package configuration"
+  }
+  give "codegen/gcc diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/codegen/gcc
 role: Construction de commandes GCC
 input_contract: Unites compilees normalisees
 output_contract: Commandes deterministes valides
 boundary: N execute pas le binaire; prepare la commande seulement
+
+owner: @vitte/gcc
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/codegen/internal/policy.vit
+++ b/src/vitte/packages/codegen/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/codegen/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/codegen/internal/runtime.vit
+++ b/src/vitte/packages/codegen/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/codegen/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/codegen/internal/validate.vit
+++ b/src/vitte/packages/codegen/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/codegen/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/codegen/llvm/internal/policy.vit
+++ b/src/vitte/packages/codegen/llvm/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/codegen/llvm/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/codegen/llvm/internal/runtime.vit
+++ b/src/vitte/packages/codegen/llvm/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/codegen/llvm/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/codegen/llvm/internal/validate.vit
+++ b/src/vitte/packages/codegen/llvm/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/codegen/llvm/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/codegen/llvm/mod.vit
+++ b/src/vitte/packages/codegen/llvm/mod.vit
@@ -5,6 +5,10 @@ package vitte/codegen/llvm
 
 space vitte/codegen/llvm
 
+use vitte/codegen/llvm/internal/runtime as codegen_llvm_runtime_pkg
+use vitte/codegen/llvm/internal/validate as codegen_llvm_validate_pkg
+use vitte/codegen/llvm/internal/policy as codegen_llvm_policy_pkg
+
 
 form IrUnit {
   ir_path: string
@@ -55,10 +59,84 @@ proc package_meta() -> string {
   give "vitte/codegen/llvm"
 }
 
+form CodegenLlvmConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick CodegenLlvmError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick CodegenLlvmResult[T] {
+  Ok(value: T)
+  Err(error: CodegenLlvmError)
+}
+
+proc default_config() -> CodegenLlvmConfig {
+  give CodegenLlvmConfig(true, codegen_llvm_policy_pkg.default_timeout_ms(), codegen_llvm_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: CodegenLlvmConfig) -> CodegenLlvmResult[bool] {
+  if codegen_llvm_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give CodegenLlvmResult.Err(CodegenLlvmError.InvalidConfig)
+  }
+  if codegen_llvm_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give CodegenLlvmResult.Err(CodegenLlvmError.InvalidConfig)
+  }
+  give CodegenLlvmResult.Ok(true)
+}
+
+proc healthcheck(cfg: CodegenLlvmConfig) -> CodegenLlvmResult[bool] {
+  let vr: CodegenLlvmResult[bool] = validate_config(cfg)
+  when vr is CodegenLlvmResult.Err {
+    give CodegenLlvmResult.Err(vr.error)
+  }
+  if codegen_llvm_runtime_pkg.runtime_status() == false {
+    give CodegenLlvmResult.Err(CodegenLlvmError.Internal)
+  }
+  give CodegenLlvmResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-CODEGENL0001" {
+    give "invalid package configuration"
+  }
+  give "codegen/llvm diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/codegen/llvm
 role: Orchestration commandes LLVM toolchain
 input_contract: IR et metadonnees cibles explicites
 output_contract: Commandes llc/opt stables
 boundary: N invoque pas les outils; prepare seulement
+
+owner: @vitte/llvm
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/codegen/mod.vit
+++ b/src/vitte/packages/codegen/mod.vit
@@ -5,6 +5,10 @@ package vitte/codegen
 
 space vitte/codegen
 
+use vitte/codegen/internal/runtime as codegen_runtime_pkg
+use vitte/codegen/internal/validate as codegen_validate_pkg
+use vitte/codegen/internal/policy as codegen_policy_pkg
+
 
 pick Backend {
   Gcc
@@ -54,10 +58,84 @@ proc package_meta() -> string {
   give "vitte/codegen"
 }
 
+form CodegenConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick CodegenError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick CodegenResult[T] {
+  Ok(value: T)
+  Err(error: CodegenError)
+}
+
+proc default_config() -> CodegenConfig {
+  give CodegenConfig(true, codegen_policy_pkg.default_timeout_ms(), codegen_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: CodegenConfig) -> CodegenResult[bool] {
+  if codegen_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give CodegenResult.Err(CodegenError.InvalidConfig)
+  }
+  if codegen_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give CodegenResult.Err(CodegenError.InvalidConfig)
+  }
+  give CodegenResult.Ok(true)
+}
+
+proc healthcheck(cfg: CodegenConfig) -> CodegenResult[bool] {
+  let vr: CodegenResult[bool] = validate_config(cfg)
+  when vr is CodegenResult.Err {
+    give CodegenResult.Err(vr.error)
+  }
+  if codegen_runtime_pkg.runtime_status() == false {
+    give CodegenResult.Err(CodegenError.Internal)
+  }
+  give CodegenResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-CODEGEN0001" {
+    give "invalid package configuration"
+  }
+  give "codegen diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/codegen
 role: Orchestration generation de code multi-backend
 input_contract: IR/AST valides et contraintes target explicites
 output_contract: Plan codegen deterministe
 boundary: Ne fait pas d optimisation metier implicite
+
+owner: @vitte/codegen
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/contracts_registry/internal/policy.vit
+++ b/src/vitte/packages/contracts_registry/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/contracts_registry/internal/policy
+
+proc default_max_contracts() -> int {
+  give 10000
+}

--- a/src/vitte/packages/contracts_registry/internal/runtime.vit
+++ b/src/vitte/packages/contracts_registry/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/contracts_registry/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/contracts_registry/internal/validate.vit
+++ b/src/vitte/packages/contracts_registry/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/contracts_registry/internal/validate
+
+proc valid_registry_name(name: string) -> bool {
+  give name.len > 0
+}
+
+proc valid_max_contracts(max_contracts: int) -> bool {
+  give max_contracts > 0 && max_contracts <= 50000
+}

--- a/src/vitte/packages/contracts_registry/mod.vit
+++ b/src/vitte/packages/contracts_registry/mod.vit
@@ -5,18 +5,91 @@ package vitte/contracts_registry
 
 space vitte/contracts_registry
 
+use vitte/contracts_registry/internal/runtime as contracts_registry_runtime_pkg
+use vitte/contracts_registry/internal/validate as contracts_registry_validate_pkg
+use vitte/contracts_registry/internal/policy as contracts_registry_policy_pkg
+
+form ContractsRegistryConfig {
+  registry_name: string
+  strict: bool
+  max_contracts: int
+}
+
+pick ContractsRegistryError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick ContractsRegistryResult[T] {
+  Ok(value: T)
+  Err(error: ContractsRegistryError)
+}
+
+proc default_config() -> ContractsRegistryConfig {
+  give ContractsRegistryConfig("default", true, contracts_registry_policy_pkg.default_max_contracts())
+}
+
+proc validate_config(cfg: ContractsRegistryConfig) -> ContractsRegistryResult[bool] {
+  if contracts_registry_validate_pkg.valid_registry_name(cfg.registry_name) == false {
+    give ContractsRegistryResult.Err(ContractsRegistryError.InvalidConfig)
+  }
+  if contracts_registry_validate_pkg.valid_max_contracts(cfg.max_contracts) == false {
+    give ContractsRegistryResult.Err(ContractsRegistryError.InvalidConfig)
+  }
+  give ContractsRegistryResult.Ok(true)
+}
+
+proc healthcheck(cfg: ContractsRegistryConfig) -> ContractsRegistryResult[bool] {
+  let vr: ContractsRegistryResult[bool] = validate_config(cfg)
+  when vr is ContractsRegistryResult.Err { give ContractsRegistryResult.Err(vr.error) }
+  if contracts_registry_runtime_pkg.runtime_status() == false {
+    give ContractsRegistryResult.Err(ContractsRegistryError.Internal)
+  }
+  give ContractsRegistryResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["contract-index", "strict-registry", "compat-check"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-CTRG0001" { give "invalid contracts_registry configuration" }
+  give "contracts_registry diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-CTRG0001" { give "set non-empty registry_name and valid max_contracts" }
+  give "review contracts_registry configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/contracts_registry"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/contracts_registry
 owner: @vitte/platform
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/contracts_registry
-input_contract: Entrees explicites et typables
-output_contract: Sorties stables et predictibles
+role: Registre de contrats publics et verifications associees
+input_contract: Config explicite du registre
+output_contract: Validation stable et predictible
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/data/internal/policy.vit
+++ b/src/vitte/packages/data/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/data/internal/policy
+
+proc default_cache_limit() -> int {
+  give 2048
+}

--- a/src/vitte/packages/data/internal/runtime.vit
+++ b/src/vitte/packages/data/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/data/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/data/internal/validate.vit
+++ b/src/vitte/packages/data/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/data/internal/validate
+
+proc valid_schema_name(schema_name: string) -> bool {
+  give schema_name.len > 0
+}
+
+proc valid_cache_limit(cache_limit: int) -> bool {
+  give cache_limit >= 0 && cache_limit <= 1000000
+}

--- a/src/vitte/packages/data/mod.vit
+++ b/src/vitte/packages/data/mod.vit
@@ -5,18 +5,91 @@ package vitte/data
 
 space vitte/data
 
+use vitte/data/internal/runtime as data_runtime_pkg
+use vitte/data/internal/validate as data_validate_pkg
+use vitte/data/internal/policy as data_policy_pkg
+
+form DataConfig {
+  schema_name: string
+  strict_schema: bool
+  cache_limit: int
+}
+
+pick DataError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick DataResult[T] {
+  Ok(value: T)
+  Err(error: DataError)
+}
+
+proc default_config() -> DataConfig {
+  give DataConfig("default", true, data_policy_pkg.default_cache_limit())
+}
+
+proc validate_config(cfg: DataConfig) -> DataResult[bool] {
+  if data_validate_pkg.valid_schema_name(cfg.schema_name) == false {
+    give DataResult.Err(DataError.InvalidConfig)
+  }
+  if data_validate_pkg.valid_cache_limit(cfg.cache_limit) == false {
+    give DataResult.Err(DataError.InvalidConfig)
+  }
+  give DataResult.Ok(true)
+}
+
+proc healthcheck(cfg: DataConfig) -> DataResult[bool] {
+  let vr: DataResult[bool] = validate_config(cfg)
+  when vr is DataResult.Err { give DataResult.Err(vr.error) }
+  if data_runtime_pkg.runtime_status() == false {
+    give DataResult.Err(DataError.Internal)
+  }
+  give DataResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["schema-check", "cache-limit", "strict-data"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-DATA0001" { give "invalid data configuration" }
+  give "data diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-DATA0001" { give "set non-empty schema_name and valid cache_limit" }
+  give "review data configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/data"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/data
 owner: @vitte/data
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/data
-input_contract: Entrees explicites et typables
-output_contract: Sorties stables et predictibles
+role: Facade data pour validation schema et contraintes cache
+input_contract: Config explicite schema/cache
+output_contract: Resultats stables et predictibles
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/docsgen_modules/internal/policy.vit
+++ b/src/vitte/packages/docsgen_modules/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/docsgen_modules/internal/policy
+
+proc default_format() -> string {
+  give "md"
+}

--- a/src/vitte/packages/docsgen_modules/internal/runtime.vit
+++ b/src/vitte/packages/docsgen_modules/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/docsgen_modules/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/docsgen_modules/internal/validate.vit
+++ b/src/vitte/packages/docsgen_modules/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/docsgen_modules/internal/validate
+
+proc valid_format(format: string) -> bool {
+  give format == "md" || format == "json"
+}
+
+proc valid_max_modules(max_modules: int) -> bool {
+  give max_modules > 0 && max_modules <= 10000
+}

--- a/src/vitte/packages/docsgen_modules/mod.vit
+++ b/src/vitte/packages/docsgen_modules/mod.vit
@@ -5,18 +5,91 @@ package vitte/docsgen_modules
 
 space vitte/docsgen_modules
 
+use vitte/docsgen_modules/internal/runtime as docsgen_runtime_pkg
+use vitte/docsgen_modules/internal/validate as docsgen_validate_pkg
+use vitte/docsgen_modules/internal/policy as docsgen_policy_pkg
+
+form DocsgenModulesConfig {
+  format: string
+  include_internal: bool
+  max_modules: int
+}
+
+pick DocsgenModulesError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick DocsgenModulesResult[T] {
+  Ok(value: T)
+  Err(error: DocsgenModulesError)
+}
+
+proc default_config() -> DocsgenModulesConfig {
+  give DocsgenModulesConfig(docsgen_policy_pkg.default_format(), false, 500)
+}
+
+proc validate_config(cfg: DocsgenModulesConfig) -> DocsgenModulesResult[bool] {
+  if docsgen_validate_pkg.valid_format(cfg.format) == false {
+    give DocsgenModulesResult.Err(DocsgenModulesError.InvalidConfig)
+  }
+  if docsgen_validate_pkg.valid_max_modules(cfg.max_modules) == false {
+    give DocsgenModulesResult.Err(DocsgenModulesError.InvalidConfig)
+  }
+  give DocsgenModulesResult.Ok(true)
+}
+
+proc healthcheck(cfg: DocsgenModulesConfig) -> DocsgenModulesResult[bool] {
+  let vr: DocsgenModulesResult[bool] = validate_config(cfg)
+  when vr is DocsgenModulesResult.Err { give DocsgenModulesResult.Err(vr.error) }
+  if docsgen_runtime_pkg.runtime_status() == false {
+    give DocsgenModulesResult.Err(DocsgenModulesError.Internal)
+  }
+  give DocsgenModulesResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["render-md", "render-json", "module-catalog"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-DOCM0001" { give "invalid docsgen_modules configuration" }
+  give "docsgen_modules diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-DOCM0001" { give "use format in {md,json} and positive max_modules" }
+  give "review docsgen_modules config"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/docsgen_modules"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/docsgen_modules
 owner: @vitte/platform
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/docsgen_modules
-input_contract: Entrees explicites et typables
+role: Generation de documentation des modules publics
+input_contract: Config explicite format/internal/max_modules
 output_contract: Sorties stables et predictibles
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/ffi/internal/policy.vit
+++ b/src/vitte/packages/ffi/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/ffi/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/ffi/internal/runtime.vit
+++ b/src/vitte/packages/ffi/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/ffi/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/ffi/internal/validate.vit
+++ b/src/vitte/packages/ffi/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/ffi/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/ffi/mod.vit
+++ b/src/vitte/packages/ffi/mod.vit
@@ -5,6 +5,10 @@ package vitte/ffi
 
 space vitte/ffi
 
+use vitte/ffi/internal/runtime as ffi_runtime_pkg
+use vitte/ffi/internal/validate as ffi_validate_pkg
+use vitte/ffi/internal/policy as ffi_policy_pkg
+
 
 form ForeignSymbol {
   lib: string
@@ -61,10 +65,84 @@ proc package_meta() -> string {
   give "vitte/ffi"
 }
 
+form FfiConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick FfiError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick FfiResult[T] {
+  Ok(value: T)
+  Err(error: FfiError)
+}
+
+proc default_config() -> FfiConfig {
+  give FfiConfig(true, ffi_policy_pkg.default_timeout_ms(), ffi_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: FfiConfig) -> FfiResult[bool] {
+  if ffi_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give FfiResult.Err(FfiError.InvalidConfig)
+  }
+  if ffi_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give FfiResult.Err(FfiError.InvalidConfig)
+  }
+  give FfiResult.Ok(true)
+}
+
+proc healthcheck(cfg: FfiConfig) -> FfiResult[bool] {
+  let vr: FfiResult[bool] = validate_config(cfg)
+  when vr is FfiResult.Err {
+    give FfiResult.Err(vr.error)
+  }
+  if ffi_runtime_pkg.runtime_status() == false {
+    give FfiResult.Err(FfiError.Internal)
+  }
+  give FfiResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-FFI0001" {
+    give "invalid package configuration"
+  }
+  give "ffi diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/ffi
 role: Pont fonctions natives et signatures
 input_contract: Definitions ABI explicites
 output_contract: Symboles FFI validables
 boundary: N execute pas de code natif directement
+
+owner: @vitte/ffi
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/kernel/internal/policy.vit
+++ b/src/vitte/packages/kernel/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/kernel/internal/policy
+
+proc default_surface() -> string {
+  give "minimal"
+}

--- a/src/vitte/packages/kernel/internal/runtime.vit
+++ b/src/vitte/packages/kernel/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/kernel/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/kernel/internal/validate.vit
+++ b/src/vitte/packages/kernel/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/kernel/internal/validate
+
+proc valid_surface(surface: string) -> bool {
+  give surface == "minimal" || surface == "extended"
+}
+
+proc valid_profile(profile: string) -> bool {
+  give profile == "core" || profile == "system" || profile == "desktop"
+}

--- a/src/vitte/packages/kernel/mod.vit
+++ b/src/vitte/packages/kernel/mod.vit
@@ -5,8 +5,79 @@ package vitte/kernel
 
 space vitte/kernel
 
+use vitte/kernel/internal/runtime as kernel_runtime_pkg
+use vitte/kernel/internal/validate as kernel_validate_pkg
+use vitte/kernel/internal/policy as kernel_policy_pkg
+
+form KernelConfig {
+  surface: string
+  profile: string
+  strict: bool
+}
+
+pick KernelError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick KernelResult[T] {
+  Ok(value: T)
+  Err(error: KernelError)
+}
+
+proc default_config() -> KernelConfig {
+  give KernelConfig(kernel_policy_pkg.default_surface(), "core", true)
+}
+
+proc validate_config(cfg: KernelConfig) -> KernelResult[bool] {
+  if kernel_validate_pkg.valid_surface(cfg.surface) == false {
+    give KernelResult.Err(KernelError.InvalidConfig)
+  }
+  if kernel_validate_pkg.valid_profile(cfg.profile) == false {
+    give KernelResult.Err(KernelError.InvalidConfig)
+  }
+  give KernelResult.Ok(true)
+}
+
+proc healthcheck(cfg: KernelConfig) -> KernelResult[bool] {
+  let vr: KernelResult[bool] = validate_config(cfg)
+  when vr is KernelResult.Err { give KernelResult.Err(vr.error) }
+  if kernel_runtime_pkg.runtime_status() == false {
+    give KernelResult.Err(KernelError.Internal)
+  }
+  give KernelResult.Ok(true)
+}
+
 proc runtime_surface() -> string {
-  give "minimal"
+  give kernel_policy_pkg.default_surface()
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["runtime-surface", "abi-bridge", "profile-aware"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-KERN0001" { give "invalid kernel configuration" }
+  give "kernel diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-KERN0001" { give "use surface in {minimal,extended} and valid profile" }
+  give "review kernel configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/kernel"
 }
 
 proc ready() -> bool {
@@ -23,4 +94,6 @@ role: API runtime minimale commune isolee de std
 input_contract: Appels explicites sans dependances haut niveau
 output_contract: Surface stable pour runtime/abi
 boundary: Pas de std, pas de side-effects implicites
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/math/internal/policy.vit
+++ b/src/vitte/packages/math/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/math/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/math/internal/runtime.vit
+++ b/src/vitte/packages/math/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/math/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/math/internal/validate.vit
+++ b/src/vitte/packages/math/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/math/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/math/mod.vit
+++ b/src/vitte/packages/math/mod.vit
@@ -5,6 +5,10 @@ package vitte/math
 
 space vitte/math
 
+use vitte/math/internal/runtime as math_runtime_pkg
+use vitte/math/internal/validate as math_validate_pkg
+use vitte/math/internal/policy as math_policy_pkg
+
 
 proc abs(n: int) -> int {
   if n < 0 { give 0 - n }
@@ -54,10 +58,84 @@ proc package_meta() -> string {
   give "vitte/math"
 }
 
+form MathConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick MathError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick MathResult[T] {
+  Ok(value: T)
+  Err(error: MathError)
+}
+
+proc default_config() -> MathConfig {
+  give MathConfig(true, math_policy_pkg.default_timeout_ms(), math_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: MathConfig) -> MathResult[bool] {
+  if math_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give MathResult.Err(MathError.InvalidConfig)
+  }
+  if math_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give MathResult.Err(MathError.InvalidConfig)
+  }
+  give MathResult.Ok(true)
+}
+
+proc healthcheck(cfg: MathConfig) -> MathResult[bool] {
+  let vr: MathResult[bool] = validate_config(cfg)
+  when vr is MathResult.Err {
+    give MathResult.Err(vr.error)
+  }
+  if math_runtime_pkg.runtime_status() == false {
+    give MathResult.Err(MathError.Internal)
+  }
+  give MathResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-MATH0001" {
+    give "invalid package configuration"
+  }
+  give "math diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/math
 role: Operations mathematiques utilitaires deterministes
 input_contract: Entiers deja valides selon domaine metier
 output_contract: Resultats purs et reproductibles
 boundary: Pas d approximation flottante implicite
+
+owner: @vitte/math
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/migration_playbook/internal/policy.vit
+++ b/src/vitte/packages/migration_playbook/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/migration_playbook/internal/policy
+
+proc default_dry_run() -> bool {
+  give true
+}

--- a/src/vitte/packages/migration_playbook/internal/runtime.vit
+++ b/src/vitte/packages/migration_playbook/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/migration_playbook/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/migration_playbook/internal/validate.vit
+++ b/src/vitte/packages/migration_playbook/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/migration_playbook/internal/validate
+
+proc valid_from_version(v: string) -> bool {
+  give v.len > 0
+}
+
+proc valid_to_version(v: string) -> bool {
+  give v.len > 0
+}

--- a/src/vitte/packages/migration_playbook/mod.vit
+++ b/src/vitte/packages/migration_playbook/mod.vit
@@ -5,18 +5,91 @@ package vitte/migration_playbook
 
 space vitte/migration_playbook
 
+use vitte/migration_playbook/internal/runtime as migration_playbook_runtime_pkg
+use vitte/migration_playbook/internal/validate as migration_playbook_validate_pkg
+use vitte/migration_playbook/internal/policy as migration_playbook_policy_pkg
+
+form MigrationPlaybookConfig {
+  from_version: string
+  to_version: string
+  dry_run: bool
+}
+
+pick MigrationPlaybookError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick MigrationPlaybookResult[T] {
+  Ok(value: T)
+  Err(error: MigrationPlaybookError)
+}
+
+proc default_config() -> MigrationPlaybookConfig {
+  give MigrationPlaybookConfig("0.0.0", "0.0.1", migration_playbook_policy_pkg.default_dry_run())
+}
+
+proc validate_config(cfg: MigrationPlaybookConfig) -> MigrationPlaybookResult[bool] {
+  if migration_playbook_validate_pkg.valid_from_version(cfg.from_version) == false {
+    give MigrationPlaybookResult.Err(MigrationPlaybookError.InvalidConfig)
+  }
+  if migration_playbook_validate_pkg.valid_to_version(cfg.to_version) == false {
+    give MigrationPlaybookResult.Err(MigrationPlaybookError.InvalidConfig)
+  }
+  give MigrationPlaybookResult.Ok(true)
+}
+
+proc healthcheck(cfg: MigrationPlaybookConfig) -> MigrationPlaybookResult[bool] {
+  let vr: MigrationPlaybookResult[bool] = validate_config(cfg)
+  when vr is MigrationPlaybookResult.Err { give MigrationPlaybookResult.Err(vr.error) }
+  if migration_playbook_runtime_pkg.runtime_status() == false {
+    give MigrationPlaybookResult.Err(MigrationPlaybookError.Internal)
+  }
+  give MigrationPlaybookResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["planning", "dry-run", "compat-report"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-MIGP0001" { give "invalid migration playbook configuration" }
+  give "migration_playbook diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-MIGP0001" { give "set valid from_version and to_version" }
+  give "review migration_playbook configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/migration_playbook"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/migration_playbook
 owner: @vitte/platform
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/migration_playbook
-input_contract: Entrees explicites et typables
-output_contract: Sorties stables et predictibles
+role: Orchestration de plans de migration compatibles
+input_contract: Versions et mode dry-run explicites
+output_contract: Validation stable et predictable
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/module_index/internal/policy.vit
+++ b/src/vitte/packages/module_index/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/module_index/internal/policy
+
+proc default_max_nodes() -> int {
+  give 10000
+}

--- a/src/vitte/packages/module_index/internal/runtime.vit
+++ b/src/vitte/packages/module_index/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/module_index/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/module_index/internal/validate.vit
+++ b/src/vitte/packages/module_index/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/module_index/internal/validate
+
+proc valid_root_module(root_module: string) -> bool {
+  give root_module.len > 0
+}
+
+proc valid_max_nodes(max_nodes: int) -> bool {
+  give max_nodes > 0 && max_nodes <= 100000
+}

--- a/src/vitte/packages/module_index/mod.vit
+++ b/src/vitte/packages/module_index/mod.vit
@@ -5,18 +5,90 @@ package vitte/module_index
 
 space vitte/module_index
 
+use vitte/module_index/internal/runtime as module_index_runtime_pkg
+use vitte/module_index/internal/validate as module_index_validate_pkg
+use vitte/module_index/internal/policy as module_index_policy_pkg
+
+form ModuleIndexConfig {
+  root_module: string
+  strict: bool
+  max_nodes: int
+}
+
+pick ModuleIndexError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick ModuleIndexResult[T] {
+  Ok(value: T)
+  Err(error: ModuleIndexError)
+}
+
+proc default_config() -> ModuleIndexConfig {
+  give ModuleIndexConfig("__root__", true, module_index_policy_pkg.default_max_nodes())
+}
+
+proc validate_config(cfg: ModuleIndexConfig) -> ModuleIndexResult[bool] {
+  if module_index_validate_pkg.valid_root_module(cfg.root_module) == false {
+    give ModuleIndexResult.Err(ModuleIndexError.InvalidConfig)
+  }
+  if module_index_validate_pkg.valid_max_nodes(cfg.max_nodes) == false {
+    give ModuleIndexResult.Err(ModuleIndexError.InvalidConfig)
+  }
+  give ModuleIndexResult.Ok(true)
+}
+
+proc healthcheck(cfg: ModuleIndexConfig) -> ModuleIndexResult[bool] {
+  let _ = cfg
+  if module_index_runtime_pkg.runtime_status() == false {
+    give ModuleIndexResult.Err(ModuleIndexError.Internal)
+  }
+  give ModuleIndexResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["graph", "index", "strict-imports"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-MIDX0001" { give "invalid module index configuration" }
+  give "module_index diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-MIDX0001" { give "set root_module and max_nodes to valid values" }
+  give "review module_index configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/module_index"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/module_index
 owner: @vitte/platform
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/module_index
-input_contract: Entrees explicites et typables
-output_contract: Sorties stables et predictibles
+role: Index stable des modules et capabilities associees
+input_contract: Config explicite et typable
+output_contract: Resultats stables et predictibles
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/pickle/internal/policy.vit
+++ b/src/vitte/packages/pickle/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/pickle/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/pickle/internal/runtime.vit
+++ b/src/vitte/packages/pickle/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/pickle/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/pickle/internal/validate.vit
+++ b/src/vitte/packages/pickle/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/pickle/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/pickle/mod.vit
+++ b/src/vitte/packages/pickle/mod.vit
@@ -5,6 +5,10 @@ package vitte/pickle
 
 space vitte/pickle
 
+use vitte/pickle/internal/runtime as pickle_runtime_pkg
+use vitte/pickle/internal/validate as pickle_validate_pkg
+use vitte/pickle/internal/policy as pickle_policy_pkg
+
 
 form Pair {
   key: string
@@ -94,10 +98,84 @@ proc package_meta() -> string {
   give "vitte/pickle"
 }
 
+form PickleConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick PickleError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick PickleResult[T] {
+  Ok(value: T)
+  Err(error: PickleError)
+}
+
+proc default_config() -> PickleConfig {
+  give PickleConfig(true, pickle_policy_pkg.default_timeout_ms(), pickle_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: PickleConfig) -> PickleResult[bool] {
+  if pickle_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give PickleResult.Err(PickleError.InvalidConfig)
+  }
+  if pickle_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give PickleResult.Err(PickleError.InvalidConfig)
+  }
+  give PickleResult.Ok(true)
+}
+
+proc healthcheck(cfg: PickleConfig) -> PickleResult[bool] {
+  let vr: PickleResult[bool] = validate_config(cfg)
+  when vr is PickleResult.Err {
+    give PickleResult.Err(vr.error)
+  }
+  if pickle_runtime_pkg.runtime_status() == false {
+    give PickleResult.Err(PickleError.Internal)
+  }
+  give PickleResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-PICKLE0001" {
+    give "invalid package configuration"
+  }
+  give "pickle diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/pickle
 role: Encodage/decodage compact de paires cle-valeur
 input_contract: Donnees deja normalisees et serialisables
 output_contract: Format stable reversible avec erreurs explicites
 boundary: Pas de crypto ni compression; serialisation legere uniquement
+
+owner: @vitte/pickle
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/platform/internal/policy.vit
+++ b/src/vitte/packages/platform/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/platform/internal/policy
+
+proc default_profile() -> string {
+  give "desktop"
+}

--- a/src/vitte/packages/platform/internal/runtime.vit
+++ b/src/vitte/packages/platform/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/platform/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/platform/internal/validate.vit
+++ b/src/vitte/packages/platform/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/platform/internal/validate
+
+proc valid_target(target: string) -> bool {
+  give target == "host" || target == "arduino" || target == "kernel"
+}
+
+proc valid_profile(profile: string) -> bool {
+  give profile == "core" || profile == "system" || profile == "desktop" || profile == "arduino"
+}

--- a/src/vitte/packages/platform/mod.vit
+++ b/src/vitte/packages/platform/mod.vit
@@ -5,18 +5,91 @@ package vitte/platform
 
 space vitte/platform
 
+use vitte/platform/internal/runtime as platform_runtime_pkg
+use vitte/platform/internal/validate as platform_validate_pkg
+use vitte/platform/internal/policy as platform_policy_pkg
+
+form PlatformConfig {
+  target: string
+  profile: string
+  strict: bool
+}
+
+pick PlatformError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick PlatformResult[T] {
+  Ok(value: T)
+  Err(error: PlatformError)
+}
+
+proc default_config() -> PlatformConfig {
+  give PlatformConfig("host", platform_policy_pkg.default_profile(), true)
+}
+
+proc validate_config(cfg: PlatformConfig) -> PlatformResult[bool] {
+  if platform_validate_pkg.valid_target(cfg.target) == false {
+    give PlatformResult.Err(PlatformError.InvalidConfig)
+  }
+  if platform_validate_pkg.valid_profile(cfg.profile) == false {
+    give PlatformResult.Err(PlatformError.InvalidConfig)
+  }
+  give PlatformResult.Ok(true)
+}
+
+proc healthcheck(cfg: PlatformConfig) -> PlatformResult[bool] {
+  let vr: PlatformResult[bool] = validate_config(cfg)
+  when vr is PlatformResult.Err { give PlatformResult.Err(vr.error) }
+  if platform_runtime_pkg.runtime_status() == false {
+    give PlatformResult.Err(PlatformError.Internal)
+  }
+  give PlatformResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["profile-gating", "target-compat", "runtime-matrix"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-PLAT0001" { give "invalid platform target or profile" }
+  give "platform diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-PLAT0001" { give "use target in {host,arduino,kernel} and valid profile" }
+  give "review platform profile configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/platform"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/platform
 owner: @vitte/platform
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/platform
-input_contract: Entrees explicites et typables
-output_contract: Sorties stables et predictibles
+role: Abstraction des profils et cibles runtime
+input_contract: Target profile strict explicites
+output_contract: Validation stable et capabilities explicites
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/plot/internal/policy.vit
+++ b/src/vitte/packages/plot/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/plot/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/plot/internal/runtime.vit
+++ b/src/vitte/packages/plot/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/plot/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/plot/internal/validate.vit
+++ b/src/vitte/packages/plot/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/plot/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/plot/mod.vit
+++ b/src/vitte/packages/plot/mod.vit
@@ -5,6 +5,10 @@ package vitte/plot
 
 space vitte/plot
 
+use vitte/plot/internal/runtime as plot_runtime_pkg
+use vitte/plot/internal/validate as plot_validate_pkg
+use vitte/plot/internal/policy as plot_policy_pkg
+
 
 form Point {
   x: int
@@ -56,10 +60,84 @@ proc package_meta() -> string {
   give "vitte/plot"
 }
 
+form PlotConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick PlotError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick PlotResult[T] {
+  Ok(value: T)
+  Err(error: PlotError)
+}
+
+proc default_config() -> PlotConfig {
+  give PlotConfig(true, plot_policy_pkg.default_timeout_ms(), plot_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: PlotConfig) -> PlotResult[bool] {
+  if plot_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give PlotResult.Err(PlotError.InvalidConfig)
+  }
+  if plot_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give PlotResult.Err(PlotError.InvalidConfig)
+  }
+  give PlotResult.Ok(true)
+}
+
+proc healthcheck(cfg: PlotConfig) -> PlotResult[bool] {
+  let vr: PlotResult[bool] = validate_config(cfg)
+  when vr is PlotResult.Err {
+    give PlotResult.Err(vr.error)
+  }
+  if plot_runtime_pkg.runtime_status() == false {
+    give PlotResult.Err(PlotError.Internal)
+  }
+  give PlotResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-PLOT0001" {
+    give "invalid package configuration"
+  }
+  give "plot diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/plot
 role: Primitives de visualisation de series numeriques
 input_contract: Points numeriques deja valides
 output_contract: Structures plottables deterministes
 boundary: Ne rend pas UI directe
+
+owner: @vitte/plot
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/random_secure/internal/policy.vit
+++ b/src/vitte/packages/random_secure/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/random_secure/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/random_secure/internal/runtime.vit
+++ b/src/vitte/packages/random_secure/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/random_secure/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/random_secure/internal/validate.vit
+++ b/src/vitte/packages/random_secure/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/random_secure/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/random_secure/mod.vit
+++ b/src/vitte/packages/random_secure/mod.vit
@@ -5,6 +5,10 @@ package vitte/random_secure
 
 space vitte/random_secure
 
+use vitte/random_secure/internal/runtime as random_secure_runtime_pkg
+use vitte/random_secure/internal/validate as random_secure_validate_pkg
+use vitte/random_secure/internal/policy as random_secure_policy_pkg
+
 
 form RngState {
   seed: int
@@ -50,10 +54,84 @@ proc package_meta() -> string {
   give "vitte/random_secure"
 }
 
+form RandomSecureConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick RandomSecureError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick RandomSecureResult[T] {
+  Ok(value: T)
+  Err(error: RandomSecureError)
+}
+
+proc default_config() -> RandomSecureConfig {
+  give RandomSecureConfig(true, random_secure_policy_pkg.default_timeout_ms(), random_secure_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: RandomSecureConfig) -> RandomSecureResult[bool] {
+  if random_secure_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give RandomSecureResult.Err(RandomSecureError.InvalidConfig)
+  }
+  if random_secure_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give RandomSecureResult.Err(RandomSecureError.InvalidConfig)
+  }
+  give RandomSecureResult.Ok(true)
+}
+
+proc healthcheck(cfg: RandomSecureConfig) -> RandomSecureResult[bool] {
+  let vr: RandomSecureResult[bool] = validate_config(cfg)
+  when vr is RandomSecureResult.Err {
+    give RandomSecureResult.Err(vr.error)
+  }
+  if random_secure_runtime_pkg.runtime_status() == false {
+    give RandomSecureResult.Err(RandomSecureError.Internal)
+  }
+  give RandomSecureResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-RANDOMSE0001" {
+    give "invalid package configuration"
+  }
+  give "random_secure diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/random_secure
 role: Generation pseudo-aleatoire a usage securise applique
 input_contract: Entropie seed explicite
 output_contract: Flux deterministe testable
 boundary: Pas de promesse crypto forte sans source systeme
+
+owner: @vitte/random_secure
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/release_guard/internal/policy.vit
+++ b/src/vitte/packages/release_guard/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/release_guard/internal/policy
+
+proc default_breaking_policy() -> bool {
+  give false
+}

--- a/src/vitte/packages/release_guard/internal/runtime.vit
+++ b/src/vitte/packages/release_guard/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/release_guard/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/release_guard/internal/validate.vit
+++ b/src/vitte/packages/release_guard/internal/validate.vit
@@ -1,0 +1,5 @@
+space vitte/release_guard/internal/validate
+
+proc valid_version(v: string) -> bool {
+  give v.len > 0
+}

--- a/src/vitte/packages/release_guard/mod.vit
+++ b/src/vitte/packages/release_guard/mod.vit
@@ -5,18 +5,91 @@ package vitte/release_guard
 
 space vitte/release_guard
 
+use vitte/release_guard/internal/runtime as release_guard_runtime_pkg
+use vitte/release_guard/internal/validate as release_guard_validate_pkg
+use vitte/release_guard/internal/policy as release_guard_policy_pkg
+
+form ReleaseGuardConfig {
+  current_version: string
+  previous_version: string
+  breaking_change: bool
+}
+
+pick ReleaseGuardError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick ReleaseGuardResult[T] {
+  Ok(value: T)
+  Err(error: ReleaseGuardError)
+}
+
+proc default_config() -> ReleaseGuardConfig {
+  give ReleaseGuardConfig("0.0.0", "0.0.0", release_guard_policy_pkg.default_breaking_policy())
+}
+
+proc validate_config(cfg: ReleaseGuardConfig) -> ReleaseGuardResult[bool] {
+  if release_guard_validate_pkg.valid_version(cfg.current_version) == false {
+    give ReleaseGuardResult.Err(ReleaseGuardError.InvalidConfig)
+  }
+  if release_guard_validate_pkg.valid_version(cfg.previous_version) == false {
+    give ReleaseGuardResult.Err(ReleaseGuardError.InvalidConfig)
+  }
+  give ReleaseGuardResult.Ok(true)
+}
+
+proc healthcheck(cfg: ReleaseGuardConfig) -> ReleaseGuardResult[bool] {
+  let vr: ReleaseGuardResult[bool] = validate_config(cfg)
+  when vr is ReleaseGuardResult.Err { give ReleaseGuardResult.Err(vr.error) }
+  if release_guard_runtime_pkg.runtime_status() == false {
+    give ReleaseGuardResult.Err(ReleaseGuardError.Internal)
+  }
+  give ReleaseGuardResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["breaking-check", "migration-gate", "semver-guard"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-RGUARD0001" { give "invalid release guard configuration" }
+  give "release_guard diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-RGUARD0001" { give "set non-empty current_version and previous_version" }
+  give "review release guard policy"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/release_guard"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/release_guard
 owner: @vitte/platform
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/release_guard
-input_contract: Entrees explicites et typables
-output_contract: Sorties stables et predictibles
+role: Garde-fous de release et compatibilite de version
+input_contract: Versions explicites et politique de rupture
+output_contract: Decision stable de validation release
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/rope/internal/policy.vit
+++ b/src/vitte/packages/rope/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/rope/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/rope/internal/runtime.vit
+++ b/src/vitte/packages/rope/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/rope/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/rope/internal/validate.vit
+++ b/src/vitte/packages/rope/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/rope/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/rope/mod.vit
+++ b/src/vitte/packages/rope/mod.vit
@@ -5,6 +5,10 @@ package vitte/rope
 
 space vitte/rope
 
+use vitte/rope/internal/runtime as rope_runtime_pkg
+use vitte/rope/internal/validate as rope_validate_pkg
+use vitte/rope/internal/policy as rope_policy_pkg
+
 
 form Rope {
   chunks: [string]
@@ -52,10 +56,84 @@ proc package_meta() -> string {
   give "vitte/rope"
 }
 
+form RopeConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick RopeError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick RopeResult[T] {
+  Ok(value: T)
+  Err(error: RopeError)
+}
+
+proc default_config() -> RopeConfig {
+  give RopeConfig(true, rope_policy_pkg.default_timeout_ms(), rope_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: RopeConfig) -> RopeResult[bool] {
+  if rope_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give RopeResult.Err(RopeError.InvalidConfig)
+  }
+  if rope_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give RopeResult.Err(RopeError.InvalidConfig)
+  }
+  give RopeResult.Ok(true)
+}
+
+proc healthcheck(cfg: RopeConfig) -> RopeResult[bool] {
+  let vr: RopeResult[bool] = validate_config(cfg)
+  when vr is RopeResult.Err {
+    give RopeResult.Err(vr.error)
+  }
+  if rope_runtime_pkg.runtime_status() == false {
+    give RopeResult.Err(RopeError.Internal)
+  }
+  give RopeResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-ROPE0001" {
+    give "invalid package configuration"
+  }
+  give "rope diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/rope
 role: Manipulation efficace de chaines segmentees
 input_contract: Chunks textuels normalises
 output_contract: Concatenation stable et previsible
 boundary: N effectue pas d I/O, uniquement structures texte
+
+owner: @vitte/rope
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/runtime/internal/policy.vit
+++ b/src/vitte/packages/runtime/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/runtime/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/runtime/internal/runtime.vit
+++ b/src/vitte/packages/runtime/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/runtime/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/runtime/internal/validate.vit
+++ b/src/vitte/packages/runtime/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/runtime/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/runtime/mod.vit
+++ b/src/vitte/packages/runtime/mod.vit
@@ -5,6 +5,10 @@ package vitte/runtime
 
 space vitte/runtime
 
+use vitte/runtime/internal/runtime as runtime_runtime_pkg
+use vitte/runtime/internal/validate as runtime_validate_pkg
+use vitte/runtime/internal/policy as runtime_policy_pkg
+
 
 pick RuntimeMode {
   Dev
@@ -55,10 +59,78 @@ proc package_meta() -> string {
   give "vitte/runtime"
 }
 
+pick RuntimeError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick RuntimeResult[T] {
+  Ok(value: T)
+  Err(error: RuntimeError)
+}
+
+proc default_config() -> RuntimeConfig {
+  give RuntimeConfig(true, runtime_policy_pkg.default_timeout_ms(), runtime_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: RuntimeConfig) -> RuntimeResult[bool] {
+  if runtime_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give RuntimeResult.Err(RuntimeError.InvalidConfig)
+  }
+  if runtime_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give RuntimeResult.Err(RuntimeError.InvalidConfig)
+  }
+  give RuntimeResult.Ok(true)
+}
+
+proc healthcheck(cfg: RuntimeConfig) -> RuntimeResult[bool] {
+  let vr: RuntimeResult[bool] = validate_config(cfg)
+  when vr is RuntimeResult.Err {
+    give RuntimeResult.Err(vr.error)
+  }
+  if runtime_runtime_pkg.runtime_status() == false {
+    give RuntimeResult.Err(RuntimeError.Internal)
+  }
+  give RuntimeResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-RUNTIME0001" {
+    give "invalid package configuration"
+  }
+  give "runtime diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/runtime
 role: Configuration execution et cycles runtime
 input_contract: Parametres runtime explicites
 output_contract: Etat runtime validable et observable
 boundary: Ne remplace pas scheduler/IO bas niveau
+
+owner: @vitte/runtime
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/shell/internal/policy.vit
+++ b/src/vitte/packages/shell/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/shell/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/shell/internal/runtime.vit
+++ b/src/vitte/packages/shell/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/shell/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/shell/internal/validate.vit
+++ b/src/vitte/packages/shell/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/shell/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/shell/mod.vit
+++ b/src/vitte/packages/shell/mod.vit
@@ -5,6 +5,10 @@ package vitte/shell
 
 space vitte/shell
 
+use vitte/shell/internal/runtime as shell_runtime_pkg
+use vitte/shell/internal/validate as shell_validate_pkg
+use vitte/shell/internal/policy as shell_policy_pkg
+
 
 form Command {
   bin: string
@@ -58,10 +62,84 @@ proc package_meta() -> string {
   give "vitte/shell"
 }
 
+form ShellConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick ShellError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick ShellResult[T] {
+  Ok(value: T)
+  Err(error: ShellError)
+}
+
+proc default_config() -> ShellConfig {
+  give ShellConfig(true, shell_policy_pkg.default_timeout_ms(), shell_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: ShellConfig) -> ShellResult[bool] {
+  if shell_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give ShellResult.Err(ShellError.InvalidConfig)
+  }
+  if shell_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give ShellResult.Err(ShellError.InvalidConfig)
+  }
+  give ShellResult.Ok(true)
+}
+
+proc healthcheck(cfg: ShellConfig) -> ShellResult[bool] {
+  let vr: ShellResult[bool] = validate_config(cfg)
+  when vr is ShellResult.Err {
+    give ShellResult.Err(vr.error)
+  }
+  if shell_runtime_pkg.runtime_status() == false {
+    give ShellResult.Err(ShellError.Internal)
+  }
+  give ShellResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-SHELL0001" {
+    give "invalid package configuration"
+  }
+  give "shell diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/shell
 role: Construction de commandes shell securisees
 input_contract: Binaire/arguments explicites
 output_contract: Commandes rendues de facon deterministe
 boundary: Ne lance pas les process directement
+
+owner: @vitte/shell
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/std/async/internal/policy.vit
+++ b/src/vitte/packages/std/async/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/std/async/internal/policy
+
+proc default_queue_depth() -> int {
+  give 64
+}

--- a/src/vitte/packages/std/async/internal/runtime.vit
+++ b/src/vitte/packages/std/async/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/std/async/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/std/async/internal/validate.vit
+++ b/src/vitte/packages/std/async/internal/validate.vit
@@ -1,0 +1,5 @@
+space vitte/std/async/internal/validate
+
+proc valid_queue_depth(queue_depth: int) -> bool {
+  give queue_depth > 0 && queue_depth <= 100000
+}

--- a/src/vitte/packages/std/async/mod.vit
+++ b/src/vitte/packages/std/async/mod.vit
@@ -2,10 +2,91 @@
 mod.vit
 package vitte/std/async
 >>>
-# ASYNC layer entrypoints (façade only)
 
 space vitte/std/async
+
+use vitte/std/async/internal/runtime as std_async_runtime_pkg
+use vitte/std/async/internal/validate as std_async_validate_pkg
+use vitte/std/async/internal/policy as std_async_policy_pkg
+
+form StdAsyncConfig {
+  queue_depth: int
+  cooperative: bool
+  deterministic: bool
+}
+
+pick StdAsyncError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick StdAsyncResult[T] {
+  Ok(value: T)
+  Err(error: StdAsyncError)
+}
+
+proc default_config() -> StdAsyncConfig {
+  give StdAsyncConfig(std_async_policy_pkg.default_queue_depth(), true, true)
+}
+
+proc validate_config(cfg: StdAsyncConfig) -> StdAsyncResult[bool] {
+  if std_async_validate_pkg.valid_queue_depth(cfg.queue_depth) == false {
+    give StdAsyncResult.Err(StdAsyncError.InvalidConfig)
+  }
+  give StdAsyncResult.Ok(true)
+}
+
+proc healthcheck(cfg: StdAsyncConfig) -> StdAsyncResult[bool] {
+  let vr: StdAsyncResult[bool] = validate_config(cfg)
+  when vr is StdAsyncResult.Err { give StdAsyncResult.Err(vr.error) }
+  if std_async_runtime_pkg.runtime_status() == false {
+    give StdAsyncResult.Err(StdAsyncError.Internal)
+  }
+  give StdAsyncResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["queue-depth", "cooperative", "deterministic"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-STDASYNC0001" { give "invalid std/async configuration" }
+  give "std/async diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-STDASYNC0001" { give "use queue_depth in valid range" }
+  give "review std/async configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
 
 proc package_meta() -> string {
   give "vitte/std/async"
 }
+
+proc ready() -> bool {
+  give true
+}
+
+<<< ROLE-CONTRACT
+package: vitte/std/async
+owner: @vitte/std
+stability: stable
+since: 3.0.0
+deprecated_in: -
+role: Facade async standard lisible et stable
+input_contract: Config async explicite
+output_contract: Resultats stables pour usages std
+boundary: Facade pure; details runtime sous internal/*
+compat_policy: additive-only
+api_version: v1
+>>>

--- a/src/vitte/packages/std/data/internal/policy.vit
+++ b/src/vitte/packages/std/data/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/std/data/internal/policy
+
+proc default_cache_size() -> int {
+  give 1024
+}

--- a/src/vitte/packages/std/data/internal/runtime.vit
+++ b/src/vitte/packages/std/data/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/std/data/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/std/data/internal/validate.vit
+++ b/src/vitte/packages/std/data/internal/validate.vit
@@ -1,0 +1,5 @@
+space vitte/std/data/internal/validate
+
+proc valid_cache_size(cache_size: int) -> bool {
+  give cache_size >= 0 && cache_size <= 1000000
+}

--- a/src/vitte/packages/std/data/mod.vit
+++ b/src/vitte/packages/std/data/mod.vit
@@ -2,10 +2,91 @@
 mod.vit
 package vitte/std/data
 >>>
-# DATA layer entrypoints (façade only)
 
 space vitte/std/data
+
+use vitte/std/data/internal/runtime as std_data_runtime_pkg
+use vitte/std/data/internal/validate as std_data_validate_pkg
+use vitte/std/data/internal/policy as std_data_policy_pkg
+
+form StdDataConfig {
+  cache_size: int
+  strict_schema: bool
+  deterministic: bool
+}
+
+pick StdDataError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick StdDataResult[T] {
+  Ok(value: T)
+  Err(error: StdDataError)
+}
+
+proc default_config() -> StdDataConfig {
+  give StdDataConfig(std_data_policy_pkg.default_cache_size(), true, true)
+}
+
+proc validate_config(cfg: StdDataConfig) -> StdDataResult[bool] {
+  if std_data_validate_pkg.valid_cache_size(cfg.cache_size) == false {
+    give StdDataResult.Err(StdDataError.InvalidConfig)
+  }
+  give StdDataResult.Ok(true)
+}
+
+proc healthcheck(cfg: StdDataConfig) -> StdDataResult[bool] {
+  let vr: StdDataResult[bool] = validate_config(cfg)
+  when vr is StdDataResult.Err { give StdDataResult.Err(vr.error) }
+  if std_data_runtime_pkg.runtime_status() == false {
+    give StdDataResult.Err(StdDataError.Internal)
+  }
+  give StdDataResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["schema-strict", "cache", "deterministic"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-STDDATA0001" { give "invalid std/data configuration" }
+  give "std/data diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-STDDATA0001" { give "use cache_size in valid range" }
+  give "review std/data configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
 
 proc package_meta() -> string {
   give "vitte/std/data"
 }
+
+proc ready() -> bool {
+  give true
+}
+
+<<< ROLE-CONTRACT
+package: vitte/std/data
+owner: @vitte/std
+stability: stable
+since: 3.0.0
+deprecated_in: -
+role: Facade data standard lisible et stable
+input_contract: Config data explicite
+output_contract: Resultats stables pour usages std
+boundary: Facade pure; details runtime sous internal/*
+compat_policy: additive-only
+api_version: v1
+>>>

--- a/src/vitte/packages/std/io/internal/policy.vit
+++ b/src/vitte/packages/std/io/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/std/io/internal/policy
+
+proc default_buffer_size() -> int {
+  give 4096
+}

--- a/src/vitte/packages/std/io/internal/runtime.vit
+++ b/src/vitte/packages/std/io/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/std/io/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/std/io/internal/validate.vit
+++ b/src/vitte/packages/std/io/internal/validate.vit
@@ -1,0 +1,5 @@
+space vitte/std/io/internal/validate
+
+proc valid_buffer_size(buffer_size: int) -> bool {
+  give buffer_size > 0 && buffer_size <= 1048576
+}

--- a/src/vitte/packages/std/io/mod.vit
+++ b/src/vitte/packages/std/io/mod.vit
@@ -2,10 +2,91 @@
 mod.vit
 package vitte/std/io
 >>>
-# IO layer entrypoints (façade only)
 
 space vitte/std/io
+
+use vitte/std/io/internal/runtime as std_io_runtime_pkg
+use vitte/std/io/internal/validate as std_io_validate_pkg
+use vitte/std/io/internal/policy as std_io_policy_pkg
+
+form StdIoConfig {
+  text_mode: bool
+  buffer_size: int
+  strict: bool
+}
+
+pick StdIoError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick StdIoResult[T] {
+  Ok(value: T)
+  Err(error: StdIoError)
+}
+
+proc default_config() -> StdIoConfig {
+  give StdIoConfig(true, std_io_policy_pkg.default_buffer_size(), true)
+}
+
+proc validate_config(cfg: StdIoConfig) -> StdIoResult[bool] {
+  if std_io_validate_pkg.valid_buffer_size(cfg.buffer_size) == false {
+    give StdIoResult.Err(StdIoError.InvalidConfig)
+  }
+  give StdIoResult.Ok(true)
+}
+
+proc healthcheck(cfg: StdIoConfig) -> StdIoResult[bool] {
+  let vr: StdIoResult[bool] = validate_config(cfg)
+  when vr is StdIoResult.Err { give StdIoResult.Err(vr.error) }
+  if std_io_runtime_pkg.runtime_status() == false {
+    give StdIoResult.Err(StdIoError.Internal)
+  }
+  give StdIoResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["buffered", "text-mode", "strict-io"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-STDIO0001" { give "invalid std/io configuration" }
+  give "std/io diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-STDIO0001" { give "use a positive buffer_size" }
+  give "review std/io configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
 
 proc package_meta() -> string {
   give "vitte/std/io"
 }
+
+proc ready() -> bool {
+  give true
+}
+
+<<< ROLE-CONTRACT
+package: vitte/std/io
+owner: @vitte/std
+stability: stable
+since: 3.0.0
+deprecated_in: -
+role: Facade IO standard lisible et stable
+input_contract: Config IO explicite
+output_contract: Resultats stables pour usages std
+boundary: Facade pure; details runtime sous internal/*
+compat_policy: additive-only
+api_version: v1
+>>>

--- a/src/vitte/packages/std/net/internal/policy.vit
+++ b/src/vitte/packages/std/net/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/std/net/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}

--- a/src/vitte/packages/std/net/internal/runtime.vit
+++ b/src/vitte/packages/std/net/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/std/net/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/std/net/internal/validate.vit
+++ b/src/vitte/packages/std/net/internal/validate.vit
@@ -1,0 +1,5 @@
+space vitte/std/net/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}

--- a/src/vitte/packages/std/net/mod.vit
+++ b/src/vitte/packages/std/net/mod.vit
@@ -2,10 +2,94 @@
 mod.vit
 package vitte/std/net
 >>>
-# NET layer entrypoints (façade only)
 
 space vitte/std/net
+
+use vitte/std/net/internal/runtime as std_net_runtime_pkg
+use vitte/std/net/internal/validate as std_net_validate_pkg
+use vitte/std/net/internal/policy as std_net_policy_pkg
+
+form StdNetConfig {
+  timeout_ms: int
+  retries: int
+  strict: bool
+}
+
+pick StdNetError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick StdNetResult[T] {
+  Ok(value: T)
+  Err(error: StdNetError)
+}
+
+proc default_config() -> StdNetConfig {
+  give StdNetConfig(std_net_policy_pkg.default_timeout_ms(), 1, true)
+}
+
+proc validate_config(cfg: StdNetConfig) -> StdNetResult[bool] {
+  if std_net_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give StdNetResult.Err(StdNetError.InvalidConfig)
+  }
+  if cfg.retries < 0 {
+    give StdNetResult.Err(StdNetError.InvalidConfig)
+  }
+  give StdNetResult.Ok(true)
+}
+
+proc healthcheck(cfg: StdNetConfig) -> StdNetResult[bool] {
+  let vr: StdNetResult[bool] = validate_config(cfg)
+  when vr is StdNetResult.Err { give StdNetResult.Err(vr.error) }
+  if std_net_runtime_pkg.runtime_status() == false {
+    give StdNetResult.Err(StdNetError.Internal)
+  }
+  give StdNetResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["timeouts", "retries", "strict-net"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-STDNET0001" { give "invalid std/net configuration" }
+  give "std/net diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-STDNET0001" { give "use timeout in 1..60000 and non-negative retries" }
+  give "review std/net configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
 
 proc package_meta() -> string {
   give "vitte/std/net"
 }
+
+proc ready() -> bool {
+  give true
+}
+
+<<< ROLE-CONTRACT
+package: vitte/std/net
+owner: @vitte/std
+stability: stable
+since: 3.0.0
+deprecated_in: -
+role: Facade net standard lisible et stable
+input_contract: Config timeout/retries explicite
+output_contract: Resultats stables pour usages std
+boundary: Facade pure; details runtime sous internal/*
+compat_policy: additive-only
+api_version: v1
+>>>

--- a/src/vitte/packages/subprocess/internal/policy.vit
+++ b/src/vitte/packages/subprocess/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/subprocess/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/subprocess/internal/runtime.vit
+++ b/src/vitte/packages/subprocess/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/subprocess/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/subprocess/internal/validate.vit
+++ b/src/vitte/packages/subprocess/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/subprocess/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/subprocess/mod.vit
+++ b/src/vitte/packages/subprocess/mod.vit
@@ -5,6 +5,10 @@ package vitte/subprocess
 
 space vitte/subprocess
 
+use vitte/subprocess/internal/runtime as subprocess_runtime_pkg
+use vitte/subprocess/internal/validate as subprocess_validate_pkg
+use vitte/subprocess/internal/policy as subprocess_policy_pkg
+
 
 form ProcSpec {
   program: string
@@ -54,10 +58,84 @@ proc package_meta() -> string {
   give "vitte/subprocess"
 }
 
+form SubprocessConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick SubprocessError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick SubprocessResult[T] {
+  Ok(value: T)
+  Err(error: SubprocessError)
+}
+
+proc default_config() -> SubprocessConfig {
+  give SubprocessConfig(true, subprocess_policy_pkg.default_timeout_ms(), subprocess_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: SubprocessConfig) -> SubprocessResult[bool] {
+  if subprocess_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give SubprocessResult.Err(SubprocessError.InvalidConfig)
+  }
+  if subprocess_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give SubprocessResult.Err(SubprocessError.InvalidConfig)
+  }
+  give SubprocessResult.Ok(true)
+}
+
+proc healthcheck(cfg: SubprocessConfig) -> SubprocessResult[bool] {
+  let vr: SubprocessResult[bool] = validate_config(cfg)
+  when vr is SubprocessResult.Err {
+    give SubprocessResult.Err(vr.error)
+  }
+  if subprocess_runtime_pkg.runtime_status() == false {
+    give SubprocessResult.Err(SubprocessError.Internal)
+  }
+  give SubprocessResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-SUBPROCE0001" {
+    give "invalid package configuration"
+  }
+  give "subprocess diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/subprocess
 role: Specification de processus externes
 input_contract: Commande/cwd explicites et valides
 output_contract: Specs executables et auditables
 boundary: N orchestre pas scheduling global
+
+owner: @vitte/subprocess
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/template/internal/policy.vit
+++ b/src/vitte/packages/template/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/template/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/template/internal/runtime.vit
+++ b/src/vitte/packages/template/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/template/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/template/internal/validate.vit
+++ b/src/vitte/packages/template/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/template/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/template/mod.vit
+++ b/src/vitte/packages/template/mod.vit
@@ -5,6 +5,10 @@ package vitte/template
 
 space vitte/template
 
+use vitte/template/internal/runtime as template_runtime_pkg
+use vitte/template/internal/validate as template_validate_pkg
+use vitte/template/internal/policy as template_policy_pkg
+
 
 form Var {
   key: string
@@ -67,10 +71,84 @@ proc package_meta() -> string {
   give "vitte/template"
 }
 
+form TemplateConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick TemplateError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick TemplateResult[T] {
+  Ok(value: T)
+  Err(error: TemplateError)
+}
+
+proc default_config() -> TemplateConfig {
+  give TemplateConfig(true, template_policy_pkg.default_timeout_ms(), template_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: TemplateConfig) -> TemplateResult[bool] {
+  if template_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give TemplateResult.Err(TemplateError.InvalidConfig)
+  }
+  if template_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give TemplateResult.Err(TemplateError.InvalidConfig)
+  }
+  give TemplateResult.Ok(true)
+}
+
+proc healthcheck(cfg: TemplateConfig) -> TemplateResult[bool] {
+  let vr: TemplateResult[bool] = validate_config(cfg)
+  when vr is TemplateResult.Err {
+    give TemplateResult.Err(vr.error)
+  }
+  if template_runtime_pkg.runtime_status() == false {
+    give TemplateResult.Err(TemplateError.Internal)
+  }
+  give TemplateResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-TEMPLATE0001" {
+    give "invalid package configuration"
+  }
+  give "template diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/template
 role: Rendu de templates textuels
 input_contract: Template et contexte explicites
 output_contract: Texte rendu deterministe
 boundary: Pas de logique metier cachee dans le moteur
+
+owner: @vitte/template
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/src/vitte/packages/testkit_modules/internal/policy.vit
+++ b/src/vitte/packages/testkit_modules/internal/policy.vit
@@ -1,0 +1,5 @@
+space vitte/testkit_modules/internal/policy
+
+proc default_max_tests() -> int {
+  give 1000
+}

--- a/src/vitte/packages/testkit_modules/internal/runtime.vit
+++ b/src/vitte/packages/testkit_modules/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/testkit_modules/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/testkit_modules/internal/validate.vit
+++ b/src/vitte/packages/testkit_modules/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/testkit_modules/internal/validate
+
+proc valid_suite_name(name: string) -> bool {
+  give name.len > 0
+}
+
+proc valid_max_tests(max_tests: int) -> bool {
+  give max_tests > 0 && max_tests <= 100000
+}

--- a/src/vitte/packages/testkit_modules/mod.vit
+++ b/src/vitte/packages/testkit_modules/mod.vit
@@ -5,18 +5,91 @@ package vitte/testkit_modules
 
 space vitte/testkit_modules
 
+use vitte/testkit_modules/internal/runtime as testkit_modules_runtime_pkg
+use vitte/testkit_modules/internal/validate as testkit_modules_validate_pkg
+use vitte/testkit_modules/internal/policy as testkit_modules_policy_pkg
+
+form TestkitModulesConfig {
+  suite_name: string
+  strict: bool
+  max_tests: int
+}
+
+pick TestkitModulesError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick TestkitModulesResult[T] {
+  Ok(value: T)
+  Err(error: TestkitModulesError)
+}
+
+proc default_config() -> TestkitModulesConfig {
+  give TestkitModulesConfig("default", true, testkit_modules_policy_pkg.default_max_tests())
+}
+
+proc validate_config(cfg: TestkitModulesConfig) -> TestkitModulesResult[bool] {
+  if testkit_modules_validate_pkg.valid_suite_name(cfg.suite_name) == false {
+    give TestkitModulesResult.Err(TestkitModulesError.InvalidConfig)
+  }
+  if testkit_modules_validate_pkg.valid_max_tests(cfg.max_tests) == false {
+    give TestkitModulesResult.Err(TestkitModulesError.InvalidConfig)
+  }
+  give TestkitModulesResult.Ok(true)
+}
+
+proc healthcheck(cfg: TestkitModulesConfig) -> TestkitModulesResult[bool] {
+  let vr: TestkitModulesResult[bool] = validate_config(cfg)
+  when vr is TestkitModulesResult.Err { give TestkitModulesResult.Err(vr.error) }
+  if testkit_modules_runtime_pkg.runtime_status() == false {
+    give TestkitModulesResult.Err(TestkitModulesError.Internal)
+  }
+  give TestkitModulesResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["suite-validation", "strict-mode", "test-budget"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-TKM0001" { give "invalid testkit_modules configuration" }
+  give "testkit_modules diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  if code == "VITTE-TKM0001" { give "set non-empty suite_name and valid max_tests" }
+  give "review testkit_modules configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
+proc package_meta() -> string {
+  give "vitte/testkit_modules"
+}
+
+proc ready() -> bool {
+  give true
+}
+
 <<< ROLE-CONTRACT
 package: vitte/testkit_modules
 owner: @vitte/platform
 stability: stable
 since: 3.0.0
 deprecated_in: -
-role: Module public vitte/testkit_modules
-input_contract: Entrees explicites et typables
-output_contract: Sorties stables et predictibles
+role: Helpers de tests modules et validation de suites
+input_contract: Suite strict et budget tests explicites
+output_contract: Validation stable et predictable
 boundary: Aucun import legacy; aliases explicites uniquement
+compat_policy: additive-only
+api_version: v1
 >>>
-
-proc ready() -> bool {
-  give true
-}

--- a/src/vitte/packages/video/internal/policy.vit
+++ b/src/vitte/packages/video/internal/policy.vit
@@ -1,0 +1,9 @@
+space vitte/video/internal/policy
+
+proc default_timeout_ms() -> int {
+  give 1000
+}
+
+proc default_retry_budget() -> int {
+  give 1
+}

--- a/src/vitte/packages/video/internal/runtime.vit
+++ b/src/vitte/packages/video/internal/runtime.vit
@@ -1,0 +1,5 @@
+space vitte/video/internal/runtime
+
+proc runtime_status() -> bool {
+  give true
+}

--- a/src/vitte/packages/video/internal/validate.vit
+++ b/src/vitte/packages/video/internal/validate.vit
@@ -1,0 +1,9 @@
+space vitte/video/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {
+  give timeout_ms > 0 && timeout_ms <= 60000
+}
+
+proc valid_retry_budget(retry_budget: int) -> bool {
+  give retry_budget >= 0 && retry_budget <= 32
+}

--- a/src/vitte/packages/video/mod.vit
+++ b/src/vitte/packages/video/mod.vit
@@ -5,6 +5,10 @@ package vitte/video
 
 space vitte/video
 
+use vitte/video/internal/runtime as video_runtime_pkg
+use vitte/video/internal/validate as video_validate_pkg
+use vitte/video/internal/policy as video_policy_pkg
+
 
 form Frame {
   width: int
@@ -56,10 +60,84 @@ proc package_meta() -> string {
   give "vitte/video"
 }
 
+form VideoConfig {
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}
+
+pick VideoError {
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}
+
+pick VideoResult[T] {
+  Ok(value: T)
+  Err(error: VideoError)
+}
+
+proc default_config() -> VideoConfig {
+  give VideoConfig(true, video_policy_pkg.default_timeout_ms(), video_policy_pkg.default_retry_budget())
+}
+
+proc validate_config(cfg: VideoConfig) -> VideoResult[bool] {
+  if video_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {
+    give VideoResult.Err(VideoError.InvalidConfig)
+  }
+  if video_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {
+    give VideoResult.Err(VideoError.InvalidConfig)
+  }
+  give VideoResult.Ok(true)
+}
+
+proc healthcheck(cfg: VideoConfig) -> VideoResult[bool] {
+  let vr: VideoResult[bool] = validate_config(cfg)
+  when vr is VideoResult.Err {
+    give VideoResult.Err(vr.error)
+  }
+  if video_runtime_pkg.runtime_status() == false {
+    give VideoResult.Err(VideoError.Internal)
+  }
+  give VideoResult.Ok(true)
+}
+
+proc version() -> string {
+  give "v1"
+}
+
+proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}
+
+proc diagnostics_message(code: string) -> string {
+  if code == "VITTE-VIDEO0001" {
+    give "invalid package configuration"
+  }
+  give "video diagnostic " + code
+}
+
+proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}
+
+proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}
+
 <<< ROLE-CONTRACT
 package: vitte/video
 role: Primitives video, timeline et metadata frame
 input_contract: Frames deja decodees et horodatees
 output_contract: Clips validables et transformables
 boundary: Pas de codec materiel ou I/O streaming direct
+
+owner: @vitte/video
+stability: stable
+since: 3.0.0
+deprecated_in: -
+compat_policy: additive-only
+api_version: v1
 >>>

--- a/tests/arduino/gpio_invalid.vit
+++ b/tests/arduino/gpio_invalid.vit
@@ -1,0 +1,11 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/gpio as gpio_pkg
+
+entry main at core/app {
+  let st: gpio_pkg.GpioState = gpio_pkg.gpio_open(gpio_pkg.gpio_default_config())
+  let wr: arduino_pkg.ArduinoResult[gpio_pkg.GpioState] = gpio_pkg.gpio_write(st, 99, gpio_pkg.PinState.High)
+  when wr is arduino_pkg.ArduinoResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/arduino/gpio_nominal.vit
+++ b/tests/arduino/gpio_nominal.vit
@@ -1,0 +1,12 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/gpio as gpio_pkg
+
+entry main at core/app {
+  let cfg: gpio_pkg.GpioConfig = gpio_pkg.gpio_with_profile(gpio_pkg.gpio_default_config(), arduino_pkg.ArduinoProfile.Uno)
+  let st: gpio_pkg.GpioState = gpio_pkg.gpio_open(cfg)
+  let wr: arduino_pkg.ArduinoResult[gpio_pkg.GpioState] = gpio_pkg.gpio_write(st, 13, gpio_pkg.PinState.High)
+  when wr is arduino_pkg.ArduinoResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/arduino/i2c_invalid.vit
+++ b/tests/arduino/i2c_invalid.vit
@@ -1,0 +1,11 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/i2c as i2c_pkg
+
+entry main at core/app {
+  let st: i2c_pkg.I2cBusState = i2c_pkg.i2c_open(i2c_pkg.i2c_default_config())
+  let rd: arduino_pkg.ArduinoResult[int] = i2c_pkg.i2c_read_register(st, 0x02, 0x00)
+  when rd is arduino_pkg.ArduinoResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/arduino/i2c_nominal.vit
+++ b/tests/arduino/i2c_nominal.vit
@@ -1,0 +1,11 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/i2c as i2c_pkg
+
+entry main at core/app {
+  let st: i2c_pkg.I2cBusState = i2c_pkg.i2c_open(i2c_pkg.i2c_default_config())
+  let wr: arduino_pkg.ArduinoResult[i2c_pkg.I2cBusState] = i2c_pkg.i2c_write_register(st, 0x20, 0x01, 7)
+  when wr is arduino_pkg.ArduinoResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/arduino/serial_invalid.vit
+++ b/tests/arduino/serial_invalid.vit
@@ -1,0 +1,11 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/serial as serial_pkg
+
+entry main at core/app {
+  let cfg: serial_pkg.SerialConfig = serial_pkg.serial_with_baud(serial_pkg.serial_default_config(), -1)
+  let st: arduino_pkg.ArduinoResult[serial_pkg.SerialState] = serial_pkg.serial_open(cfg)
+  when st is arduino_pkg.ArduinoResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/arduino/serial_nominal.vit
+++ b/tests/arduino/serial_nominal.vit
@@ -1,0 +1,15 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/serial as serial_pkg
+
+entry main at core/app {
+  let cfg: serial_pkg.SerialConfig = serial_pkg.serial_with_baud(serial_pkg.serial_default_config(), 115200)
+  let st: arduino_pkg.ArduinoResult[serial_pkg.SerialState] = serial_pkg.serial_open(cfg)
+  when st is arduino_pkg.ArduinoResult.Err {
+    return 1
+  }
+  let wr: arduino_pkg.ArduinoResult[serial_pkg.SerialState] = serial_pkg.serial_write(st.value, 65)
+  when wr is arduino_pkg.ArduinoResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/arduino/spi_invalid.vit
+++ b/tests/arduino/spi_invalid.vit
@@ -1,0 +1,11 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/spi as spi_pkg
+
+entry main at core/app {
+  let cfg: spi_pkg.SpiConfig = spi_pkg.spi_with_clock_hz(spi_pkg.spi_default_config(), 99999999)
+  let op: arduino_pkg.ArduinoResult[spi_pkg.SpiBusState] = spi_pkg.spi_open(cfg)
+  when op is arduino_pkg.ArduinoResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/arduino/spi_nominal.vit
+++ b/tests/arduino/spi_nominal.vit
@@ -1,0 +1,15 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/spi as spi_pkg
+
+entry main at core/app {
+  let cfg: spi_pkg.SpiConfig = spi_pkg.spi_with_clock_hz(spi_pkg.spi_default_config(), 1000000)
+  let op: arduino_pkg.ArduinoResult[spi_pkg.SpiBusState] = spi_pkg.spi_open(cfg)
+  when op is arduino_pkg.ArduinoResult.Err {
+    return 1
+  }
+  let tr: arduino_pkg.ArduinoResult[int] = spi_pkg.spi_transfer(op.value, 42)
+  when tr is arduino_pkg.ArduinoResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/arduino/timer_invalid.vit
+++ b/tests/arduino/timer_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/timer as timer_pkg
+
+entry main at core/app {
+  let ko: arduino_pkg.ArduinoResult[bool] = timer_pkg.timer_delay_ms(70000)
+  when ko is arduino_pkg.ArduinoResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/arduino/timer_nominal.vit
+++ b/tests/arduino/timer_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/arduino as arduino_pkg
+use vitte/arduino/timer as timer_pkg
+
+entry main at core/app {
+  let ok: arduino_pkg.ArduinoResult[bool] = timer_pkg.timer_delay_ms(5)
+  when ok is arduino_pkg.ArduinoResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/catalog/catalog_invalid.vit
+++ b/tests/catalog/catalog_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/catalog as catalog_pkg
+
+entry main at core/app {
+  let cfg: catalog_pkg.CatalogConfig = catalog_pkg.CatalogConfig("", true, -1)
+  let vr: catalog_pkg.CatalogResult[bool] = catalog_pkg.validate_config(cfg)
+  when vr is catalog_pkg.CatalogResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/catalog/catalog_nominal.vit
+++ b/tests/catalog/catalog_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/catalog as catalog_pkg
+
+entry main at core/app {
+  let cfg: catalog_pkg.CatalogConfig = catalog_pkg.default_config()
+  let hr: catalog_pkg.CatalogResult[bool] = catalog_pkg.healthcheck(cfg)
+  when hr is catalog_pkg.CatalogResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/contracts_registry/contracts_registry_invalid.vit
+++ b/tests/contracts_registry/contracts_registry_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/contracts_registry as contracts_registry_pkg
+
+entry main at core/app {
+  let cfg: contracts_registry_pkg.ContractsRegistryConfig = contracts_registry_pkg.ContractsRegistryConfig("", true, -5)
+  let vr: contracts_registry_pkg.ContractsRegistryResult[bool] = contracts_registry_pkg.validate_config(cfg)
+  when vr is contracts_registry_pkg.ContractsRegistryResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/contracts_registry/contracts_registry_nominal.vit
+++ b/tests/contracts_registry/contracts_registry_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/contracts_registry as contracts_registry_pkg
+
+entry main at core/app {
+  let cfg: contracts_registry_pkg.ContractsRegistryConfig = contracts_registry_pkg.default_config()
+  let hr: contracts_registry_pkg.ContractsRegistryResult[bool] = contracts_registry_pkg.healthcheck(cfg)
+  when hr is contracts_registry_pkg.ContractsRegistryResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/data/data_invalid.vit
+++ b/tests/data/data_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/data as data_pkg
+
+entry main at core/app {
+  let cfg: data_pkg.DataConfig = data_pkg.DataConfig("", true, -1)
+  let vr: data_pkg.DataResult[bool] = data_pkg.validate_config(cfg)
+  when vr is data_pkg.DataResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/data/data_nominal.vit
+++ b/tests/data/data_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/data as data_pkg
+
+entry main at core/app {
+  let cfg: data_pkg.DataConfig = data_pkg.default_config()
+  let hr: data_pkg.DataResult[bool] = data_pkg.healthcheck(cfg)
+  when hr is data_pkg.DataResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/docsgen_modules/docsgen_modules_invalid.vit
+++ b/tests/docsgen_modules/docsgen_modules_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/docsgen_modules as docsgen_pkg
+
+entry main at core/app {
+  let cfg: docsgen_pkg.DocsgenModulesConfig = docsgen_pkg.DocsgenModulesConfig("xml", false, 0)
+  let vr: docsgen_pkg.DocsgenModulesResult[bool] = docsgen_pkg.validate_config(cfg)
+  when vr is docsgen_pkg.DocsgenModulesResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/docsgen_modules/docsgen_modules_nominal.vit
+++ b/tests/docsgen_modules/docsgen_modules_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/docsgen_modules as docsgen_pkg
+
+entry main at core/app {
+  let cfg: docsgen_pkg.DocsgenModulesConfig = docsgen_pkg.default_config()
+  let hr: docsgen_pkg.DocsgenModulesResult[bool] = docsgen_pkg.healthcheck(cfg)
+  when hr is docsgen_pkg.DocsgenModulesResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/kernel/kernel_invalid.vit
+++ b/tests/kernel/kernel_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/kernel as kernel_pkg
+
+entry main at core/app {
+  let cfg: kernel_pkg.KernelConfig = kernel_pkg.KernelConfig("bad", "unknown", true)
+  let vr: kernel_pkg.KernelResult[bool] = kernel_pkg.validate_config(cfg)
+  when vr is kernel_pkg.KernelResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/kernel/kernel_nominal.vit
+++ b/tests/kernel/kernel_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/kernel as kernel_pkg
+
+entry main at core/app {
+  let cfg: kernel_pkg.KernelConfig = kernel_pkg.default_config()
+  let hr: kernel_pkg.KernelResult[bool] = kernel_pkg.healthcheck(cfg)
+  when hr is kernel_pkg.KernelResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/migration_playbook/migration_playbook_invalid.vit
+++ b/tests/migration_playbook/migration_playbook_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/migration_playbook as migration_playbook_pkg
+
+entry main at core/app {
+  let cfg: migration_playbook_pkg.MigrationPlaybookConfig = migration_playbook_pkg.MigrationPlaybookConfig("", "", true)
+  let vr: migration_playbook_pkg.MigrationPlaybookResult[bool] = migration_playbook_pkg.validate_config(cfg)
+  when vr is migration_playbook_pkg.MigrationPlaybookResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/migration_playbook/migration_playbook_nominal.vit
+++ b/tests/migration_playbook/migration_playbook_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/migration_playbook as migration_playbook_pkg
+
+entry main at core/app {
+  let cfg: migration_playbook_pkg.MigrationPlaybookConfig = migration_playbook_pkg.default_config()
+  let hr: migration_playbook_pkg.MigrationPlaybookResult[bool] = migration_playbook_pkg.healthcheck(cfg)
+  when hr is migration_playbook_pkg.MigrationPlaybookResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/module_index/module_index_invalid.vit
+++ b/tests/module_index/module_index_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/module_index as module_index_pkg
+
+entry main at core/app {
+  let cfg: module_index_pkg.ModuleIndexConfig = module_index_pkg.ModuleIndexConfig("", true, -1)
+  let vr: module_index_pkg.ModuleIndexResult[bool] = module_index_pkg.validate_config(cfg)
+  when vr is module_index_pkg.ModuleIndexResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/module_index/module_index_nominal.vit
+++ b/tests/module_index/module_index_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/module_index as module_index_pkg
+
+entry main at core/app {
+  let cfg: module_index_pkg.ModuleIndexConfig = module_index_pkg.default_config()
+  let vr: module_index_pkg.ModuleIndexResult[bool] = module_index_pkg.validate_config(cfg)
+  when vr is module_index_pkg.ModuleIndexResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/platform/platform_invalid.vit
+++ b/tests/platform/platform_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/platform as platform_pkg
+
+entry main at core/app {
+  let cfg: platform_pkg.PlatformConfig = platform_pkg.PlatformConfig("unknown", "bad", true)
+  let vr: platform_pkg.PlatformResult[bool] = platform_pkg.validate_config(cfg)
+  when vr is platform_pkg.PlatformResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/platform/platform_nominal.vit
+++ b/tests/platform/platform_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/platform as platform_pkg
+
+entry main at core/app {
+  let cfg: platform_pkg.PlatformConfig = platform_pkg.default_config()
+  let hr: platform_pkg.PlatformResult[bool] = platform_pkg.healthcheck(cfg)
+  when hr is platform_pkg.PlatformResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/release_guard/release_guard_invalid.vit
+++ b/tests/release_guard/release_guard_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/release_guard as release_guard_pkg
+
+entry main at core/app {
+  let cfg: release_guard_pkg.ReleaseGuardConfig = release_guard_pkg.ReleaseGuardConfig("", "", true)
+  let vr: release_guard_pkg.ReleaseGuardResult[bool] = release_guard_pkg.validate_config(cfg)
+  when vr is release_guard_pkg.ReleaseGuardResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/release_guard/release_guard_nominal.vit
+++ b/tests/release_guard/release_guard_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/release_guard as release_guard_pkg
+
+entry main at core/app {
+  let cfg: release_guard_pkg.ReleaseGuardConfig = release_guard_pkg.ReleaseGuardConfig("1.2.0", "1.1.0", false)
+  let vr: release_guard_pkg.ReleaseGuardResult[bool] = release_guard_pkg.validate_config(cfg)
+  when vr is release_guard_pkg.ReleaseGuardResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/std/async/std_async_invalid.vit
+++ b/tests/std/async/std_async_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/std/async as std_async_pkg
+
+entry main at core/app {
+  let cfg: std_async_pkg.StdAsyncConfig = std_async_pkg.StdAsyncConfig(0, true, true)
+  let vr: std_async_pkg.StdAsyncResult[bool] = std_async_pkg.validate_config(cfg)
+  when vr is std_async_pkg.StdAsyncResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/std/async/std_async_nominal.vit
+++ b/tests/std/async/std_async_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/std/async as std_async_pkg
+
+entry main at core/app {
+  let cfg: std_async_pkg.StdAsyncConfig = std_async_pkg.default_config()
+  let hr: std_async_pkg.StdAsyncResult[bool] = std_async_pkg.healthcheck(cfg)
+  when hr is std_async_pkg.StdAsyncResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/std/data/std_data_invalid.vit
+++ b/tests/std/data/std_data_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/std/data as std_data_pkg
+
+entry main at core/app {
+  let cfg: std_data_pkg.StdDataConfig = std_data_pkg.StdDataConfig(-1, true, true)
+  let vr: std_data_pkg.StdDataResult[bool] = std_data_pkg.validate_config(cfg)
+  when vr is std_data_pkg.StdDataResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/std/data/std_data_nominal.vit
+++ b/tests/std/data/std_data_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/std/data as std_data_pkg
+
+entry main at core/app {
+  let cfg: std_data_pkg.StdDataConfig = std_data_pkg.default_config()
+  let hr: std_data_pkg.StdDataResult[bool] = std_data_pkg.healthcheck(cfg)
+  when hr is std_data_pkg.StdDataResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/std/io/std_io_invalid.vit
+++ b/tests/std/io/std_io_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/std/io as std_io_pkg
+
+entry main at core/app {
+  let cfg: std_io_pkg.StdIoConfig = std_io_pkg.StdIoConfig(true, 0, true)
+  let vr: std_io_pkg.StdIoResult[bool] = std_io_pkg.validate_config(cfg)
+  when vr is std_io_pkg.StdIoResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/std/io/std_io_nominal.vit
+++ b/tests/std/io/std_io_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/std/io as std_io_pkg
+
+entry main at core/app {
+  let cfg: std_io_pkg.StdIoConfig = std_io_pkg.default_config()
+  let hr: std_io_pkg.StdIoResult[bool] = std_io_pkg.healthcheck(cfg)
+  when hr is std_io_pkg.StdIoResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/std/net/std_net_invalid.vit
+++ b/tests/std/net/std_net_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/std/net as std_net_pkg
+
+entry main at core/app {
+  let cfg: std_net_pkg.StdNetConfig = std_net_pkg.StdNetConfig(0, -1, true)
+  let vr: std_net_pkg.StdNetResult[bool] = std_net_pkg.validate_config(cfg)
+  when vr is std_net_pkg.StdNetResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/std/net/std_net_nominal.vit
+++ b/tests/std/net/std_net_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/std/net as std_net_pkg
+
+entry main at core/app {
+  let cfg: std_net_pkg.StdNetConfig = std_net_pkg.default_config()
+  let hr: std_net_pkg.StdNetResult[bool] = std_net_pkg.healthcheck(cfg)
+  when hr is std_net_pkg.StdNetResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tests/testkit_modules/testkit_modules_invalid.vit
+++ b/tests/testkit_modules/testkit_modules_invalid.vit
@@ -1,0 +1,10 @@
+use vitte/testkit_modules as testkit_modules_pkg
+
+entry main at core/app {
+  let cfg: testkit_modules_pkg.TestkitModulesConfig = testkit_modules_pkg.TestkitModulesConfig("", true, -1)
+  let vr: testkit_modules_pkg.TestkitModulesResult[bool] = testkit_modules_pkg.validate_config(cfg)
+  when vr is testkit_modules_pkg.TestkitModulesResult.Err {
+    return 0
+  }
+  return 1
+}

--- a/tests/testkit_modules/testkit_modules_nominal.vit
+++ b/tests/testkit_modules/testkit_modules_nominal.vit
@@ -1,0 +1,10 @@
+use vitte/testkit_modules as testkit_modules_pkg
+
+entry main at core/app {
+  let cfg: testkit_modules_pkg.TestkitModulesConfig = testkit_modules_pkg.default_config()
+  let hr: testkit_modules_pkg.TestkitModulesResult[bool] = testkit_modules_pkg.healthcheck(cfg)
+  when hr is testkit_modules_pkg.TestkitModulesResult.Err {
+    return 1
+  }
+  return 0
+}

--- a/tools/harden_existing_mod_vit.py
+++ b/tools/harden_existing_mod_vit.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ROLE_START = "<<< ROLE-CONTRACT"
+ROLE_END = ">>>"
+
+
+def pascal_case(name: str) -> str:
+    parts = re.split(r"[/_\-]+", name)
+    return "".join(p[:1].upper() + p[1:] for p in parts if p)
+
+
+def diag_prefix(name: str) -> str:
+    raw = re.sub(r"[^A-Za-z0-9]", "", name).upper()
+    if not raw:
+        raw = "PKG"
+    return raw[:8]
+
+
+def has_form(text: str, form_name: str) -> bool:
+    return re.search(rf"^\s*form\s+{re.escape(form_name)}\b", text, flags=re.M) is not None
+
+
+def has_pick(text: str, pick_name: str) -> bool:
+    return re.search(rf"^\s*pick\s+{re.escape(pick_name)}\b", text, flags=re.M) is not None
+
+
+def has_proc(text: str, proc_name: str) -> bool:
+    return re.search(rf"^\s*proc\s+{re.escape(proc_name)}\s*\(", text, flags=re.M) is not None
+
+
+def insert_before_role(text: str, block: str) -> str:
+    idx = text.find(ROLE_START)
+    if idx == -1:
+        if not text.endswith("\n"):
+            text += "\n"
+        return text + "\n" + block + "\n"
+    return text[:idx].rstrip() + "\n\n" + block + "\n\n" + text[idx:]
+
+
+def parse_info_meta(info_path: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not info_path.exists():
+        return out
+    for raw in info_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def ensure_imports(text: str, pkg: str, alias_base: str) -> str:
+    imports = [
+        f"use vitte/{pkg}/internal/runtime as {alias_base}_runtime_pkg",
+        f"use vitte/{pkg}/internal/validate as {alias_base}_validate_pkg",
+        f"use vitte/{pkg}/internal/policy as {alias_base}_policy_pkg",
+    ]
+    missing = [imp for imp in imports if imp not in text]
+    if not missing:
+        return text
+
+    m = re.search(r"^\s*space\s+vitte/[^\n]+\n", text, flags=re.M)
+    if not m:
+        return text
+    insert_at = m.end()
+    ins = "\n" + "\n".join(missing) + "\n"
+    return text[:insert_at] + ins + text[insert_at:]
+
+
+def ensure_role_fields(text: str, meta: dict[str, str]) -> str:
+    start = text.find(ROLE_START)
+    if start == -1:
+        return text
+    end = text.find(ROLE_END, start)
+    if end == -1:
+        return text
+
+    block = text[start:end]
+    add_lines: list[str] = []
+    required = [
+        ("owner", meta.get("owner", "@vitte/platform")),
+        ("stability", meta.get("stability", "stable")),
+        ("since", meta.get("since", "3.0.0")),
+        ("deprecated_in", meta.get("deprecated_in", "-")),
+        ("compat_policy", "additive-only"),
+        ("api_version", "v1"),
+    ]
+    for key, default in required:
+        if re.search(rf"^\s*{re.escape(key)}\s*:", block, flags=re.M) is None:
+            add_lines.append(f"{key}: {default}")
+
+    if not add_lines:
+        return text
+
+    insert = "\n" + "\n".join(add_lines) + "\n"
+    return text[:end] + insert + text[end:]
+
+
+def ensure_role_block(text: str, pkg: str, meta: dict[str, str]) -> str:
+    if ROLE_START in text:
+        return ensure_role_fields(text, meta)
+    owner = meta.get("owner", "@vitte/platform")
+    stability = meta.get("stability", "stable")
+    since = meta.get("since", "3.0.0")
+    deprecated = meta.get("deprecated_in", "-")
+    block = f"""<<< ROLE-CONTRACT
+package: vitte/{pkg}
+owner: {owner}
+stability: {stability}
+since: {since}
+deprecated_in: {deprecated}
+role: Facade publique stable
+input_contract: Config explicite et typable
+output_contract: Resultats stables et predictibles
+boundary: Implementation privee sous vitte/{pkg}/internal/*
+compat_policy: additive-only
+api_version: v1
+>>>"""
+    if not text.endswith("\n"):
+        text += "\n"
+    return text + "\n" + block + "\n"
+
+
+def ensure_internal_files(pkg_dir: Path, pkg: str, alias_base: str) -> None:
+    internal = pkg_dir / "internal"
+    internal.mkdir(parents=True, exist_ok=True)
+
+    runtime = internal / "runtime.vit"
+    if not runtime.exists():
+        runtime.write_text(
+            f"""space vitte/{pkg}/internal/runtime
+
+proc runtime_status() -> bool {{
+  give true
+}}
+""",
+            encoding="utf-8",
+        )
+
+    validate = internal / "validate.vit"
+    if not validate.exists():
+        validate.write_text(
+            f"""space vitte/{pkg}/internal/validate
+
+proc valid_timeout_ms(timeout_ms: int) -> bool {{
+  give timeout_ms > 0 && timeout_ms <= 60000
+}}
+
+proc valid_retry_budget(retry_budget: int) -> bool {{
+  give retry_budget >= 0 && retry_budget <= 32
+}}
+""",
+            encoding="utf-8",
+        )
+
+    policy = internal / "policy.vit"
+    if not policy.exists():
+        policy.write_text(
+            f"""space vitte/{pkg}/internal/policy
+
+proc default_timeout_ms() -> int {{
+  give 1000
+}}
+
+proc default_retry_budget() -> int {{
+  give 1
+}}
+""",
+            encoding="utf-8",
+        )
+
+
+def harden_mod(mod_path: Path, pkg: str, meta: dict[str, str]) -> tuple[str, bool]:
+    text = mod_path.read_text(encoding="utf-8")
+    original = text
+    base = pascal_case(pkg)
+    alias_base = pkg.replace("/", "_")
+    pfx = diag_prefix(pkg)
+
+    text = ensure_imports(text, pkg, alias_base)
+
+    config_t = f"{base}Config"
+    error_t = f"{base}Error"
+    result_t = f"{base}Result"
+
+    if not has_form(text, config_t):
+        text = insert_before_role(
+            text,
+            f"""form {config_t} {{
+  strict: bool
+  timeout_ms: int
+  retry_budget: int
+}}""",
+        )
+
+    if not has_pick(text, error_t):
+        text = insert_before_role(
+            text,
+            f"""pick {error_t} {{
+  InvalidConfig
+  Unsupported
+  Timeout
+  Internal
+}}""",
+        )
+
+    if not has_pick(text, result_t):
+        text = insert_before_role(
+            text,
+            f"""pick {result_t}[T] {{
+  Ok(value: T)
+  Err(error: {error_t})
+}}""",
+        )
+
+    if not has_proc(text, "default_config"):
+        text = insert_before_role(
+            text,
+            f"""proc default_config() -> {config_t} {{
+  give {config_t}(true, {alias_base}_policy_pkg.default_timeout_ms(), {alias_base}_policy_pkg.default_retry_budget())
+}}""",
+        )
+
+    if not has_proc(text, "validate_config"):
+        text = insert_before_role(
+            text,
+            f"""proc validate_config(cfg: {config_t}) -> {result_t}[bool] {{
+  if {alias_base}_validate_pkg.valid_timeout_ms(cfg.timeout_ms) == false {{
+    give {result_t}.Err({error_t}.InvalidConfig)
+  }}
+  if {alias_base}_validate_pkg.valid_retry_budget(cfg.retry_budget) == false {{
+    give {result_t}.Err({error_t}.InvalidConfig)
+  }}
+  give {result_t}.Ok(true)
+}}""",
+        )
+
+    if not has_proc(text, "healthcheck"):
+        text = insert_before_role(
+            text,
+            f"""proc healthcheck(cfg: {config_t}) -> {result_t}[bool] {{
+  let vr: {result_t}[bool] = validate_config(cfg)
+  when vr is {result_t}.Err {{
+    give {result_t}.Err(vr.error)
+  }}
+  if {alias_base}_runtime_pkg.runtime_status() == false {{
+    give {result_t}.Err({error_t}.Internal)
+  }}
+  give {result_t}.Ok(true)
+}}""",
+        )
+
+    if not has_proc(text, "version"):
+        text = insert_before_role(
+            text,
+            """proc version() -> string {
+  give "v1"
+}""",
+        )
+
+    if not has_proc(text, "capabilities"):
+        text = insert_before_role(
+            text,
+            """proc capabilities() -> [string] {
+  give ["config", "validate", "healthcheck"]
+}""",
+        )
+
+    if not has_proc(text, "diagnostics_message"):
+        text = insert_before_role(
+            text,
+            f"""proc diagnostics_message(code: string) -> string {{
+  if code == "VITTE-{pfx}0001" {{
+    give "invalid package configuration"
+  }}
+  give "{pkg} diagnostic " + code
+}}""",
+        )
+
+    if not has_proc(text, "diagnostics_quickfix"):
+        text = insert_before_role(
+            text,
+            """proc diagnostics_quickfix(code: string) -> string {
+  let _ = code
+  give "review package configuration"
+}""",
+        )
+
+    if not has_proc(text, "diagnostics_doc_url"):
+        text = insert_before_role(
+            text,
+            """proc diagnostics_doc_url(code: string) -> string {
+  give "https://docs.vitte.dev/diagnostics/" + code
+}""",
+        )
+
+    if not has_proc(text, "package_meta"):
+        text = insert_before_role(
+            text,
+            f"""proc package_meta() -> string {{
+  give "vitte/{pkg}"
+}}""",
+        )
+
+    text = ensure_role_block(text, pkg, meta)
+    return text, text != original
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Harden existing mod.vit files with missing standard blocks")
+    ap.add_argument("packages", nargs="+", help="package names under src/vitte/packages (e.g. kernel std/io)")
+    ap.add_argument("--write", action="store_true", help="write changes (default: dry-run)")
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src" / "vitte" / "packages"
+    changed = 0
+
+    for pkg in args.packages:
+        pkg_dir = root / pkg
+        mod = pkg_dir / "mod.vit"
+        info = pkg_dir / "info.vit"
+        if not mod.exists():
+            print(f"[harden-mod][warn] missing mod.vit for package: {pkg}")
+            continue
+
+        meta = parse_info_meta(info)
+        alias_base = pkg.replace("/", "_")
+        ensure_internal_files(pkg_dir, pkg, alias_base)
+        new_text, is_changed = harden_mod(mod, pkg, meta)
+        if is_changed:
+            changed += 1
+            if args.write:
+                mod.write_text(new_text, encoding="utf-8")
+                print(f"[harden-mod] updated {mod.relative_to(repo)}")
+            else:
+                print(f"[harden-mod] would update {mod.relative_to(repo)}")
+        else:
+            print(f"[harden-mod] already hardened {mod.relative_to(repo)}")
+
+    print(f"[harden-mod] packages changed: {changed}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- apply a global package hardening pass across remaining package modules
- add internal runtime/validate/policy layers for package facades that previously mixed concerns
- add nominal and invalid tests for quasi-empty and newly structured packages, including arduino modules
- include tooling script for repeatable hardening of existing mod.vit files

## Main areas touched
- packages: catalog, codegen (base/gcc/llvm/cranelift), contracts_registry, data, docsgen_modules, ffi, kernel, math, migration_playbook, module_index, pickle, platform, plot, random_secure, release_guard, rope, runtime, shell, std/*, subprocess, template, testkit_modules, video
- new arduino package family: arduino, gpio, i2c, serial, spi, timer
- tests: package-level nominal/invalid suites for the above packages and arduino modules
- tooling: tools/harden_existing_mod_vit.py

## Validation run
- make -s package-layout-lint-strict
- make -s packages-governance-lint
- make -s quasi-empty-package-tests
- make -s parse-modules

## Notes
- this PR is intentionally broad and follows the prior strict PR focused on async/env/jsonpath/openapi/fuzzkit
