### PR TITLE
[codex] man: simplify vitte pages

### DIFF
--- a/man/vitte.1
+++ b/man/vitte.1
@@ -1,103 +1,93 @@
-.TH VITTE 1 "February 2026" "vitte 2.1.1" "User Commands"
+.TH VITTE 1 "May 2026" "vitte 2.1.1" "User Commands"
 .SH NAME
-vitte \- compiler, checker, and tooling CLI for the Vitte language
+vitte \- main CLI for the Vitte compiler and tools
 .SH SYNOPSIS
 .B vitte
 [\fIcommand\fR] [\fIoptions\fR] \fI<input>\fR
 .SH DESCRIPTION
 .B vitte
-parses, checks, lowers, emits, and builds Vitte source files.
-It also provides module graph/doctor tooling, diagnostics explainers,
-and project bootstrap helpers.
+is the main command for the Vitte compiler.
+It can parse source, check it, lower it through IR, emit output, and run build-related helpers.
+
+The current repository keeps the compiler surface in Vitte.
+The goal is to keep the bootstrap path small, easy to read, and easy to test.
 .SH COMMANDS
 .TP
 .B help
 Show help and common tasks.
 .TP
 .B init [dir]
-Create a minimal project scaffold.
+Create a small project in the given directory.
 .TP
 .B explain <code>
-Explain a diagnostic code (for example \fBE0001\fR).
+Explain a diagnostic code such as \fBE0001\fR or \fBW1001\fR.
 .TP
 .B doctor
-Check toolchain prerequisites.
+Check toolchain and host setup.
 .TP
 .B parse
-Parse only (no backend).
+Parse only.
 .TP
 .B check
-Parse + resolve + IR (no backend).
+Parse, resolve, and lower to IR without backend output.
 .TP
 .B emit
-Emit C++ only (no native compile).
+Emit a compiler artifact for inspection.
 .TP
 .B build
-Full build (default command path).
+Run the full build path.
 .TP
 .B profile
-Build with stage timing/memory profile report.
+Run the build with timing and profile data.
 .TP
 .B reduce
-Reduce a failing input to a minimal reproducer.
+Shrink a failing input to a small reproducer.
 .TP
 .B clean-cache
-Remove \fB.vitte-cache\fR artifacts.
+Remove cached compiler state.
 .TP
 .B mod graph
-Show module import graph and cycle report.
+Show the module graph and cycle report.
 .TP
 .B mod doctor
-Lint module imports, aliases, and collisions.
+Check imports, aliases, and collisions.
 .TP
 .B mod contract-diff
-Compare exported module contract between two inputs.
-.TP
-.B mod api-diff
-Legacy alias for \fBmod contract-diff\fR.
+Compare exported module contracts between two inputs.
 .SH OPTIONS
 .TP
 .B \-h, \-\-help
 Show help.
 .TP
 .BI \-o " <file>"
-Output executable name.
+Set the output file name.
 .TP
 .BI \-\-lang " <code>"
-Language for diagnostics (for example \fBen\fR, \fBfr\fR).
+Set the diagnostics language, for example \fBen\fR or \fBfr\fR.
 .TP
 .BI \-\-explain " <code>"
 Explain one diagnostic code.
 .TP
 .BI \-\-runtime-include " <path>"
-Add include directory for \fBvitte_runtime.hpp\fR.
+Add a runtime include directory.
 .TP
 .BI \-\-target " <name>"
-Select target (for example \fBnative\fR, \fBarduino-uno\fR).
+Select the output target, for example \fBnative\fR or \fBarduino-uno\fR.
 .TP
 .B \-\-upload
-Upload to Arduino after build (requires \fB\-\-port\fR).
+Upload to Arduino after build.
 .TP
 .BI \-\-port " <path>"
-Serial port for Arduino upload.
+Arduino serial port.
 .TP
 .BI \-\-fqbn " <name>"
 Arduino fully qualified board name.
 .TP
 .B \-\-parse-only
-Parse only (legacy flag).
-.TP
-.B \-\-parse-modules
-Parse + load modules, no resolve/lowering.
-.TP
-.B \-\-parse-silent
-Suppress parse-only informational logs.
-.TP
-.B \-\-strict-parse
-Disallow keywords as identifiers.
+Parse only.
 .TP
 .B \-\-resolve-only
-Resolve only (no lowering).
+Resolve only.
 .TP
 .B \-\-hir-only
 Lower to HIR only.
@@ -106,167 +96,95 @@ Lower to HIR only.
 Lower to MIR only.
 .TP
 .B \-\-dump-ast
