### PR TITLE
packages: tighten governance and overlap reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ make build
 Recommended baseline checks:
 
 ```sh
+make core-language-gate
+make core-release-gate
 make parse
 make hir-validate
 make negative-tests
@@ -34,7 +36,16 @@ If you touched modules/packages policy or lint behavior, also run:
 make modules-tests
 make modules-snapshots
 make modules-contract-snapshots
+make packages-gate
 ```
+
+To check a package facade directly, use:
+
+```sh
+make package-check SRC=src/vitte/packages/std/data/mod.vit
+```
+
+This intentionally enables `--allow-internal` so a package facade can validate against its own `internal/*` implementation modules.
 
 ## 3) Coding Style
 
@@ -82,10 +93,29 @@ When snapshots fail:
 Useful commands:
 
 ```sh
+make core-language-gate
+make core-release-gate
+make update-diagnostics-ftl
 make diag-snapshots
 make modules-snapshots
 make modules-snapshots-update
 ```
+
+If your change touches syntax, diagnostics, imports, or language semantics, `make core-language-gate` is the minimum regression gate.
+If your change affects the documented protected contract, release wording, or stability policy, `make core-release-gate` is the minimum release-facing gate.
+
+Language maturity vocabulary:
+
+- `stable`: protected by an explicit gate or compatibility policy
+- `experimental`: implemented, but outside the protected contract
+- `internal`: not a public contract
+
+Protected language contract references:
+
+- `docs/LANGUAGE_CORE_COMPATIBILITY.md`
+- `docs/LANGUAGE_CORE_GUARANTEES.md`
+- `docs/LANGUAGE_CORE_SURFACE.md`
+- `docs/LANGUAGE_CORE_TEST_PLAN.md`
 
 ## 7) Modules / Packages Rules (Important)
 

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ install-bin:
 
 install-editors:
 	@$(MKDIR) "$(VIM_DIR)/syntax" "$(VIM_DIR)/indent" "$(VIM_DIR)/ftdetect" "$(VIM_DIR)/ftplugin" "$(VIM_DIR)/compiler"
-	@$(CP) editors/vim/vitte.vim "$(VIM_DIR)/syntax/vitte.vim"
+	@$(CP) editors/vim/syntax/vitte.vim "$(VIM_DIR)/syntax/vitte.vim"
 	@$(CP) editors/vim/indent/vitte.vim "$(VIM_DIR)/indent/vitte.vim"
 	@$(CP) editors/vim/ftdetect/vitte.vim "$(VIM_DIR)/ftdetect/vitte.vim"
 	@$(CP) editors/vim/ftplugin/vitte.vim "$(VIM_DIR)/ftplugin/vitte.vim"
@@ -307,6 +307,18 @@ negative-tests:
 diag-snapshots:
 	@tools/diag_snapshots.sh
 
+.PHONY: diagnostics-locales-lint
+diagnostics-locales-lint:
+	@python3 tools/check_diagnostics_locales.py
+
+.PHONY: core-semantic-snapshots
+core-semantic-snapshots:
+	@MANIFEST=tests/diag_snapshots/core_semantic_manifest.txt tools/diag_snapshots.sh
+
+.PHONY: core-semantic-success
+core-semantic-success:
+	@MANIFEST=tests/core_semantic_success_manifest.txt tools/check_manifest.sh
+
 .PHONY: resolve-tests
 resolve-tests:
 	@TEST_DIR=tests/diag_snapshots/resolve tools/diag_snapshots.sh
@@ -336,6 +348,14 @@ grammar-check:
 grammar-test:
 	@python3 book/grammar/scripts/validate_examples.py
 
+.PHONY: core-language-test
+core-language-test:
+	@python3 book/grammar/scripts/validate_examples.py --manifest tests/grammar/core_manifest.txt
+
+.PHONY: core-language-test-update
+core-language-test-update:
+	@python3 book/grammar/scripts/validate_examples.py --manifest tests/grammar/core_manifest.txt --update-snapshots
+
 .PHONY: grammar-test-update
 grammar-test-update:
 	@python3 book/grammar/scripts/validate_examples.py --update-snapshots
@@ -350,6 +370,12 @@ grammar-docs-check:
 
 .PHONY: grammar-gate
 grammar-gate: grammar-check grammar-test grammar-docs-check
+
+.PHONY: core-language-gate
+core-language-gate: grammar-check core-language-test core-semantic-success core-semantic-snapshots diagnostics-locales-lint
+
+.PHONY: core-release-gate
+core-release-gate: core-language-gate diagnostics-ftl-check
 
 .PHONY: book-qa
 book-qa:
@@ -371,11 +397,15 @@ keywords-lint:
 update-diagnostics-ftl:
 	@tools/update_diagnostics_ftl.py
 
+.PHONY: diagnostics-ftl-check
+diagnostics-ftl-check:
+	@tools/update_diagnostics_ftl.py --check
+
 .PHONY: ci-strict
-ci-strict: grammar-check package-layout-lint legacy-import-path-lint negative-tests diag-snapshots geany-lint highlight-snapshots
+ci-strict: core-language-gate package-layout-lint legacy-import-path-lint negative-tests diag-snapshots geany-lint highlight-snapshots
 
 .PHONY: ci-fast
-ci-fast: grammar-check package-layout-lint legacy-import-path-lint negative-tests diag-snapshots completions-snapshots wrapper-stage-test geany-lint
+ci-fast: core-language-gate package-layout-lint legacy-import-path-lint negative-tests diag-snapshots completions-snapshots wrapper-stage-test geany-lint
 
 .PHONY: ci-completions
 ci-completions: completions-check completions-lint completions-snapshots completions-fallback