-Dump AST after parsing.
-.TP
-.B \-\-dump-ir
-Dump IR (alias of \fB\-\-dump-mir\fR).
-.TP
-.B \-\-dump-resolve
-Dump symbol table after resolve.
+Print AST after parsing.
 .TP
 .B \-\-dump-hir
-Dump HIR after lowering.
-.TP
-.B \-\-dump-hir-json
-Dump HIR as JSON.
-.TP
-.B \-\-dump-hir-compact
-Dump HIR as compact text.
-.TP
-.BI \-\-dump-hir= " pretty|compact|json"
-Select HIR dump format.
+Print HIR after lowering.
 .TP
 .B \-\-dump-mir
-Dump MIR after lowering.
+Print MIR after lowering.
 .TP
-.B \-\-emit-cpp
-Emit C++ only (legacy alias path).
+.B \-\-emit-vitte
+Emit a Vitte artifact only.
 .TP
 .B \-\-diag-json
-Emit diagnostics as JSON.
-.TP
-.B \-\-diag-json-pretty
-Emit diagnostics as pretty JSON.
-.TP
-.BI \-\-diag-filter " <codes>"
-Emit only selected diagnostic codes (comma-separated).
+Print diagnostics as JSON.
 .TP
 .B \-\-diag-code-only
-Emit compact diagnostics (\fBfile:line:col CODE\fR).
+Print compact diagnostics.
 .TP
 .B \-\-deterministic
-Enable deterministic output ordering.
-.TP
-.B \-\-cache-report
-Print parse/resolve/ir cache report.
+Keep output ordering stable.
 .TP
 .BI \-\-runtime-profile " <name>"
-Select runtime profile: \fBcore\fR, \fBsystem\fR, \fBdesktop\fR, \fBarduino\fR.
-.TP
-.BI \-\-stdlib-profile " <name>"
-Legacy alias of \fB\-\-runtime-profile\fR.
-.TP
-.B \-\-dump-stdlib-map
-Dump stdlib module -> exported symbols map.
-.TP
-.B \-\-dump-module-index
-Dump full module index as JSON.
+Select the runtime profile: \fBcore\fR, \fBsystem\fR, \fBdesktop\fR, or \fBarduino\fR.
 .TP
 .B \-\-allow-experimental
-Allow imports under experimental namespace.
-.TP
-.B \-\-warn-experimental
-Downgrade experimental import denial to warning.
+Allow experimental imports.
 .TP
 .B \-\-deny-internal
-Enforce internal module privacy (default).
+Keep internal module privacy enabled.
 .TP
 .B \-\-allow-internal
-Disable internal module privacy checks.
-.TP
-.B \-\-json
-For \fBmod graph\fR: output JSON.
-.TP
-.BI \-\-from " <module>"
-For \fBmod graph\fR: focus subgraph from module.
-.TP
-.B \-\-fix
-For \fBmod doctor\fR: print rewrite suggestions.
-.TP
-.BI \-\-max-imports " N"
-For \fBmod doctor\fR: threshold for module fan-out.
-.TP
-.BI \-\-old " <file>"
-For \fBmod contract-diff\fR: old entry file.
-.TP
-.BI \-\-new " <file>"
-For \fBmod contract-diff\fR: new entry file.
+Disable internal privacy checks.
 .TP
 .B \-\-strict-types
 Enforce canonical type names.
 .TP
 .B \-\-strict-modules
-Forbid glob imports, enforce alias + canonical path.
+Require explicit module imports.
 .TP
 .B \-\-strict-imports
-Enforce explicit imports and reject unused aliases.
-.TP
-.B \-\-strict-bridge
-Alias of \fB\-\-strict-imports\fR.
+Require explicit imports and reject unused aliases.
 .TP
 .B \-\-fail-on-warning
 Treat warnings as errors.
 .TP
 .BI \-\-stage " <name>"
-Stop at stage: \fBparse\fR, \fBresolve\fR, \fBir\fR, \fBbackend\fR.
+Stop at a stage: \fBparse\fR, \fBresolve\fR, \fBir\fR, or \fBbackend\fR.
 .TP
 .B \-\-freestanding
 Enable freestanding mode.
 .TP
 .B \-\-stdout
-Emit C++ to stdout (implies emit).
+Write output to stdout.
 .TP
 .B \-\-emit-obj
-Emit a native object file (\fB.o\fR).
+Emit an object file.
 .TP
 .B \-\-repro
-Enable reproducible object output flags.
+Enable reproducible output flags.
 .TP
 .B \-\-repro-strict