@@ -578,11 +608,20 @@ modules-report:
 
 .PHONY: packages-report
 packages-report:
-	@SEARCH_ROOT=src/vitte/packages ENTRY_GLOB=mod.vit OUT_FILE=target/reports/packages_modules_report.txt OUT_JSON=target/reports/packages_modules_report.json tools/modules_report.sh
+	@SEARCH_ROOT=src/vitte/packages ENTRY_GLOB=mod.vit OUT_FILE=target/reports/packages_modules_report.txt OUT_JSON=target/reports/packages_modules_report.json DEPENDENCY_OVERLAP_ALLOWLIST=tools/package_dependency_export_overlap_allowlist.txt tools/modules_report.sh
+
+.PHONY: packages-dependency-overlap-lint
+packages-dependency-overlap-lint:
+	@SEARCH_ROOT=src/vitte/packages ENTRY_GLOB=mod.vit OUT_FILE=target/reports/packages_modules_report.txt OUT_JSON=target/reports/packages_modules_report.json DEPENDENCY_OVERLAP_ALLOWLIST=tools/package_dependency_export_overlap_allowlist.txt FAIL_ON_DEPENDENCY_OVERLAP=1 tools/modules_report.sh
+
+.PHONY: package-check
+package-check:
+	@test -n "$(SRC)" || (echo "usage: make package-check SRC=src/vitte/packages/<pkg>/mod.vit" >&2; exit 2)
+	@bin/vitte check --lang=en --allow-internal --resolve-only "$(SRC)"
 
 .PHONY: modules-perf-cache
 modules-perf-cache:
-	@tools/modules_cache_perf.sh tests/modules/mod_graph/main.vit
+	@tools/modules_cache_perf.sh tests/modules/mod_doctor/main.vit
 
 .PHONY: packages-contract-snapshots
 packages-contract-snapshots:
@@ -593,7 +632,7 @@ packages-contract-snapshots-update:
 	@tools/packages_contract_snapshots.sh --update
 
 .PHONY: packages-gate
-packages-gate: package-layout-lint-strict packages-governance-lint no-std-lint module-naming-lint legacy-import-path-lint critical-runtime-matrix-lint new-public-packages-snapshots-lint modules-perf-cache packages-report packages-contract-snapshots
+packages-gate: package-layout-lint-strict packages-governance-lint no-std-lint module-naming-lint legacy-import-path-lint critical-runtime-matrix-lint new-public-packages-snapshots-lint modules-perf-cache packages-dependency-overlap-lint packages-contract-snapshots
 
 .PHONY: modules-ci-strict
 modules-ci-strict: modules-tests modules-snapshots modules-contract-snapshots module-tree-lint module-naming-lint critical-module-contract-lint experimental-modules-lint public-modules-snapshots-lint modules-perf-cache legacy-import-path-lint migration-check modules-report
@@ -811,7 +850,15 @@ PKG_VERSION ?= 2.1.1
 
 .PHONY: pkg-debian
 pkg-debian:
-	@VERSION=$(PKG_VERSION) toolchain/scripts/package/make-debian-deb.sh
+	@VERSION=$(PKG_VERSION) PACKAGE_PROFILE=full toolchain/scripts/package/make-debian-deb.sh
+
+.PHONY: pkg-debian-min
+pkg-debian-min:
+	@VERSION=$(PKG_VERSION) PACKAGE_PROFILE=minimal toolchain/scripts/package/make-debian-deb.sh
+
+.PHONY: pkg-debian-audit
+pkg-debian-audit: pkg-debian
+	@toolchain/scripts/package/audit-debian-deb.sh pkgout/vitte_$(PKG_VERSION)_$$(dpkg --print-architecture).deb
 
 .PHONY: pkg-debian-install
 pkg-debian-install: pkg-debian
@@ -826,7 +873,7 @@ pkg-macos-uninstall:
 	@VERSION=$(PKG_VERSION) toolchain/scripts/package/make-macos-uninstall-pkg.sh
 
 .PHONY: release-check
-release-check: build ci-fast package-layout-lint-strict legacy-import-allowlist-empty ci-completions pkg-macos
+release-check: build core-release-gate ci-fast package-layout-lint-strict legacy-import-allowlist-empty ci-completions pkg-macos
 
 .PHONY: migration-check
 migration-check: diag-snapshots package-layout-lint-strict legacy-import-path-lint
@@ -921,8 +968,16 @@ help:
 	@echo "  make grammar-sync regenerate grammar surface artifacts from src/vitte/grammar/vitte.ebnf"
 	@echo "  make grammar-check fail if grammar generated artifacts are out of sync"
 	@echo "  make grammar-test validate grammar corpus + diagnostics snapshots"
+	@echo "  make core-language-test validate the focused core language corpus"
+	@echo "  make core-semantic-success validate focused passing core semantic examples"
+	@echo "  make core-semantic-snapshots validate focused core semantic diagnostics"
+	@echo "  make diagnostics-locales-lint validate locale files against centralized diagnostics"
+	@echo "  make update-diagnostics-ftl synchronize diagnostics locales from the central table"
+	@echo "  make diagnostics-ftl-check fail if diagnostics locales are out of sync"
 	@echo "  make grammar-docs regenerate railroad SVG diagrams"
 	@echo "  make grammar-gate run grammar-check + grammar-test"
+	@echo "  make core-language-gate run grammar-check + core-language-test + core semantic gates + diagnostics locales lint"
+	@echo "  make core-release-gate run the protected language contract gate for release-facing work"
 	@echo "  make keywords-normalize apply strict keyword template on book/keywords/*.md"
 	@echo "  make keywords-lint validate keyword quality sections/diagnostics/links/score"
 	@echo "  make test-examples build/check all examples/*.vit"