-Enforce strict deterministic IR lowering order.
-.TP
-.B \-\-no-auto-reduce
-Disable automatic repro reduction on backend/linker failure.
-.TP
-.BI \-\-crash-dir " <dir>"
-Write crash artifacts (\fBmetadata.txt\fR/\fBmetadata.json\fR, reduced input) under this directory.
+Enforce strict deterministic lowering.
 .TP
 .B \-\-debug
-Enable debug symbols.
+Include debug symbols.
 .TP
 .B \-O0 .. \-O3
 Set optimization level.
+.SH STAGES
+.TP
+.B parse
+Read syntax and top-level structure.
+.TP
+.B resolve
+Check modules, imports, and symbols.
+.TP
+.B ir
+Lower to HIR and MIR.
+.TP
+.B backend
+Emit target output.
 .SH FILES
 .TP
-.B .vitte-cache/
-Local cache for parse/resolve/ir artifacts.
+.B src/vitte/compiler
+Main Vitte compiler source tree.
 .TP
-.B stdlib source tree
-Stdlib source tree in repository layout.
-.SH ENVIRONMENT
+.B docs
+Project docs and site pages.
 .TP
-.B VITTE_ROOT
-Override repository/toolchain root used to resolve stdlib/runtime paths.
-.TP
-.B OPENSSL_DIR
-OpenSSL prefix for native compile/link.
-.TP
-.B CURL_DIR
-libcurl prefix for native compile/link.
-.TP
-.B LLD_PATH
-Path to \fBld.lld\fR for kernel/target flows requiring lld.
-.SH EXAMPLES
-.nf
-vitte help
-vitte init app
-vitte check src/main.vit
-vitte emit --stdout src/main.vit
-vitte mod graph --json --from __root__ src/main.vit
-vitte explain E0001
-.fi
-.SH EXIT STATUS
-Returns 0 on success, non-zero on parse/resolve/backend/toolchain failure.
+.B man/vittec.1
+Compatibility manual page.
 .SH SEE ALSO
-.BR c++ (1),
-.BR ld (1)
+.BR vittec (1)

--- a/man/vittec.1
+++ b/man/vittec.1
@@ -1,33 +1,28 @@
-.TH VITTEC 1 "March 2026" "vitte 03.2025" "User Commands"
+.TH VITTEC 1 "May 2026" "vitte 2.1.1" "User Commands"
 .SH NAME
-vittec \- compatibility frontend for the Vitte compiler CLI
+vittec \- compatibility CLI for the Vitte compiler
 .SH SYNOPSIS
 .B vittec
 [\fIcommand\fR] [\fIoptions\fR] \fI<input>\fR
 .SH DESCRIPTION
 .B vittec
-is a compatibility entrypoint for existing workflows.
-In current stdlib workflows, it resolves to the same CLI behavior as
+is a compatibility entrypoint.
+It keeps older workflows working while using the same compiler behavior as
 .BR vitte (1).
-When invoked through compatibility wrappers, startup logs include
-\fB[compat] vittec mode via vitte X.Y.Z\fR to make dispatch explicit.
+
+The main project should use
+.BR vitte (1)
+directly.
 .SH COMMANDS
 See
 .BR vitte (1)
-for the full command list (\fBparse\fR, \fBcheck\fR, \fBbuild\fR,
-module tooling, diagnostics explainers, and project helpers).
+for the full command list.
 .SH EXIT STATUS
-Returns 0 on success, non-zero on compilation/validation errors.
-.SH ENVIRONMENT
-See
-.BR vitte (1)
-(\fBVITTE_ROOT\fR, \fBOPENSSL_DIR\fR, \fBCURL_DIR\fR, \fBLLD_PATH\fR).
+Returns 0 on success and a non-zero code on errors.
 .SH EXAMPLES
 .nf
 vittec check src/main.vit
 vittec build src/main.vit
 .fi
 .SH SEE ALSO
-.BR vitte (1),
-.BR vitte-linker (1),
-.BR vitte-editor (1)
+.BR vitte (1)


### PR DESCRIPTION
## What changed
- Simplified `man/vitte.1` in plain English.
- Simplified `man/vittec.1` so the compatibility page stays short and clear.
- Kept the main commands, options, stages, and examples.

## Why
- Make the manual pages easier to read.
- Match the simpler English style used in the README.
- Keep the man pages useful without too much detail.

## Impact
- New users can scan the CLI docs faster.
- The main compiler entrypoint is easier to understand.
- The compatibility entrypoint stays documented in a small page.

## Validation
- `groff -Tutf8 -man man/vitte.1 >/dev/null`
- `groff -Tutf8 -man man/vittec.1 >/dev/null`