@@ -957,11 +1012,13 @@ help:
 	@echo "  make vitteos-bin-quality run /bin quality checks + matrix report"
 	@echo "  make vitteos-bin-runnable-check assert bin/vitte is host-runnable (non-regression arch/format guard)"
 	@echo "  make vitteos-bin-runtime run runtime-smoke probes and update runtime column"
-	@echo "  make pkg-debian build Debian .deb installer (PKG_VERSION=$(PKG_VERSION))"
+	@echo "  make pkg-debian build Debian .deb installer (PACKAGE_PROFILE=full, PKG_VERSION=$(PKG_VERSION))"
+	@echo "  make pkg-debian-min build Debian .deb installer (PACKAGE_PROFILE=minimal, PKG_VERSION=$(PKG_VERSION))"
+	@echo "  make pkg-debian-audit audit generated Debian .deb content and largest files"
 	@echo "  make pkg-debian-install build and install Debian .deb locally via dpkg"
 	@echo "  make pkg-macos build macOS installer pkg (PKG_VERSION=$(PKG_VERSION))"
 	@echo "  make pkg-macos-uninstall build macOS uninstall pkg (PKG_VERSION=$(PKG_VERSION))"
-	@echo "  make release-check run build + ci-fast + ci-completions + pkg build"
+	@echo "  make release-check run build + core-release-gate + ci-fast + ci-completions + pkg build"
 	@echo "  make reports-index build target/reports/index.json (unified reports registry)"
 	@echo "  make ci-mod-fast module-focused CI (grammar + snapshots + module tests)"
 	@echo "  make ci-fast-compiler compiler-focused CI with cache skip (grammar + resolve + module snapshots + explain + runtime matrix)"

--- a/src/vitte/packages/sync/OWNERS
+++ b/src/vitte/packages/sync/OWNERS
@@ -1,0 +1,1 @@
+@vitte/sync

--- a/tests/modules/snapshots/mod_cache_report.cmd
+++ b/tests/modules/snapshots/mod_cache_report.cmd
@@ -1,1 +1,1 @@
-check --cache-report tests/modules/mod_graph/main.vit
+check --cache-report tests/modules/mod_doctor/main.vit

--- a/tests/modules/snapshots/packages/packages_gate.diagjson.must
+++ b/tests/modules/snapshots/packages/packages_gate.diagjson.must
@@ -1,79 +1,125 @@
-[package-layout-lint] scanned packages: 127
+[package-layout-lint] scanned packages: 128
 [package-layout-lint] OK (warnings: 0)
-[packages-governance-lint] scanned modules: 155
+[packages-governance-lint] scanned modules: 156
 [packages-governance-lint] OK
+[no-std-lint] scanned files: 791
 [no-std-lint] allowlist entries: 2
 [no-std-lint] OK
-[module-naming-lint] scanned modules: 155
+[module-naming-lint] scanned modules: 156
 [module-naming-lint] OK
+[legacy-import-lint] scanned files: 840
 [legacy-import-lint] allowlist entries: 5 (budget: 5)
 [legacy-import-lint] OK
 [critical-runtime-matrix] profiles=core,system,desktop,arduino modules=abi,core,db,http,alerts
 [critical-runtime-matrix] OK
 [new-public-snapshots] BASE_REF not set; skipping check
+[modules-cache-perf] cold_ms=10 hot_ms=12
+[modules-cache-perf] skip ratio check (cold_ms=10 < min=20 ms)
 [modules-cache-perf] OK
 modules-report
-fixtures: 155
-unique_modules: 15
-edges: 14
+fixtures: 156
+unique_modules: 35
+edges: 36
 cycles: 0
 critical_cycles: 0
 fanout_median: 0
 fanin_median: 1
-max_depth: 3
+max_depth: 4
+
 fanout_top:
   vitte/process/internal/runtime: imports=7
-  __root__: imports=1
+  vitte/fs: imports=3
+  vitte/http_client: imports=3
+  vitte/json: imports=3
+  vitte/std/base: imports=3
+  vitte/yaml: imports=3
+  __root__: imports=2
+  vitte/process: imports=2
   vitte/process/compat: imports=1
   std/core/option: imports=0
-  std/core/result: imports=0
-  vitte/arduino: imports=0
-  vitte/crypto: imports=0
-  vitte/process/internal/capture: imports=0
-  vitte/process/internal/policy: imports=0
-  vitte/process/internal/signal: imports=0
+
 fanin_top:
   vitte/arduino: fanin=5
-  std/core/option: fanin=1
-  std/core/result: fanin=1
-  vitte/crypto: fanin=1
-  vitte/process/compat: fanin=1
-  vitte/process/internal/capture: fanin=1
-  vitte/process/internal/policy: fanin=1
-  vitte/process/internal/runtime: fanin=1
-  vitte/process/internal/signal: fanin=1
-  vitte/process/internal/spawn: fanin=1
+  vitte/process/internal/runtime: fanin=3
+  vitte/json: fanin=2
+  vitte/json/internal/policy: fanin=2
+  vitte/json/internal/runtime: fanin=2
+  vitte/json/internal/validate: fanin=2
+  vitte/process/compat: fanin=2
+  vitte/process/internal/capture: fanin=2
+  vitte/process/internal/policy: fanin=2
+  vitte/process/internal/signal: fanin=2
+
 loc_top:
-  __root__: loc=1908
-  vitte/process/internal/runtime: loc=188
-  vitte/arduino: loc=161
-  vitte/std/base: loc=115
-  vitte/crypto: loc=89
-  vitte/process/compat: loc=88
-  vitte/process/internal/validate: loc=60
-  vitte/process/internal/policy: loc=49
-  vitte/process/internal/spawn: loc=40
-  vitte/process/internal/wait: loc=25
+  __root__: loc=2076
+  vitte/arduino: loc=621
+  vitte/fs: loc=569
+  vitte/process: loc=426
+  vitte/http_client: loc=422
+  vitte/yaml: loc=369
+  vitte/crypto: loc=363
+  vitte/json: loc=318
+  vitte/std/base: loc=309
+  vitte/yaml/internal/runtime: loc=248
+
 cycle_samples:
   none
+
 cycles_by_severity:
   none
+
 critical_cycle_samples:
   none
+
 potential_collisions:
-  src/vitte/packages/process/mod.vit: symbol='command_allowlisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='command_denylisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='shell_exec_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='shell_injection_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='args_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='contains' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='cwd_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='env_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='has_control_chars' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='policy_hash' owners=vitte/process/internal/runtime,vitte/process/internal/spawn
-  src/vitte/packages/process/mod.vit: symbol='starts_with' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  none
+
+dependency_export_overlap:
+  none
+
+dependency_export_overlap_allowlisted:
+  src/vitte/packages/std/data/mod.vit: symbol='Array' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='FormatOptions' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Number' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Object' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='ObjectEntry' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='ParseOptions' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Schema' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='StreamState' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Value' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='api_version' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='capabilities' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_config' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_format_options' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_parse_options' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_doc_url' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_message' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_quickfix' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diff' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='doctor_status' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='err' owners=vitte/json,vitte/yaml
+
 high_frequency_symbols:
-  symbol='package_meta' count=3 owners=vitte/arduino,vitte/crypto,vitte/std/base
+  symbol='diagnostics_doc_url' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='diagnostics_message' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='diagnostics_quickfix' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='package_meta' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='healthcheck' count=9 owners=std/core/option,std/core/result,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='capabilities' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='default_config' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='ready' count=8 owners=vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='validate_config' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='version' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='err' count=7 owners=vitte/arduino,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='ok' count=7 owners=vitte/arduino,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='api_version' count=6 owners=vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='doctor_status' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='normalize_config' count=5 owners=vitte/crypto,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='quickfix_apply' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='quickfix_preview' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='analyze_report_json_stub' count=3 owners=vitte/fs,vitte/http_client,vitte/process
+  symbol='assert_or_err' count=3 owners=vitte/fs,vitte/http_client,vitte/std/base
+  symbol='panic_guard' count=3 owners=vitte/fs,vitte/http_client,vitte/std/base
 [modules-report] wrote target/reports/packages_modules_report.txt
 [modules-report] wrote target/reports/packages_modules_report.json
 [packages-contract-snapshots] OK

--- a/tests/modules/snapshots/packages/packages_gate.must
+++ b/tests/modules/snapshots/packages/packages_gate.must
@@ -1,79 +1,125 @@
-[package-layout-lint] scanned packages: 127
+[package-layout-lint] scanned packages: 128
 [package-layout-lint] OK (warnings: 0)
-[packages-governance-lint] scanned modules: 155
+[packages-governance-lint] scanned modules: 156
 [packages-governance-lint] OK
+[no-std-lint] scanned files: 791
 [no-std-lint] allowlist entries: 2
 [no-std-lint] OK
-[module-naming-lint] scanned modules: 155
+[module-naming-lint] scanned modules: 156
 [module-naming-lint] OK
+[legacy-import-lint] scanned files: 840
 [legacy-import-lint] allowlist entries: 5 (budget: 5)
 [legacy-import-lint] OK
 [critical-runtime-matrix] profiles=core,system,desktop,arduino modules=abi,core,db,http,alerts
 [critical-runtime-matrix] OK
 [new-public-snapshots] BASE_REF not set; skipping check
+[modules-cache-perf] cold_ms=10 hot_ms=12
+[modules-cache-perf] skip ratio check (cold_ms=10 < min=20 ms)
 [modules-cache-perf] OK
 modules-report
-fixtures: 155
-unique_modules: 15
-edges: 14
+fixtures: 156
+unique_modules: 35
+edges: 36
 cycles: 0
 critical_cycles: 0
 fanout_median: 0
 fanin_median: 1
-max_depth: 3
+max_depth: 4
+
 fanout_top:
   vitte/process/internal/runtime: imports=7
-  __root__: imports=1
+  vitte/fs: imports=3
+  vitte/http_client: imports=3
+  vitte/json: imports=3
+  vitte/std/base: imports=3
+  vitte/yaml: imports=3
+  __root__: imports=2
+  vitte/process: imports=2
   vitte/process/compat: imports=1
   std/core/option: imports=0
-  std/core/result: imports=0
-  vitte/arduino: imports=0
-  vitte/crypto: imports=0
-  vitte/process/internal/capture: imports=0
-  vitte/process/internal/policy: imports=0
-  vitte/process/internal/signal: imports=0
+
 fanin_top:
   vitte/arduino: fanin=5
-  std/core/option: fanin=1
-  std/core/result: fanin=1
-  vitte/crypto: fanin=1
-  vitte/process/compat: fanin=1
-  vitte/process/internal/capture: fanin=1
-  vitte/process/internal/policy: fanin=1
-  vitte/process/internal/runtime: fanin=1
-  vitte/process/internal/signal: fanin=1
-  vitte/process/internal/spawn: fanin=1
+  vitte/process/internal/runtime: fanin=3
+  vitte/json: fanin=2
+  vitte/json/internal/policy: fanin=2
+  vitte/json/internal/runtime: fanin=2
+  vitte/json/internal/validate: fanin=2
+  vitte/process/compat: fanin=2
+  vitte/process/internal/capture: fanin=2
+  vitte/process/internal/policy: fanin=2
+  vitte/process/internal/signal: fanin=2
+
 loc_top:
-  __root__: loc=1908
-  vitte/process/internal/runtime: loc=188
-  vitte/arduino: loc=161
-  vitte/std/base: loc=115
-  vitte/crypto: loc=89
-  vitte/process/compat: loc=88
-  vitte/process/internal/validate: loc=60
-  vitte/process/internal/policy: loc=49
-  vitte/process/internal/spawn: loc=40
-  vitte/process/internal/wait: loc=25
+  __root__: loc=2076
+  vitte/arduino: loc=621
+  vitte/fs: loc=569
+  vitte/process: loc=426
+  vitte/http_client: loc=422
+  vitte/yaml: loc=369
+  vitte/crypto: loc=363
+  vitte/json: loc=318
+  vitte/std/base: loc=309
+  vitte/yaml/internal/runtime: loc=248
+
 cycle_samples:
   none
+
 cycles_by_severity:
   none
+
 critical_cycle_samples:
   none
+
 potential_collisions:
-  src/vitte/packages/process/mod.vit: symbol='command_allowlisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='command_denylisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='shell_exec_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='shell_injection_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='args_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='contains' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='cwd_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='env_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='has_control_chars' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='policy_hash' owners=vitte/process/internal/runtime,vitte/process/internal/spawn
-  src/vitte/packages/process/mod.vit: symbol='starts_with' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  none
+
+dependency_export_overlap:
+  none
+
+dependency_export_overlap_allowlisted:
+  src/vitte/packages/std/data/mod.vit: symbol='Array' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='FormatOptions' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Number' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Object' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='ObjectEntry' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='ParseOptions' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Schema' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='StreamState' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Value' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='api_version' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='capabilities' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_config' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_format_options' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_parse_options' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_doc_url' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_message' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_quickfix' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diff' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='doctor_status' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='err' owners=vitte/json,vitte/yaml
+
 high_frequency_symbols:
-  symbol='package_meta' count=3 owners=vitte/arduino,vitte/crypto,vitte/std/base
+  symbol='diagnostics_doc_url' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='diagnostics_message' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='diagnostics_quickfix' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='package_meta' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='healthcheck' count=9 owners=std/core/option,std/core/result,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='capabilities' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='default_config' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='ready' count=8 owners=vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='validate_config' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='version' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='err' count=7 owners=vitte/arduino,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='ok' count=7 owners=vitte/arduino,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='api_version' count=6 owners=vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='doctor_status' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='normalize_config' count=5 owners=vitte/crypto,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='quickfix_apply' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='quickfix_preview' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='analyze_report_json_stub' count=3 owners=vitte/fs,vitte/http_client,vitte/process
+  symbol='assert_or_err' count=3 owners=vitte/fs,vitte/http_client,vitte/std/base
+  symbol='panic_guard' count=3 owners=vitte/fs,vitte/http_client,vitte/std/base
 [modules-report] wrote target/reports/packages_modules_report.txt
 [modules-report] wrote target/reports/packages_modules_report.json
 [packages-contract-snapshots] OK

--- a/tests/modules/snapshots/packages/packages_report.diagjson.must
+++ b/tests/modules/snapshots/packages/packages_report.diagjson.must
@@ -1,64 +1,106 @@
 modules-report
-fixtures: 155
-unique_modules: 15
-edges: 14
+fixtures: 156
+unique_modules: 35
+edges: 36
 cycles: 0
 critical_cycles: 0
 fanout_median: 0
 fanin_median: 1
-max_depth: 3
+max_depth: 4
+
 fanout_top:
   vitte/process/internal/runtime: imports=7
-  __root__: imports=1
+  vitte/fs: imports=3
+  vitte/http_client: imports=3
+  vitte/json: imports=3
+  vitte/std/base: imports=3
+  vitte/yaml: imports=3
+  __root__: imports=2
+  vitte/process: imports=2
   vitte/process/compat: imports=1
   std/core/option: imports=0
-  std/core/result: imports=0
-  vitte/arduino: imports=0
-  vitte/crypto: imports=0
-  vitte/process/internal/capture: imports=0
-  vitte/process/internal/policy: imports=0
-  vitte/process/internal/signal: imports=0
+
 fanin_top:
   vitte/arduino: fanin=5
-  std/core/option: fanin=1
-  std/core/result: fanin=1
-  vitte/crypto: fanin=1
-  vitte/process/compat: fanin=1
-  vitte/process/internal/capture: fanin=1
-  vitte/process/internal/policy: fanin=1
-  vitte/process/internal/runtime: fanin=1
-  vitte/process/internal/signal: fanin=1
-  vitte/process/internal/spawn: fanin=1
+  vitte/process/internal/runtime: fanin=3
+  vitte/json: fanin=2
+  vitte/json/internal/policy: fanin=2
+  vitte/json/internal/runtime: fanin=2
+  vitte/json/internal/validate: fanin=2
+  vitte/process/compat: fanin=2
+  vitte/process/internal/capture: fanin=2
+  vitte/process/internal/policy: fanin=2
+  vitte/process/internal/signal: fanin=2
+
 loc_top:
-  __root__: loc=1908
-  vitte/process/internal/runtime: loc=188
-  vitte/arduino: loc=161
-  vitte/std/base: loc=115
-  vitte/crypto: loc=89
-  vitte/process/compat: loc=88
-  vitte/process/internal/validate: loc=60
-  vitte/process/internal/policy: loc=49
-  vitte/process/internal/spawn: loc=40
-  vitte/process/internal/wait: loc=25
+  __root__: loc=2076
+  vitte/arduino: loc=621
+  vitte/fs: loc=569
+  vitte/process: loc=426
+  vitte/http_client: loc=422
+  vitte/yaml: loc=369
+  vitte/crypto: loc=363
+  vitte/json: loc=318
+  vitte/std/base: loc=309
+  vitte/yaml/internal/runtime: loc=248
+
 cycle_samples:
   none
+
 cycles_by_severity:
   none
+
 critical_cycle_samples:
   none
+
 potential_collisions:
-  src/vitte/packages/process/mod.vit: symbol='command_allowlisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='command_denylisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='shell_exec_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='shell_injection_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='args_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='contains' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='cwd_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='env_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='has_control_chars' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='policy_hash' owners=vitte/process/internal/runtime,vitte/process/internal/spawn
-  src/vitte/packages/process/mod.vit: symbol='starts_with' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  none
+
+dependency_export_overlap:
+  none
+
+dependency_export_overlap_allowlisted:
+  src/vitte/packages/std/data/mod.vit: symbol='Array' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='FormatOptions' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Number' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Object' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='ObjectEntry' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='ParseOptions' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Schema' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='StreamState' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Value' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='api_version' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='capabilities' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_config' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_format_options' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_parse_options' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_doc_url' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_message' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_quickfix' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diff' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='doctor_status' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='err' owners=vitte/json,vitte/yaml
+
 high_frequency_symbols:
-  symbol='package_meta' count=3 owners=vitte/arduino,vitte/crypto,vitte/std/base
+  symbol='diagnostics_doc_url' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='diagnostics_message' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='diagnostics_quickfix' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='package_meta' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='healthcheck' count=9 owners=std/core/option,std/core/result,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='capabilities' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='default_config' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='ready' count=8 owners=vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='validate_config' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='version' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='err' count=7 owners=vitte/arduino,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='ok' count=7 owners=vitte/arduino,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='api_version' count=6 owners=vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='doctor_status' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='normalize_config' count=5 owners=vitte/crypto,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='quickfix_apply' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='quickfix_preview' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='analyze_report_json_stub' count=3 owners=vitte/fs,vitte/http_client,vitte/process
+  symbol='assert_or_err' count=3 owners=vitte/fs,vitte/http_client,vitte/std/base
+  symbol='panic_guard' count=3 owners=vitte/fs,vitte/http_client,vitte/std/base
 [modules-report] wrote target/reports/packages_modules_report.txt
 [modules-report] wrote target/reports/packages_modules_report.json

--- a/tests/modules/snapshots/packages/packages_report.must
+++ b/tests/modules/snapshots/packages/packages_report.must
@@ -1,64 +1,106 @@
 modules-report
-fixtures: 155
-unique_modules: 15
-edges: 14
+fixtures: 156
+unique_modules: 35
+edges: 36
 cycles: 0
 critical_cycles: 0
 fanout_median: 0
 fanin_median: 1
-max_depth: 3
+max_depth: 4
+
 fanout_top:
   vitte/process/internal/runtime: imports=7
-  __root__: imports=1
+  vitte/fs: imports=3
+  vitte/http_client: imports=3
+  vitte/json: imports=3
+  vitte/std/base: imports=3
+  vitte/yaml: imports=3
+  __root__: imports=2
+  vitte/process: imports=2
   vitte/process/compat: imports=1
   std/core/option: imports=0
-  std/core/result: imports=0
-  vitte/arduino: imports=0
-  vitte/crypto: imports=0
-  vitte/process/internal/capture: imports=0
-  vitte/process/internal/policy: imports=0
-  vitte/process/internal/signal: imports=0
+
 fanin_top:
   vitte/arduino: fanin=5
-  std/core/option: fanin=1
-  std/core/result: fanin=1
-  vitte/crypto: fanin=1
-  vitte/process/compat: fanin=1
-  vitte/process/internal/capture: fanin=1
-  vitte/process/internal/policy: fanin=1
-  vitte/process/internal/runtime: fanin=1
-  vitte/process/internal/signal: fanin=1
-  vitte/process/internal/spawn: fanin=1
+  vitte/process/internal/runtime: fanin=3
+  vitte/json: fanin=2
+  vitte/json/internal/policy: fanin=2
+  vitte/json/internal/runtime: fanin=2
+  vitte/json/internal/validate: fanin=2
+  vitte/process/compat: fanin=2
+  vitte/process/internal/capture: fanin=2
+  vitte/process/internal/policy: fanin=2
+  vitte/process/internal/signal: fanin=2
+
 loc_top:
-  __root__: loc=1908
-  vitte/process/internal/runtime: loc=188
-  vitte/arduino: loc=161
-  vitte/std/base: loc=115
-  vitte/crypto: loc=89
-  vitte/process/compat: loc=88
-  vitte/process/internal/validate: loc=60
-  vitte/process/internal/policy: loc=49
-  vitte/process/internal/spawn: loc=40
-  vitte/process/internal/wait: loc=25
+  __root__: loc=2076
+  vitte/arduino: loc=621
+  vitte/fs: loc=569
+  vitte/process: loc=426
+  vitte/http_client: loc=422
+  vitte/yaml: loc=369
+  vitte/crypto: loc=363
+  vitte/json: loc=318
+  vitte/std/base: loc=309
+  vitte/yaml/internal/runtime: loc=248
+
 cycle_samples:
   none
+
 cycles_by_severity:
   none
+
 critical_cycle_samples:
   none
+
 potential_collisions:
-  src/vitte/packages/process/mod.vit: symbol='command_allowlisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='command_denylisted' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='shell_exec_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='shell_injection_pattern' owners=vitte/process/internal/policy,vitte/process/internal/runtime
-  src/vitte/packages/process/mod.vit: symbol='args_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='contains' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='cwd_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='env_valid' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='has_control_chars' owners=vitte/process/internal/runtime,vitte/process/internal/validate
-  src/vitte/packages/process/mod.vit: symbol='policy_hash' owners=vitte/process/internal/runtime,vitte/process/internal/spawn
-  src/vitte/packages/process/mod.vit: symbol='starts_with' owners=vitte/process/internal/runtime,vitte/process/internal/validate
+  none
+
+dependency_export_overlap:
+  none
+
+dependency_export_overlap_allowlisted:
+  src/vitte/packages/std/data/mod.vit: symbol='Array' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='FormatOptions' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Number' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Object' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='ObjectEntry' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='ParseOptions' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Schema' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='StreamState' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='Value' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='api_version' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='capabilities' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_config' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_format_options' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='default_parse_options' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_doc_url' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_message' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diagnostics_quickfix' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='diff' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='doctor_status' owners=vitte/json,vitte/yaml
+  src/vitte/packages/std/data/mod.vit: symbol='err' owners=vitte/json,vitte/yaml
+
 high_frequency_symbols:
-  symbol='package_meta' count=3 owners=vitte/arduino,vitte/crypto,vitte/std/base
+  symbol='diagnostics_doc_url' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='diagnostics_message' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='diagnostics_quickfix' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='package_meta' count=10 owners=std/core/option,std/core/result,vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='healthcheck' count=9 owners=std/core/option,std/core/result,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='capabilities' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='default_config' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='ready' count=8 owners=vitte/arduino,vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='validate_config' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='version' count=8 owners=std/core/option,std/core/result,vitte/crypto,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='err' count=7 owners=vitte/arduino,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='ok' count=7 owners=vitte/arduino,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='api_version' count=6 owners=vitte/crypto,vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='doctor_status' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='normalize_config' count=5 owners=vitte/crypto,vitte/json,vitte/process,vitte/std/base,vitte/yaml
+  symbol='quickfix_apply' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='quickfix_preview' count=5 owners=vitte/fs,vitte/http_client,vitte/json,vitte/process,vitte/yaml
+  symbol='analyze_report_json_stub' count=3 owners=vitte/fs,vitte/http_client,vitte/process
+  symbol='assert_or_err' count=3 owners=vitte/fs,vitte/http_client,vitte/std/base
+  symbol='panic_guard' count=3 owners=vitte/fs,vitte/http_client,vitte/std/base
 [modules-report] wrote target/reports/packages_modules_report.txt
 [modules-report] wrote target/reports/packages_modules_report.json

--- a/tools/LINTS.md
+++ b/tools/LINTS.md
@@ -193,3 +193,14 @@ make packages-gate
 make migration-check
 make release-modules-gate
 ```
+
+`packages-report` distingue maintenant deux signaux:
+- `potential_collisions`: collision actionnable sur la surface exportée du module racine analysé
+- `dependency_export_overlap`: recouvrement de noms entre dépendances publiques co-chargees par une facade, utile a surveiller mais non bloquant a lui seul
+- `dependency_export_overlap_allowlisted`: recouvrement intentional versionne dans `tools/package_dependency_export_overlap_allowlist.txt`
+
+Pour rendre la gate stricte sans penaliser les facades connues:
+- `make packages-dependency-overlap-lint`
+
+Pour verifier directement une facade package qui depend de son propre `internal/*`:
+- `make package-check SRC=src/vitte/packages/std/data/mod.vit`

--- a/tools/modules_report.sh
+++ b/tools/modules_report.sh
@@ -8,6 +8,8 @@ ENTRY_GLOB="${ENTRY_GLOB:-main.vit}"
 OUT_DIR="${OUT_DIR:-$ROOT_DIR/target/reports}"
 OUT_FILE="${OUT_FILE:-$OUT_DIR/modules_report.txt}"
 OUT_JSON="${OUT_JSON:-$OUT_DIR/modules_report.json}"
+DEPENDENCY_OVERLAP_ALLOWLIST="${DEPENDENCY_OVERLAP_ALLOWLIST:-}"
+FAIL_ON_DEPENDENCY_OVERLAP="${FAIL_ON_DEPENDENCY_OVERLAP:-0}"
 
 log() { printf "[modules-report] %s\n" "$*"; }
 die() { printf "[modules-report][error] %s\n" "$*" >&2; exit 1; }
@@ -52,15 +54,18 @@ PY
   rm -f "$tmp_out"
 done < <(find "$SEARCH_ROOT" -type f -name "$ENTRY_GLOB" | sort)
 
-python3 - "$tmp_json" "$OUT_FILE" "$OUT_JSON" <<'PY'
+python3 - "$tmp_json" "$OUT_FILE" "$OUT_JSON" "$DEPENDENCY_OVERLAP_ALLOWLIST" "$FAIL_ON_DEPENDENCY_OVERLAP" <<'PY'
 import json
 import sys
 from collections import defaultdict
 from statistics import median
+from pathlib import Path
 
 path = sys.argv[1]
 out_file = sys.argv[2]
 out_json = sys.argv[3]
+allowlist_path = sys.argv[4]
+fail_on_dependency_overlap = sys.argv[5] == "1"
 
 records = []
 with open(path, encoding="utf-8") as f:
@@ -75,13 +80,29 @@ mod_loc = defaultdict(int)
 mod_exports = defaultdict(set)
 edges = set()
 collision_entries = []
+dependency_overlap_entries = []
+allowed_dependency_overlap_entries = []
 export_frequency = defaultdict(set)
+
+dependency_overlap_allow = set()
+if allowlist_path:
+    p = Path(allowlist_path)
+    if p.exists():
+        for raw in p.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            dependency_overlap_allow.add(line)
 
 for rec in records:
     fixture = rec["fixture"]
     per_symbol = defaultdict(set)
+    direct_public = set()
+    root_exports = set()
+    root_imports = set()
     for m in rec.get("modules", []):
         key = m.get("key", "")
+        level = m.get("level", "")
         imps = m.get("imports", [])
         exps = m.get("exports", [])
         loc = int(m.get("loc", 0) or 0)
@@ -90,13 +111,28 @@ for rec in records:
         for dep in imps:
             edges.add((key, dep))
             mod_fanin[dep] += 1
+        if key == "__root__":
+            root_imports.update(imps)
+            root_exports.update(exps)
+        if level != "public":
+            continue
+        if key == "__root__" or key in root_imports:
+            direct_public.add(key)
         for s in exps:
             mod_exports[key].add(s)
             per_symbol[s].add(key)
             export_frequency[s].add(key)
     for sym, owners in per_symbol.items():
-        if len(owners) > 1:
+        if len(owners) > 1 and "__root__" in owners:
             collision_entries.append((fixture, sym, sorted(owners)))
+        direct_owners = sorted(owners & direct_public)
+        if len(direct_owners) > 1 and "__root__" not in owners:
+            owner_key = ",".join(direct_owners)
+            allow_key = f"{fixture}|{owner_key}"
+            if allow_key in dependency_overlap_allow:
+                allowed_dependency_overlap_entries.append((fixture, sym, direct_owners))
+            else:
+                dependency_overlap_entries.append((fixture, sym, direct_owners))
 
 # cycle detection (small graphs; DFS from each node)
 graph = defaultdict(set)
@@ -151,6 +187,8 @@ fanout_top = sorted(mod_imports.items(), key=lambda kv: (-kv[1], kv[0]))[:10]
 fanin_top = sorted(mod_fanin.items(), key=lambda kv: (-kv[1], kv[0]))[:10]
 loc_top = sorted(mod_loc.items(), key=lambda kv: (-kv[1], kv[0]))[:10]
 collisions_top = collision_entries[:20]
+dependency_overlaps_top = dependency_overlap_entries[:20]
+allowed_dependency_overlaps_top = allowed_dependency_overlap_entries[:20]
 frequent_collisions = sorted(
     [(sym, sorted(owners)) for sym, owners in export_frequency.items() if len(owners) >= 3],
     key=lambda kv: (-len(kv[1]), kv[0]),
@@ -210,6 +248,20 @@ if collisions_top:
 else:
     lines.append("  none")
 lines.append("")
+lines.append("dependency_export_overlap:")
+if dependency_overlaps_top:
+    for fixture, sym, owners in dependency_overlaps_top:
+        lines.append(f"  {fixture}: symbol='{sym}' owners={','.join(owners)}")
+else:
+    lines.append("  none")
+lines.append("")
+lines.append("dependency_export_overlap_allowlisted:")
+if allowed_dependency_overlaps_top:
+    for fixture, sym, owners in allowed_dependency_overlaps_top:
+        lines.append(f"  {fixture}: symbol='{sym}' owners={','.join(owners)}")
+else:
+    lines.append("  none")
+lines.append("")
 lines.append("high_frequency_symbols:")
 if frequent_collisions:
     for sym, owners in frequent_collisions:
@@ -239,6 +291,14 @@ payload = {
         {"fixture": fixture, "symbol": sym, "owners": owners}
         for fixture, sym, owners in collisions_top
     ],
+    "dependency_export_overlap": [
+        {"fixture": fixture, "symbol": sym, "owners": owners}
+        for fixture, sym, owners in dependency_overlaps_top
+    ],
+    "dependency_export_overlap_allowlisted": [
+        {"fixture": fixture, "symbol": sym, "owners": owners}
+        for fixture, sym, owners in allowed_dependency_overlaps_top
+    ],
     "high_frequency_symbols": [
         {"symbol": sym, "owners": owners, "count": len(owners)}
         for sym, owners in frequent_collisions
@@ -248,6 +308,8 @@ with open(out_json, "w", encoding="utf-8") as f:
     json.dump(payload, f, indent=2, sort_keys=True)
 
 if critical_cycles:
+    raise SystemExit(1)
+if fail_on_dependency_overlap and dependency_overlap_entries:
     raise SystemExit(1)
 PY
 

--- a/tools/package_dependency_export_overlap_allowlist.txt
+++ b/tools/package_dependency_export_overlap_allowlist.txt
@@ -1,0 +1,4 @@
+# fixture|owner_a,owner_b
+# Allowlisted overlaps are intentional facade combinations between public packages.
+src/vitte/packages/std/data/mod.vit|vitte/json,vitte/yaml
+src/vitte/packages/std/net/mod.vit|vitte/http_client,vitte/json

--- a/tools/packages_contract_snapshots.sh
+++ b/tools/packages_contract_snapshots.sh
@@ -47,7 +47,7 @@ for mod in "${CRITICAL[@]}"; do
   snap_hash="$mod_snap_dir/$mod.exports.sha256"
 
   raw_json="$tmp_root/$mod.module-index.json"
-  out="$($BIN check --lang=en --allow-internal --dump-module-index "$src" 2>&1)"
+  out="$($BIN check --lang=en --allow-internal --resolve-only --dump-module-index "$src" 2>&1)"
   printf "%s\n" "$out" > "$raw_json"
 
   gen_all="$tmp_root/$mod.exports"


### PR DESCRIPTION
## Summary
- split actionable package-surface collisions from dependency export overlap
- add an allowlist-backed packages overlap lint and wire it into the gate
- document the new package governance workflow and add missing sync ownership metadata

## Testing
- make -s packages-gate
