### PR TITLE
i18n: export diagnostics messages for translation (CSV)

### DIFF
--- a/pkgout/diagnostics_for_translation.csv
+++ b/pkgout/diagnostics_for_translation.csv
@@ -1,0 +1,1472 @@
+key,english_text
+AST_E_DUPLICATE_FIELD,duplicate field
+AST_E_EMPTY_MODULE,empty module
+AST_E_INVALID_ATTRIBUTE,invalid attribute
+AST_E_INVALID_DECL,invalid decl
+AST_E_INVALID_ENTRY,invalid entry
+AST_E_INVALID_EXPR,invalid expr
+AST_E_INVALID_NODE,invalid node
+AST_E_INVALID_PATTERN,invalid pattern
+AST_E_INVALID_VISIBILITY,invalid visibility
+BACKEND_E_ABI_MISMATCH,abi mismatch
+BACKEND_E_AMBIGUOUS_NAME,ambiguous name
+BACKEND_E_ARGUMENT_MISMATCH,argument mismatch
+BACKEND_E_ARITY_MISMATCH,arity mismatch
+BACKEND_E_ASSEMBLER_FAILED,assembler failed
+BACKEND_E_ASSIGNMENT_MISMATCH,assignment mismatch
+BACKEND_E_BORROW_CONFLICT,borrow conflict
+BACKEND_E_BRANCH_MISMATCH,branch mismatch
+BACKEND_E_CODEGEN_FAILED,codegen failed
+BACKEND_E_CONST_CYCLE,const cycle
+BACKEND_E_CONST_DIVISION_BY_ZERO,const division by zero
+BACKEND_E_CONST_OVERFLOW,const overflow
+BACKEND_E_CONST_REQUIRED,const required
+BACKEND_E_DANGLING_REFERENCE,dangling reference
+BACKEND_E_DOUBLE_DROP,double drop
+BACKEND_E_DUPLICATE_NAME,duplicate name
+BACKEND_E_EXPECTED_BLOCK,expected block
+BACKEND_E_EXPECTED_DELIMITER,expected delimiter
+BACKEND_E_EXPECTED_EXPRESSION,expected expression
+BACKEND_E_EXPECTED_IDENTIFIER,expected identifier
+BACKEND_E_EXPECTED_PATTERN,expected pattern
+BACKEND_E_EXPECTED_TYPE,expected type
+BACKEND_E_EXPORT_CONFLICT,export conflict
+BACKEND_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+BACKEND_E_GENERIC_BOUND_FAILED,generic bound failed
+BACKEND_E_IMPORT_CYCLE,import cycle
+BACKEND_E_IMPORT_NOT_FOUND,import not found
+BACKEND_E_INVALID_ATTRIBUTE,invalid attribute
+BACKEND_E_INVALID_BORROW,invalid borrow
+BACKEND_E_INVALID_CALL,invalid call
+BACKEND_E_INVALID_CAST,invalid cast
+BACKEND_E_INVALID_DECLARATION,invalid declaration
+BACKEND_E_INVALID_DEREF,invalid deref
+BACKEND_E_INVALID_EXPRESSION,invalid expression
+BACKEND_E_INVALID_INDEX,invalid index
+BACKEND_E_INVALID_LITERAL,invalid literal
+BACKEND_E_INVALID_MODIFIER,invalid modifier
+BACKEND_E_INVALID_MOVE,invalid move
+BACKEND_E_INVALID_OPERATOR,invalid operator
+BACKEND_E_INVALID_PATTERN,invalid pattern
+BACKEND_E_INVALID_STATEMENT,invalid statement
+BACKEND_E_LIFETIME_TOO_SHORT,lifetime too short
+BACKEND_E_LINK_FAILED,link failed
+BACKEND_E_MACRO_EXPANSION_FAILED,macro expansion failed
+BACKEND_E_MACRO_NOT_FOUND,macro not found
+BACKEND_E_MACRO_RECURSION,macro recursion
+BACKEND_E_MISSING_BODY,missing body
+BACKEND_E_MISSING_RETURN,missing return
+BACKEND_E_MUTABILITY_CONFLICT,mutability conflict
+BACKEND_E_NATIVE_TOOL_MISSING,native tool missing
+BACKEND_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+BACKEND_E_OBJECT_WRITE_FAILED,object write failed
+BACKEND_E_PRIVATE_SYMBOL,private symbol
+BACKEND_E_RUNTIME_PANIC,runtime panic
+BACKEND_E_TRAIT_AMBIGUOUS,trait ambiguous
+BACKEND_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+BACKEND_E_UNBALANCED_DELIMITER,unbalanced delimiter
+BACKEND_E_UNEXPECTED_TOKEN,unexpected token
+BACKEND_E_UNKNOWN_MEMBER,unknown member
+BACKEND_E_UNKNOWN_MODULE,unknown module
+BACKEND_E_UNKNOWN_NAME,unknown name
+BACKEND_E_UNKNOWN_TYPE,unknown type
+BACKEND_E_UNREACHABLE_PATTERN,unreachable pattern
+BACKEND_E_UNSUPPORTED_FEATURE,unsupported feature
+BACKEND_E_UNSUPPORTED_TARGET,unsupported target
+BACKEND_E_USE_AFTER_DROP,use after drop
+BACKEND_E_USE_AFTER_MOVE,use after move
+BACKEND_E_USE_BEFORE_INIT,use before init
+BOOTSTRAP_E_ARTIFACT_INVALID,artifact invalid
+BOOTSTRAP_E_COMPILER_MISSING,compiler missing
+BOOTSTRAP_E_SEED_MISSING,seed missing
+BOOTSTRAP_E_SELF_CHECK_FAILED,self check failed
+BOOTSTRAP_E_STAGE_FAILURE,stage failure
+BORROWCK_E_ASSIGN_WHILE_BORROWED,assign while borrowed
+BORROWCK_E_BORROW_OF_MOVED_VALUE,borrow of moved value
+BORROWCK_E_DANGLING_REFERENCE,dangling reference
+BORROWCK_E_DOUBLE_DROP,double drop
+BORROWCK_E_DROP_WHILE_BORROWED,drop while borrowed
+BORROWCK_E_IMMUTABLE_ASSIGN,immutable assign
+BORROWCK_E_INTERNAL,internal
+BORROWCK_E_LIFETIME_TOO_SHORT,lifetime too short
+BORROWCK_E_MOVE_AFTER_BORROW,move after borrow
+BORROWCK_E_MOVE_AFTER_MOVE,move after move
+BORROWCK_E_MOVE_WHILE_BORROWED,move while borrowed
+BORROWCK_E_MUTABLE_ALIAS,mutable alias
+BORROWCK_E_MUTABLE_BORROW_CONFLICT,mutable borrow conflict
+BORROWCK_E_RETURN_BORROW_OF_LOCAL,return borrow of local
+BORROWCK_E_RETURN_REF_TO_LOCAL,return ref to local
+BORROWCK_E_SHARED_BORROW_CONFLICT,shared borrow conflict
+BORROWCK_E_UNINITIALIZED_USE,uninitialized use
+BORROWCK_E_UNKNOWN,unknown
+BORROWCK_E_USE_AFTER_DROP,use after drop
+BORROWCK_E_USE_AFTER_MOVE,value used after move
+BORROWCK_E_WRITE_WHILE_BORROWED,write while borrowed
+CONST_EVAL_E_CYCLE,cycle
+CONST_EVAL_E_DIVISION_BY_ZERO,division by zero in constant evaluation
+CONST_EVAL_E_MUTATION_IN_CONST,mutation in const
+CONST_EVAL_E_NON_CONST_CALL,non const call
+CONST_EVAL_E_OVERFLOW,overflow
+CONST_EVAL_E_PARSE,parse
+CONST_EVAL_E_STATIC_ASSERT_FAILED,static assert failed
+CONST_EVAL_E_UNKNOWN,unknown
+CONST_EVAL_E_UNKNOWN_NAME,unknown name
+CONST_EVAL_E_UNSUPPORTED_EXPR,unsupported expr
+CONST_E_ABI_MISMATCH,abi mismatch
+CONST_E_AMBIGUOUS_NAME,ambiguous name
+CONST_E_ARGUMENT_MISMATCH,argument mismatch
+CONST_E_ARITY_MISMATCH,arity mismatch
+CONST_E_ASSIGNMENT_MISMATCH,assignment mismatch
+CONST_E_BORROW_CONFLICT,borrow conflict
+CONST_E_BRANCH_MISMATCH,branch mismatch
+CONST_E_CONST_CYCLE,const cycle
+CONST_E_CONST_DIVISION_BY_ZERO,const division by zero
+CONST_E_CONST_OVERFLOW,const overflow
+CONST_E_CONST_REQUIRED,const required
+CONST_E_DANGLING_REFERENCE,dangling reference
+CONST_E_DOUBLE_DROP,double drop
+CONST_E_DUPLICATE_NAME,duplicate name
+CONST_E_EXPECTED_BLOCK,expected block
+CONST_E_EXPECTED_DELIMITER,expected delimiter
+CONST_E_EXPECTED_EXPRESSION,expected expression
+CONST_E_EXPECTED_IDENTIFIER,expected identifier
+CONST_E_EXPECTED_PATTERN,expected pattern
+CONST_E_EXPECTED_TYPE,expected type
+CONST_E_EXPORT_CONFLICT,export conflict
+CONST_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+CONST_E_GENERIC_BOUND_FAILED,generic bound failed
+CONST_E_IMPORT_CYCLE,import cycle
+CONST_E_IMPORT_NOT_FOUND,import not found
+CONST_E_INVALID_ATTRIBUTE,invalid attribute
+CONST_E_INVALID_BORROW,invalid borrow
+CONST_E_INVALID_CALL,invalid call
+CONST_E_INVALID_CAST,invalid cast
+CONST_E_INVALID_DECLARATION,invalid declaration
+CONST_E_INVALID_DEREF,invalid deref
+CONST_E_INVALID_EXPRESSION,invalid expression
+CONST_E_INVALID_INDEX,invalid index
+CONST_E_INVALID_LITERAL,invalid literal
+CONST_E_INVALID_MODIFIER,invalid modifier
+CONST_E_INVALID_MOVE,invalid move
+CONST_E_INVALID_OPERATOR,invalid operator
+CONST_E_INVALID_PATTERN,invalid pattern
+CONST_E_INVALID_STATEMENT,invalid statement
+CONST_E_LIFETIME_TOO_SHORT,lifetime too short
+CONST_E_LINK_FAILED,link failed
+CONST_E_MACRO_EXPANSION_FAILED,macro expansion failed
+CONST_E_MACRO_NOT_FOUND,macro not found
+CONST_E_MACRO_RECURSION,macro recursion
+CONST_E_MISSING_BODY,missing body
+CONST_E_MISSING_RETURN,missing return
+CONST_E_MUTABILITY_CONFLICT,mutability conflict
+CONST_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+CONST_E_PRIVATE_SYMBOL,private symbol
+CONST_E_RUNTIME_PANIC,runtime panic
+CONST_E_TRAIT_AMBIGUOUS,trait ambiguous
+CONST_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+CONST_E_UNBALANCED_DELIMITER,unbalanced delimiter
+CONST_E_UNEXPECTED_TOKEN,unexpected token
+CONST_E_UNKNOWN_MEMBER,unknown member
+CONST_E_UNKNOWN_MODULE,unknown module
+CONST_E_UNKNOWN_NAME,unknown name
+CONST_E_UNKNOWN_TYPE,unknown type
+CONST_E_UNREACHABLE_PATTERN,unreachable pattern
+CONST_E_UNSUPPORTED_TARGET,unsupported target
+CONST_E_USE_AFTER_DROP,use after drop
+CONST_E_USE_AFTER_MOVE,use after move
+CONST_E_USE_BEFORE_INIT,use before init
+DRIVER_E_ABI_MISMATCH,abi mismatch
+DRIVER_E_AMBIGUOUS_NAME,ambiguous name
+DRIVER_E_ARGUMENT_MISMATCH,argument mismatch
+DRIVER_E_ARITY_MISMATCH,arity mismatch
+DRIVER_E_ASSIGNMENT_MISMATCH,assignment mismatch
+DRIVER_E_BORROW_CONFLICT,borrow conflict
+DRIVER_E_BRANCH_MISMATCH,branch mismatch
+DRIVER_E_CACHE_READ_FAILED,cache read failed
+DRIVER_E_CACHE_WRITE_FAILED,cache write failed
+DRIVER_E_CONST_CYCLE,const cycle
+DRIVER_E_CONST_DIVISION_BY_ZERO,const division by zero
+DRIVER_E_CONST_OVERFLOW,const overflow
+DRIVER_E_CONST_REQUIRED,const required
+DRIVER_E_DANGLING_REFERENCE,dangling reference
+DRIVER_E_DOUBLE_DROP,double drop
+DRIVER_E_DUPLICATE_NAME,duplicate name
+DRIVER_E_EXPECTED_BLOCK,expected block
+DRIVER_E_EXPECTED_DELIMITER,expected delimiter
+DRIVER_E_EXPECTED_EXPRESSION,expected expression
+DRIVER_E_EXPECTED_IDENTIFIER,expected identifier
+DRIVER_E_EXPECTED_PATTERN,expected pattern
+DRIVER_E_EXPECTED_TYPE,expected type
+DRIVER_E_EXPORT_CONFLICT,export conflict
+DRIVER_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+DRIVER_E_GENERIC_BOUND_FAILED,generic bound failed
+DRIVER_E_IMPORT_CYCLE,import cycle
+DRIVER_E_IMPORT_NOT_FOUND,import not found
+DRIVER_E_INPUT_NOT_FOUND,input not found
+DRIVER_E_INVALID_ARGUMENT,invalid argument
+DRIVER_E_INVALID_ATTRIBUTE,invalid attribute
+DRIVER_E_INVALID_BORROW,invalid borrow
+DRIVER_E_INVALID_CALL,invalid call
+DRIVER_E_INVALID_CAST,invalid cast
+DRIVER_E_INVALID_DECLARATION,invalid declaration
+DRIVER_E_INVALID_DEREF,invalid deref
+DRIVER_E_INVALID_EXPRESSION,invalid expression
+DRIVER_E_INVALID_INDEX,invalid index
+DRIVER_E_INVALID_LITERAL,invalid literal
+DRIVER_E_INVALID_MODIFIER,invalid modifier
+DRIVER_E_INVALID_MOVE,invalid move
+DRIVER_E_INVALID_OPERATOR,invalid operator
+DRIVER_E_INVALID_PATTERN,invalid pattern
+DRIVER_E_INVALID_STATEMENT,invalid statement
+DRIVER_E_LIFETIME_TOO_SHORT,lifetime too short
+DRIVER_E_LINK_FAILED,link failed
+DRIVER_E_MACRO_EXPANSION_FAILED,macro expansion failed
+DRIVER_E_MACRO_NOT_FOUND,macro not found
+DRIVER_E_MACRO_RECURSION,macro recursion
+DRIVER_E_MISSING_BODY,missing body
+DRIVER_E_MISSING_INPUT,missing input
+DRIVER_E_MISSING_RETURN,missing return
+DRIVER_E_MUTABILITY_CONFLICT,mutability conflict
+DRIVER_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+DRIVER_E_OUTPUT_WRITE_FAILED,output write failed
+DRIVER_E_PRIVATE_SYMBOL,private symbol
+DRIVER_E_PROFILE_NOT_FOUND,profile not found
+DRIVER_E_RUNTIME_PANIC,runtime panic
+DRIVER_E_TARGET_NOT_FOUND,target not found
+DRIVER_E_TRAIT_AMBIGUOUS,trait ambiguous
+DRIVER_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+DRIVER_E_UNBALANCED_DELIMITER,unbalanced delimiter
+DRIVER_E_UNEXPECTED_TOKEN,unexpected token
+DRIVER_E_UNKNOWN_MEMBER,unknown member
+DRIVER_E_UNKNOWN_MODULE,unknown module
+DRIVER_E_UNKNOWN_NAME,unknown name
+DRIVER_E_UNKNOWN_TYPE,unknown type
+DRIVER_E_UNREACHABLE_PATTERN,unreachable pattern
+DRIVER_E_UNSUPPORTED_TARGET,unsupported target
+DRIVER_E_USE_AFTER_DROP,use after drop
+DRIVER_E_USE_AFTER_MOVE,use after move
+DRIVER_E_USE_BEFORE_INIT,use before init
+E0001,expected identifier
+E0002,expected expression
+E0003,expected pattern
+E0004,expected type
+E0005,expected 'end'
+E0006,expected proc after attribute
+E0007,expected top-level declaration
+E0008,extern proc cannot have a body
+E0009,proc requires a body unless marked #[extern]
+E0010,type alias requires a target type
+E0011,select requires at least one when branch
+E0012,select branch must be a when statement
+E0013,proc may exit without returning a value
+E0014,forbidden top-level syntax in strict-core mode
+E0015,forbidden statement syntax in strict-core mode
+E0016,forbidden expression syntax in strict-core mode
+E0017,expected '}'
+E0018,expected 'case' or 'otherwise' in match
+E1001,duplicate pattern binding
+E1002,unknown type (did you mean a built-in like int/i32/i64/i128/u32/u64/u128/bool/string?)
+E1003,unknown generic base type
+E1004,generic type requires at least one argument
+E1005,unknown identifier
+E1006,generic type requires at least one type argument
+E1007,invalid cast between signed and unsigned values
+E1010,stdlib module denied by active stdlib profile
+E1011,strict-imports requires explicit alias
+E1012,strict-imports forbids unused import aliases
+E1013,strict-imports forbids non-canonical import paths
+E1014,stdlib module not found
+E1015,experimental module import denied
+E1016,internal module import denied
+E1017,re-export symbol conflict
+E1018,ambiguous import path
+E1019,strict-modules forbids glob imports
+E1020,legacy import path is deprecated
+E1021,entry module path must be canonical
+E1022,duplicate entry name
+E1023,share references unknown symbol
+E1024,duplicate symbol in share list
+E1025,symbol not exported by module
+E1026,duplicate share declaration
+E1027,duplicate import binding
+E1028,import binding conflicts with local declaration
+E1029,duplicate local declaration name
+E1030,module alias member not exported
+E1031,qualified type member not found
+E1032,expression is not callable
+E2001,unsupported type
+E2002,invoke has no callee
+E2003,unsupported expression in HIR
+E2004,unsupported pattern in HIR
+E2005,unsupported statement in HIR
+E2006,unexpected HIR type kind
+E2007,unexpected HIR expr kind
+E2008,unexpected HIR stmt kind
+E2009,unexpected HIR pattern kind
+E2010,unexpected HIR decl kind
+E_BOOTSTRAP_BANNER,missing banner_text()
+E_BOOTSTRAP_CONST_SIGNATURE,"expected const NAME: string = ""..."" or const NAME: int = 123"
+E_BOOTSTRAP_DUP_PROC_PREFIX,duplicate proc
+E_BOOTSTRAP_EXPECTED_INT_CONST,expected int constant
+E_BOOTSTRAP_EXPECTED_STRING_CONST,expected string constant
+E_BOOTSTRAP_EXPORT,expected export *
+E_BOOTSTRAP_FULL_COMPILER_BRIDGE_DISABLED,full compiler bootstrap bridge disabled for this build
+E_BOOTSTRAP_MAIN_BODY,expected main to give int
+E_BOOTSTRAP_MAIN_SIGNATURE,expected proc main(args: list[string]) -> int {
+E_BOOTSTRAP_NATIVE_SUBSET,native build is limited in this bootstrap binary
+E_BOOTSTRAP_NATIVE_SUBSET.hint,only bootstrap-native sources are supported: proc main() -> int { give <integer>; } or the full compiler entry src/vitte/compiler/main.vit; set VITTE_BOOTSTRAP_ALLOW_FULL_COMPILER_BRIDGE=1 for compiler repository test sources under src/vitte/compiler/tests
+E_BOOTSTRAP_PROC_BODY,unsupported statement in bootstrap proc
+E_BOOTSTRAP_PROC_BODY_GIVE,expected exactly one supported give
+E_BOOTSTRAP_PROC_BODY_INT,expected int literal or int constant give
+E_BOOTSTRAP_PROC_BODY_STRING,expected string literal or string constant give
+E_BOOTSTRAP_PROC_SIGNATURE,expected proc name() -> string { or proc main(args: list[string]) -> int {
+E_BOOTSTRAP_PROC_SIGNATURE_PARAMS,bootstrap string proc must have no parameters: proc name() -> string {
+E_BOOTSTRAP_PROC_SIGNATURE_RETURN,bootstrap string proc must return string: proc name() -> string {
+E_BOOTSTRAP_SPACE,missing space declaration
+E_BOOTSTRAP_TOP_LEVEL,unsupported top-level item
+E_BOOTSTRAP_UNCLOSED_PROC,missing closing brace
+E_BOOTSTRAP_UNKNOWN_INT_CONST,unknown int constant
+E_BOOTSTRAP_UNKNOWN_PROC_PREFIX,unsupported bootstrap proc
+E_BOOTSTRAP_UNKNOWN_STRING_CONST,unknown string constant
+E_BOOTSTRAP_VERSION,missing version_text()
+FAST0001,fast0001
+FLEX0001,flex0001
+GENERIC_E_ABI_MISMATCH,abi mismatch
+GENERIC_E_AMBIGUOUS_NAME,ambiguous name
+GENERIC_E_ARGUMENT_MISMATCH,argument mismatch
+GENERIC_E_ARITY_MISMATCH,arity mismatch
+GENERIC_E_ASSIGNMENT_MISMATCH,assignment mismatch
+GENERIC_E_BORROW_CONFLICT,borrow conflict
+GENERIC_E_BRANCH_MISMATCH,branch mismatch
+GENERIC_E_CONST_CYCLE,const cycle
+GENERIC_E_CONST_DIVISION_BY_ZERO,const division by zero
+GENERIC_E_CONST_OVERFLOW,const overflow
+GENERIC_E_CONST_REQUIRED,const required
+GENERIC_E_DANGLING_REFERENCE,dangling reference
+GENERIC_E_DOUBLE_DROP,double drop
+GENERIC_E_DUPLICATE_NAME,duplicate name
+GENERIC_E_EXPECTED_BLOCK,expected block
+GENERIC_E_EXPECTED_DELIMITER,expected delimiter
+GENERIC_E_EXPECTED_EXPRESSION,expected expression
+GENERIC_E_EXPECTED_IDENTIFIER,expected identifier
+GENERIC_E_EXPECTED_PATTERN,expected pattern
+GENERIC_E_EXPECTED_TYPE,expected type
+GENERIC_E_EXPORT_CONFLICT,export conflict
+GENERIC_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+GENERIC_E_GENERIC_BOUND_FAILED,generic bound failed
+GENERIC_E_IMPORT_CYCLE,import cycle
+GENERIC_E_IMPORT_NOT_FOUND,import not found
+GENERIC_E_INVALID_ATTRIBUTE,invalid attribute
+GENERIC_E_INVALID_BORROW,invalid borrow
+GENERIC_E_INVALID_CALL,invalid call
+GENERIC_E_INVALID_CAST,invalid cast
+GENERIC_E_INVALID_DECLARATION,invalid declaration
+GENERIC_E_INVALID_DEREF,invalid deref
+GENERIC_E_INVALID_EXPRESSION,invalid expression
+GENERIC_E_INVALID_INDEX,invalid index
+GENERIC_E_INVALID_LITERAL,invalid literal
+GENERIC_E_INVALID_MODIFIER,invalid modifier
+GENERIC_E_INVALID_MOVE,invalid move
+GENERIC_E_INVALID_OPERATOR,invalid operator
+GENERIC_E_INVALID_PATTERN,invalid pattern
+GENERIC_E_INVALID_STATEMENT,invalid statement
+GENERIC_E_LIFETIME_TOO_SHORT,lifetime too short
+GENERIC_E_LINK_FAILED,link failed
+GENERIC_E_MACRO_EXPANSION_FAILED,macro expansion failed
+GENERIC_E_MACRO_NOT_FOUND,macro not found
+GENERIC_E_MACRO_RECURSION,macro recursion
+GENERIC_E_MISSING_BODY,missing body
+GENERIC_E_MISSING_RETURN,missing return
+GENERIC_E_MUTABILITY_CONFLICT,mutability conflict
+GENERIC_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+GENERIC_E_PRIVATE_SYMBOL,private symbol
+GENERIC_E_RUNTIME_PANIC,runtime panic
+GENERIC_E_TRAIT_AMBIGUOUS,trait ambiguous
+GENERIC_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+GENERIC_E_UNBALANCED_DELIMITER,unbalanced delimiter
+GENERIC_E_UNEXPECTED_TOKEN,unexpected token
+GENERIC_E_UNKNOWN_MEMBER,unknown member
+GENERIC_E_UNKNOWN_MODULE,unknown module
+GENERIC_E_UNKNOWN_NAME,unknown name
+GENERIC_E_UNKNOWN_TYPE,unknown type
+GENERIC_E_UNREACHABLE_PATTERN,unreachable pattern
+GENERIC_E_UNSUPPORTED_TARGET,unsupported target
+GENERIC_E_USE_AFTER_DROP,use after drop
+GENERIC_E_USE_AFTER_MOVE,use after move
+GENERIC_E_USE_BEFORE_INIT,use before init
+HIR_E_ABI_MISMATCH,abi mismatch
+HIR_E_AMBIGUOUS_NAME,ambiguous name
+HIR_E_ARGUMENT_MISMATCH,argument mismatch
+HIR_E_ARITY_MISMATCH,arity mismatch
+HIR_E_ASSIGNMENT_MISMATCH,assignment mismatch
+HIR_E_BORROW_CONFLICT,borrow conflict
+HIR_E_BRANCH_MISMATCH,branch mismatch
+HIR_E_CONST_CYCLE,const cycle
+HIR_E_CONST_DIVISION_BY_ZERO,const division by zero
+HIR_E_CONST_OVERFLOW,const overflow
+HIR_E_CONST_REQUIRED,const required
+HIR_E_DANGLING_REFERENCE,dangling reference
+HIR_E_DOUBLE_DROP,double drop
+HIR_E_DUPLICATE_NAME,duplicate name
+HIR_E_EXPECTED_BLOCK,expected block
+HIR_E_EXPECTED_DELIMITER,expected delimiter
+HIR_E_EXPECTED_EXPRESSION,expected expression
+HIR_E_EXPECTED_IDENTIFIER,expected identifier
+HIR_E_EXPECTED_PATTERN,expected pattern
+HIR_E_EXPECTED_TYPE,expected type
+HIR_E_EXPORT_CONFLICT,export conflict
+HIR_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+HIR_E_GENERIC_BOUND_FAILED,generic bound failed
+HIR_E_IMPORT_CYCLE,import cycle
+HIR_E_IMPORT_NOT_FOUND,import not found
+HIR_E_INVALID_ATTRIBUTE,invalid attribute
+HIR_E_INVALID_BORROW,invalid borrow
+HIR_E_INVALID_CALL,invalid call
+HIR_E_INVALID_CAST,invalid cast
+HIR_E_INVALID_CONTROL_FLOW,invalid control flow
+HIR_E_INVALID_DECLARATION,invalid declaration
+HIR_E_INVALID_DEREF,invalid deref
+HIR_E_INVALID_EXPR,invalid expr
+HIR_E_INVALID_EXPRESSION,invalid expression
+HIR_E_INVALID_INDEX,invalid index
+HIR_E_INVALID_LITERAL,invalid literal
+HIR_E_INVALID_MODIFIER,invalid modifier
+HIR_E_INVALID_MOVE,invalid move
+HIR_E_INVALID_OPERATOR,invalid operator
+HIR_E_INVALID_PATTERN,invalid pattern
+HIR_E_INVALID_STATEMENT,invalid statement
+HIR_E_INVALID_STMT,invalid stmt
+HIR_E_INVALID_TYPE,invalid type
+HIR_E_LIFETIME_TOO_SHORT,lifetime too short
+HIR_E_LINK_FAILED,link failed
+HIR_E_LOWERING_FAILED,lowering failed
+HIR_E_MACRO_EXPANSION_FAILED,macro expansion failed
+HIR_E_MACRO_NOT_FOUND,macro not found
+HIR_E_MACRO_RECURSION,macro recursion
+HIR_E_MISSING_BODY,missing body
+HIR_E_MISSING_RETURN,missing return
+HIR_E_MISSING_SYMBOL,missing symbol
+HIR_E_MUTABILITY_CONFLICT,mutability conflict
+HIR_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+HIR_E_PRIVATE_SYMBOL,private symbol
+HIR_E_RUNTIME_PANIC,runtime panic
+HIR_E_TRAIT_AMBIGUOUS,trait ambiguous
+HIR_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+HIR_E_UNBALANCED_DELIMITER,unbalanced delimiter
+HIR_E_UNEXPECTED_TOKEN,unexpected token
+HIR_E_UNKNOWN_MEMBER,unknown member
+HIR_E_UNKNOWN_MODULE,unknown module
+HIR_E_UNKNOWN_NAME,unknown name
+HIR_E_UNKNOWN_TYPE,unknown type
+HIR_E_UNREACHABLE_PATTERN,unreachable pattern
+HIR_E_UNSUPPORTED_TARGET,unsupported target
+HIR_E_USE_AFTER_DROP,use after drop
+HIR_E_USE_AFTER_MOVE,use after move
+HIR_E_USE_BEFORE_INIT,use before init
+IR_E_ABI_MISMATCH,abi mismatch
+IR_E_AMBIGUOUS_NAME,ambiguous name
+IR_E_ARGUMENT_MISMATCH,argument mismatch
+IR_E_ARITY_MISMATCH,arity mismatch
+IR_E_ASSIGNMENT_MISMATCH,assignment mismatch
+IR_E_BORROW_CONFLICT,borrow conflict
+IR_E_BRANCH_MISMATCH,branch mismatch
+IR_E_CONST_CYCLE,const cycle
+IR_E_CONST_DIVISION_BY_ZERO,const division by zero
+IR_E_CONST_OVERFLOW,const overflow
+IR_E_CONST_REQUIRED,const required
+IR_E_DANGLING_REFERENCE,dangling reference
+IR_E_DOUBLE_DROP,double drop
+IR_E_DUPLICATE_NAME,duplicate name
+IR_E_EXPECTED_BLOCK,expected block
+IR_E_EXPECTED_DELIMITER,expected delimiter
+IR_E_EXPECTED_EXPRESSION,expected expression
+IR_E_EXPECTED_IDENTIFIER,expected identifier
+IR_E_EXPECTED_PATTERN,expected pattern
+IR_E_EXPECTED_TYPE,expected type
+IR_E_EXPORT_CONFLICT,export conflict
+IR_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+IR_E_GENERIC_BOUND_FAILED,generic bound failed
+IR_E_IMPORT_CYCLE,import cycle
+IR_E_IMPORT_NOT_FOUND,import not found
+IR_E_INVALID_ATTRIBUTE,invalid attribute
+IR_E_INVALID_BLOCK,invalid block
+IR_E_INVALID_BORROW,invalid borrow
+IR_E_INVALID_CALL,invalid call
+IR_E_INVALID_CAST,invalid cast
+IR_E_INVALID_DECLARATION,invalid declaration
+IR_E_INVALID_DEREF,invalid deref
+IR_E_INVALID_EXPRESSION,invalid expression
+IR_E_INVALID_FUNCTION,invalid function
+IR_E_INVALID_INDEX,invalid index
+IR_E_INVALID_INSTRUCTION,invalid instruction
+IR_E_INVALID_LITERAL,invalid literal
+IR_E_INVALID_MODIFIER,invalid modifier
+IR_E_INVALID_MODULE,invalid module
+IR_E_INVALID_MOVE,invalid move
+IR_E_INVALID_OPERATOR,invalid operator
+IR_E_INVALID_PATTERN,invalid pattern
+IR_E_INVALID_STATEMENT,invalid statement
+IR_E_LIFETIME_TOO_SHORT,lifetime too short
+IR_E_LINK_FAILED,link failed
+IR_E_MACRO_EXPANSION_FAILED,macro expansion failed
+IR_E_MACRO_NOT_FOUND,macro not found
+IR_E_MACRO_RECURSION,macro recursion
+IR_E_MISSING_BODY,missing body
+IR_E_MISSING_RETURN,missing return
+IR_E_MUTABILITY_CONFLICT,mutability conflict
+IR_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+IR_E_PRIVATE_SYMBOL,private symbol
+IR_E_RUNTIME_PANIC,runtime panic
+IR_E_TRAIT_AMBIGUOUS,trait ambiguous
+IR_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+IR_E_TYPE_MISMATCH,type mismatch
+IR_E_UNBALANCED_DELIMITER,unbalanced delimiter
+IR_E_UNEXPECTED_TOKEN,unexpected token
+IR_E_UNKNOWN_MEMBER,unknown member
+IR_E_UNKNOWN_MODULE,unknown module
+IR_E_UNKNOWN_NAME,unknown name
+IR_E_UNKNOWN_TYPE,unknown type
+IR_E_UNREACHABLE_PATTERN,unreachable pattern
+IR_E_UNSUPPORTED_TARGET,unsupported target
+IR_E_USE_AFTER_DROP,use after drop
+IR_E_USE_AFTER_MOVE,use after move
+IR_E_USE_BEFORE_INIT,use before init
+IR_E_VERIFY_FAILED,verify failed
+LEX_E_INVALID_BINARY,invalid binary
+LEX_E_INVALID_CHAR,invalid character
+LEX_E_INVALID_CHAR_LITERAL,invalid char literal
+LEX_E_INVALID_ESCAPE,invalid escape sequence
+LEX_E_INVALID_FLOAT,invalid float
+LEX_E_INVALID_HEX,invalid hex
+LEX_E_INVALID_IDENTIFIER,invalid identifier
+LEX_E_INVALID_INDENTATION,invalid indentation
+LEX_E_INVALID_NUMBER,invalid numeric literal
+LEX_E_INVALID_OCTAL,invalid octal
+LEX_E_INVALID_TOKEN,invalid token
+LEX_E_INVALID_UNICODE_ESCAPE,invalid unicode escape sequence
+LEX_E_INVALID_UTF8,invalid UTF-8 byte sequence
+LEX_E_TOKEN_TOO_LARGE,token too large
+LEX_E_UNEXPECTED_EOF,unexpected end of file
+LEX_E_UNTERMINATED_BLOCK_COMMENT,unterminated block comment
+LEX_E_UNTERMINATED_CHAR,unterminated char literal
+LEX_E_UNTERMINATED_REGION_COMMENT,unterminated region comment
+LEX_E_UNTERMINATED_STRING,unterminated string literal
+LIFETIME_E_ABI_MISMATCH,abi mismatch
+LIFETIME_E_AMBIGUOUS_NAME,ambiguous name
+LIFETIME_E_ARGUMENT_MISMATCH,argument mismatch
+LIFETIME_E_ARITY_MISMATCH,arity mismatch
+LIFETIME_E_ASSIGNMENT_MISMATCH,assignment mismatch
+LIFETIME_E_BORROW_CONFLICT,borrow conflict
+LIFETIME_E_BRANCH_MISMATCH,branch mismatch
+LIFETIME_E_CONST_CYCLE,const cycle
+LIFETIME_E_CONST_DIVISION_BY_ZERO,const division by zero
+LIFETIME_E_CONST_OVERFLOW,const overflow
+LIFETIME_E_CONST_REQUIRED,const required
+LIFETIME_E_DANGLING_REFERENCE,dangling reference
+LIFETIME_E_DOUBLE_DROP,double drop
+LIFETIME_E_DUPLICATE_NAME,duplicate name
+LIFETIME_E_EXPECTED_BLOCK,expected block
+LIFETIME_E_EXPECTED_DELIMITER,expected delimiter
+LIFETIME_E_EXPECTED_EXPRESSION,expected expression
+LIFETIME_E_EXPECTED_IDENTIFIER,expected identifier
+LIFETIME_E_EXPECTED_PATTERN,expected pattern
+LIFETIME_E_EXPECTED_TYPE,expected type
+LIFETIME_E_EXPORT_CONFLICT,export conflict
+LIFETIME_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+LIFETIME_E_GENERIC_BOUND_FAILED,generic bound failed
+LIFETIME_E_IMPORT_CYCLE,import cycle
+LIFETIME_E_IMPORT_NOT_FOUND,import not found
+LIFETIME_E_INVALID_ATTRIBUTE,invalid attribute
+LIFETIME_E_INVALID_BORROW,invalid borrow
+LIFETIME_E_INVALID_CALL,invalid call
+LIFETIME_E_INVALID_CAST,invalid cast
+LIFETIME_E_INVALID_DECLARATION,invalid declaration
+LIFETIME_E_INVALID_DEREF,invalid deref
+LIFETIME_E_INVALID_EXPRESSION,invalid expression
+LIFETIME_E_INVALID_INDEX,invalid index
+LIFETIME_E_INVALID_LITERAL,invalid literal
+LIFETIME_E_INVALID_MODIFIER,invalid modifier
+LIFETIME_E_INVALID_MOVE,invalid move
+LIFETIME_E_INVALID_OPERATOR,invalid operator
+LIFETIME_E_INVALID_PATTERN,invalid pattern
+LIFETIME_E_INVALID_STATEMENT,invalid statement
+LIFETIME_E_LIFETIME_TOO_SHORT,lifetime too short
+LIFETIME_E_LINK_FAILED,link failed
+LIFETIME_E_MACRO_EXPANSION_FAILED,macro expansion failed
+LIFETIME_E_MACRO_NOT_FOUND,macro not found
+LIFETIME_E_MACRO_RECURSION,macro recursion
+LIFETIME_E_MISSING_BODY,missing body
+LIFETIME_E_MISSING_RETURN,missing return
+LIFETIME_E_MUTABILITY_CONFLICT,mutability conflict
+LIFETIME_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+LIFETIME_E_PRIVATE_SYMBOL,private symbol
+LIFETIME_E_RUNTIME_PANIC,runtime panic
+LIFETIME_E_TRAIT_AMBIGUOUS,trait ambiguous
+LIFETIME_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+LIFETIME_E_UNBALANCED_DELIMITER,unbalanced delimiter
+LIFETIME_E_UNEXPECTED_TOKEN,unexpected token
+LIFETIME_E_UNKNOWN_MEMBER,unknown member
+LIFETIME_E_UNKNOWN_MODULE,unknown module
+LIFETIME_E_UNKNOWN_NAME,unknown name
+LIFETIME_E_UNKNOWN_TYPE,unknown type
+LIFETIME_E_UNREACHABLE_PATTERN,unreachable pattern
+LIFETIME_E_UNSUPPORTED_TARGET,unsupported target
+LIFETIME_E_USE_AFTER_DROP,use after drop
+LIFETIME_E_USE_AFTER_MOVE,use after move
+LIFETIME_E_USE_BEFORE_INIT,use before init
+LIMIT_AST_DEPTH_MAX,ast depth max
+LIMIT_DIAGNOSTICS_MAX,too many diagnostics emitted
+LIMIT_EXPR_DEPTH_MAX,expr depth max
+LIMIT_E_ABI_MISMATCH,abi mismatch
+LIMIT_E_AMBIGUOUS_NAME,ambiguous name
+LIMIT_E_ARGUMENT_MISMATCH,argument mismatch
+LIMIT_E_ARITY_MISMATCH,arity mismatch
+LIMIT_E_ASSIGNMENT_MISMATCH,assignment mismatch
+LIMIT_E_BORROW_CONFLICT,borrow conflict
+LIMIT_E_BRANCH_MISMATCH,branch mismatch
+LIMIT_E_CONST_CYCLE,const cycle
+LIMIT_E_CONST_DIVISION_BY_ZERO,const division by zero
+LIMIT_E_CONST_OVERFLOW,const overflow
+LIMIT_E_CONST_REQUIRED,const required
+LIMIT_E_DANGLING_REFERENCE,dangling reference
+LIMIT_E_DOUBLE_DROP,double drop
+LIMIT_E_DUPLICATE_NAME,duplicate name
+LIMIT_E_EXPECTED_BLOCK,expected block
+LIMIT_E_EXPECTED_DELIMITER,expected delimiter
+LIMIT_E_EXPECTED_EXPRESSION,expected expression
+LIMIT_E_EXPECTED_IDENTIFIER,expected identifier
+LIMIT_E_EXPECTED_PATTERN,expected pattern
+LIMIT_E_EXPECTED_TYPE,expected type
+LIMIT_E_EXPORT_CONFLICT,export conflict
+LIMIT_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+LIMIT_E_GENERIC_BOUND_FAILED,generic bound failed
+LIMIT_E_IMPORT_CYCLE,import cycle
+LIMIT_E_IMPORT_NOT_FOUND,import not found
+LIMIT_E_INVALID_ATTRIBUTE,invalid attribute
+LIMIT_E_INVALID_BORROW,invalid borrow
+LIMIT_E_INVALID_CALL,invalid call
+LIMIT_E_INVALID_CAST,invalid cast
+LIMIT_E_INVALID_DECLARATION,invalid declaration
+LIMIT_E_INVALID_DEREF,invalid deref
+LIMIT_E_INVALID_EXPRESSION,invalid expression
+LIMIT_E_INVALID_INDEX,invalid index
+LIMIT_E_INVALID_LITERAL,invalid literal
+LIMIT_E_INVALID_MODIFIER,invalid modifier
+LIMIT_E_INVALID_MOVE,invalid move
+LIMIT_E_INVALID_OPERATOR,invalid operator
+LIMIT_E_INVALID_PATTERN,invalid pattern
+LIMIT_E_INVALID_STATEMENT,invalid statement
+LIMIT_E_LIFETIME_TOO_SHORT,lifetime too short
+LIMIT_E_LINK_FAILED,link failed
+LIMIT_E_MACRO_EXPANSION_FAILED,macro expansion failed
+LIMIT_E_MACRO_NOT_FOUND,macro not found
+LIMIT_E_MACRO_RECURSION,macro recursion
+LIMIT_E_MISSING_BODY,missing body
+LIMIT_E_MISSING_RETURN,missing return
+LIMIT_E_MUTABILITY_CONFLICT,mutability conflict
+LIMIT_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+LIMIT_E_PRIVATE_SYMBOL,private symbol
+LIMIT_E_RUNTIME_PANIC,runtime panic
+LIMIT_E_TRAIT_AMBIGUOUS,trait ambiguous
+LIMIT_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+LIMIT_E_UNBALANCED_DELIMITER,unbalanced delimiter
+LIMIT_E_UNEXPECTED_TOKEN,unexpected token
+LIMIT_E_UNKNOWN_MEMBER,unknown member
+LIMIT_E_UNKNOWN_MODULE,unknown module
+LIMIT_E_UNKNOWN_NAME,unknown name
+LIMIT_E_UNKNOWN_TYPE,unknown type
+LIMIT_E_UNREACHABLE_PATTERN,unreachable pattern
+LIMIT_E_UNSUPPORTED_TARGET,unsupported target
+LIMIT_E_USE_AFTER_DROP,use after drop
+LIMIT_E_USE_AFTER_MOVE,use after move
+LIMIT_E_USE_BEFORE_INIT,use before init
+LIMIT_FILE_SIZE_MAX,file size max
+LIMIT_IMPORT_DEPTH_MAX,import depth max
+LIMIT_MACRO_EXPANSION_MAX,macro expansion max
+LIMIT_MODULE_COUNT_MAX,module count max
+LIMIT_PARSER_RECURSION_MAX,parser recursion max
+LIMIT_SYMBOL_COUNT_MAX,symbol count max
+LIMIT_TOKEN_SIZE_MAX,token size max
+LINK_E_ABI_MISMATCH,abi mismatch
+LINK_E_AMBIGUOUS_NAME,ambiguous name
+LINK_E_ARGUMENT_MISMATCH,argument mismatch
+LINK_E_ARITY_MISMATCH,arity mismatch
+LINK_E_ASSIGNMENT_MISMATCH,assignment mismatch
+LINK_E_BORROW_CONFLICT,borrow conflict
+LINK_E_BRANCH_MISMATCH,branch mismatch
+LINK_E_CONST_CYCLE,const cycle
+LINK_E_CONST_DIVISION_BY_ZERO,const division by zero
+LINK_E_CONST_OVERFLOW,const overflow
+LINK_E_CONST_REQUIRED,const required
+LINK_E_DANGLING_REFERENCE,dangling reference
+LINK_E_DOUBLE_DROP,double drop
+LINK_E_DUPLICATE_NAME,duplicate name
+LINK_E_DUPLICATE_SYMBOL,duplicate symbol
+LINK_E_EXPECTED_BLOCK,expected block
+LINK_E_EXPECTED_DELIMITER,expected delimiter
+LINK_E_EXPECTED_EXPRESSION,expected expression
+LINK_E_EXPECTED_IDENTIFIER,expected identifier
+LINK_E_EXPECTED_PATTERN,expected pattern
+LINK_E_EXPECTED_TYPE,expected type
+LINK_E_EXPORT_CONFLICT,export conflict
+LINK_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+LINK_E_GENERIC_BOUND_FAILED,generic bound failed
+LINK_E_IMPORT_CYCLE,import cycle
+LINK_E_IMPORT_NOT_FOUND,import not found
+LINK_E_INVALID_ATTRIBUTE,invalid attribute
+LINK_E_INVALID_BORROW,invalid borrow
+LINK_E_INVALID_CALL,invalid call
+LINK_E_INVALID_CAST,invalid cast
+LINK_E_INVALID_DECLARATION,invalid declaration
+LINK_E_INVALID_DEREF,invalid deref
+LINK_E_INVALID_EXPRESSION,invalid expression
+LINK_E_INVALID_INDEX,invalid index
+LINK_E_INVALID_LITERAL,invalid literal
+LINK_E_INVALID_MODIFIER,invalid modifier
+LINK_E_INVALID_MOVE,invalid move
+LINK_E_INVALID_OPERATOR,invalid operator
+LINK_E_INVALID_PATTERN,invalid pattern
+LINK_E_INVALID_STATEMENT,invalid statement
+LINK_E_LIBRARY_NOT_FOUND,library not found
+LINK_E_LIFETIME_TOO_SHORT,lifetime too short
+LINK_E_LINK_FAILED,link failed
+LINK_E_MACRO_EXPANSION_FAILED,macro expansion failed
+LINK_E_MACRO_NOT_FOUND,macro not found
+LINK_E_MACRO_RECURSION,macro recursion
+LINK_E_MISSING_BODY,missing body
+LINK_E_MISSING_RETURN,missing return
+LINK_E_MUTABILITY_CONFLICT,mutability conflict
+LINK_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+LINK_E_OBJECT_NOT_FOUND,object not found
+LINK_E_PRIVATE_SYMBOL,private symbol
+LINK_E_RUNTIME_PANIC,runtime panic
+LINK_E_SYSTEM_LINKER_FAILED,system linker failed
+LINK_E_TRAIT_AMBIGUOUS,trait ambiguous
+LINK_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+LINK_E_UNBALANCED_DELIMITER,unbalanced delimiter
+LINK_E_UNDEFINED_SYMBOL,undefined symbol
+LINK_E_UNEXPECTED_TOKEN,unexpected token
+LINK_E_UNKNOWN_MEMBER,unknown member
+LINK_E_UNKNOWN_MODULE,unknown module
+LINK_E_UNKNOWN_NAME,unknown name
+LINK_E_UNKNOWN_TYPE,unknown type
+LINK_E_UNREACHABLE_PATTERN,unreachable pattern
+LINK_E_UNSUPPORTED_FORMAT,unsupported format
+LINK_E_UNSUPPORTED_TARGET,unsupported target
+LINK_E_USE_AFTER_DROP,use after drop
+LINK_E_USE_AFTER_MOVE,use after move
+LINK_E_USE_BEFORE_INIT,use before init
+MACRO_E_ABI_MISMATCH,abi mismatch
+MACRO_E_AMBIGUOUS_NAME,ambiguous name
+MACRO_E_ARGUMENT_MISMATCH,argument mismatch
+MACRO_E_ARITY_MISMATCH,arity mismatch
+MACRO_E_ASSIGNMENT_MISMATCH,assignment mismatch
+MACRO_E_BORROW_CONFLICT,borrow conflict
+MACRO_E_BRANCH_MISMATCH,branch mismatch
+MACRO_E_CONST_CYCLE,const cycle
+MACRO_E_CONST_DIVISION_BY_ZERO,const division by zero
+MACRO_E_CONST_OVERFLOW,const overflow
+MACRO_E_CONST_REQUIRED,const required
+MACRO_E_DANGLING_REFERENCE,dangling reference
+MACRO_E_DOUBLE_DROP,double drop
+MACRO_E_DUPLICATE_NAME,duplicate name
+MACRO_E_EXPANSION_FAILED,expansion failed
+MACRO_E_EXPECTED_BLOCK,expected block
+MACRO_E_EXPECTED_DELIMITER,expected delimiter
+MACRO_E_EXPECTED_EXPRESSION,expected expression
+MACRO_E_EXPECTED_IDENTIFIER,expected identifier
+MACRO_E_EXPECTED_PATTERN,expected pattern
+MACRO_E_EXPECTED_TYPE,expected type
+MACRO_E_EXPORT_CONFLICT,export conflict
+MACRO_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+MACRO_E_GENERIC_BOUND_FAILED,generic bound failed
+MACRO_E_IMPORT_CYCLE,import cycle
+MACRO_E_IMPORT_NOT_FOUND,import not found
+MACRO_E_INVALID_ARGUMENT,invalid argument
+MACRO_E_INVALID_ATTRIBUTE,invalid attribute
+MACRO_E_INVALID_BORROW,invalid borrow
+MACRO_E_INVALID_CALL,invalid call
+MACRO_E_INVALID_CAST,invalid cast
+MACRO_E_INVALID_DECLARATION,invalid declaration
+MACRO_E_INVALID_DEREF,invalid deref
+MACRO_E_INVALID_EXPRESSION,invalid expression
+MACRO_E_INVALID_INDEX,invalid index
+MACRO_E_INVALID_LITERAL,invalid literal
+MACRO_E_INVALID_MODIFIER,invalid modifier
+MACRO_E_INVALID_MOVE,invalid move
+MACRO_E_INVALID_OPERATOR,invalid operator
+MACRO_E_INVALID_PATTERN,invalid pattern
+MACRO_E_INVALID_STATEMENT,invalid statement
+MACRO_E_LIFETIME_TOO_SHORT,lifetime too short
+MACRO_E_LINK_FAILED,link failed
+MACRO_E_MACRO_EXPANSION_FAILED,macro expansion failed
+MACRO_E_MACRO_NOT_FOUND,macro not found
+MACRO_E_MACRO_RECURSION,macro recursion
+MACRO_E_MISSING_BODY,missing body
+MACRO_E_MISSING_RETURN,missing return
+MACRO_E_MUTABILITY_CONFLICT,mutability conflict
+MACRO_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+MACRO_E_PRIVATE_SYMBOL,private symbol
+MACRO_E_RECURSION_LIMIT,recursion limit
+MACRO_E_RUNTIME_PANIC,runtime panic
+MACRO_E_TRAIT_AMBIGUOUS,trait ambiguous
+MACRO_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+MACRO_E_UNBALANCED_DELIMITER,unbalanced delimiter
+MACRO_E_UNEXPECTED_TOKEN,unexpected token
+MACRO_E_UNKNOWN_MACRO,unknown macro
+MACRO_E_UNKNOWN_MEMBER,unknown member
+MACRO_E_UNKNOWN_MODULE,unknown module
+MACRO_E_UNKNOWN_NAME,unknown name
+MACRO_E_UNKNOWN_TYPE,unknown type
+MACRO_E_UNREACHABLE_PATTERN,unreachable pattern
+MACRO_E_UNSTABLE_FEATURE,unstable feature
+MACRO_E_UNSUPPORTED_TARGET,unsupported target
+MACRO_E_USE_AFTER_DROP,use after drop
+MACRO_E_USE_AFTER_MOVE,use after move
+MACRO_E_USE_BEFORE_INIT,use before init
+MIR_E_ABI_MISMATCH,abi mismatch
+MIR_E_AMBIGUOUS_NAME,ambiguous name
+MIR_E_ARGUMENT_MISMATCH,argument mismatch
+MIR_E_ARITY_MISMATCH,arity mismatch
+MIR_E_ASSIGNMENT_MISMATCH,assignment mismatch
+MIR_E_BORROW_CONFLICT,borrow conflict
+MIR_E_BRANCH_MISMATCH,branch mismatch
+MIR_E_CONST_CYCLE,const cycle
+MIR_E_CONST_DIVISION_BY_ZERO,const division by zero
+MIR_E_CONST_OVERFLOW,const overflow
+MIR_E_CONST_REQUIRED,const required
+MIR_E_DANGLING_REFERENCE,dangling reference
+MIR_E_DATAFLOW_CONFLICT,dataflow conflict
+MIR_E_DOUBLE_DROP,double drop
+MIR_E_DUPLICATE_NAME,duplicate name
+MIR_E_EXPECTED_BLOCK,expected block
+MIR_E_EXPECTED_DELIMITER,expected delimiter
+MIR_E_EXPECTED_EXPRESSION,expected expression
+MIR_E_EXPECTED_IDENTIFIER,expected identifier
+MIR_E_EXPECTED_PATTERN,expected pattern
+MIR_E_EXPECTED_TYPE,expected type
+MIR_E_EXPORT_CONFLICT,export conflict
+MIR_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+MIR_E_GENERIC_BOUND_FAILED,generic bound failed
+MIR_E_IMPORT_CYCLE,import cycle
+MIR_E_IMPORT_NOT_FOUND,import not found
+MIR_E_INVALID_ATTRIBUTE,invalid attribute
+MIR_E_INVALID_BLOCK,invalid block
+MIR_E_INVALID_BORROW,invalid borrow
+MIR_E_INVALID_CALL,invalid call
+MIR_E_INVALID_CAST,invalid cast
+MIR_E_INVALID_DECLARATION,invalid declaration
+MIR_E_INVALID_DEREF,invalid deref
+MIR_E_INVALID_EXPRESSION,invalid expression
+MIR_E_INVALID_INDEX,invalid index
+MIR_E_INVALID_LITERAL,invalid literal
+MIR_E_INVALID_MODIFIER,invalid modifier
+MIR_E_INVALID_MOVE,invalid move
+MIR_E_INVALID_OPERAND,invalid operand
+MIR_E_INVALID_OPERATOR,invalid operator
+MIR_E_INVALID_PATTERN,invalid pattern
+MIR_E_INVALID_PLACE,invalid place
+MIR_E_INVALID_STATEMENT,invalid statement
+MIR_E_INVALID_TERMINATOR,invalid terminator
+MIR_E_LIFETIME_TOO_SHORT,lifetime too short
+MIR_E_LINK_FAILED,link failed
+MIR_E_MACRO_EXPANSION_FAILED,macro expansion failed
+MIR_E_MACRO_NOT_FOUND,macro not found
+MIR_E_MACRO_RECURSION,macro recursion
+MIR_E_MISSING_BODY,missing body
+MIR_E_MISSING_RETURN,missing return
+MIR_E_MUTABILITY_CONFLICT,mutability conflict
+MIR_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+MIR_E_PRIVATE_SYMBOL,private symbol
+MIR_E_RUNTIME_PANIC,runtime panic
+MIR_E_TRAIT_AMBIGUOUS,trait ambiguous
+MIR_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+MIR_E_UNBALANCED_DELIMITER,unbalanced delimiter
+MIR_E_UNEXPECTED_TOKEN,unexpected token
+MIR_E_UNKNOWN_MEMBER,unknown member
+MIR_E_UNKNOWN_MODULE,unknown module
+MIR_E_UNKNOWN_NAME,unknown name
+MIR_E_UNKNOWN_TYPE,unknown type
+MIR_E_UNREACHABLE_BLOCK,unreachable block
+MIR_E_UNREACHABLE_PATTERN,unreachable pattern
+MIR_E_UNSUPPORTED_TARGET,unsupported target
+MIR_E_USE_AFTER_DROP,use after drop
+MIR_E_USE_AFTER_MOVE,use after move
+MIR_E_USE_BEFORE_INIT,use before init
+MIR_E_VERIFICATION_FAILED,verification failed
+MODULE_E_ABI_MISMATCH,abi mismatch
+MODULE_E_AMBIGUOUS_NAME,ambiguous name
+MODULE_E_ARGUMENT_MISMATCH,argument mismatch
+MODULE_E_ARITY_MISMATCH,arity mismatch
+MODULE_E_ASSIGNMENT_MISMATCH,assignment mismatch
+MODULE_E_BORROW_CONFLICT,borrow conflict
+MODULE_E_BRANCH_MISMATCH,branch mismatch
+MODULE_E_CONST_CYCLE,const cycle
+MODULE_E_CONST_DIVISION_BY_ZERO,const division by zero
+MODULE_E_CONST_OVERFLOW,const overflow
+MODULE_E_CONST_REQUIRED,const required
+MODULE_E_DANGLING_REFERENCE,dangling reference
+MODULE_E_DOUBLE_DROP,double drop
+MODULE_E_DUPLICATE_NAME,duplicate name
+MODULE_E_EXPECTED_BLOCK,expected block
+MODULE_E_EXPECTED_DELIMITER,expected delimiter
+MODULE_E_EXPECTED_EXPRESSION,expected expression
+MODULE_E_EXPECTED_IDENTIFIER,expected identifier
+MODULE_E_EXPECTED_PATTERN,expected pattern
+MODULE_E_EXPECTED_TYPE,expected type
+MODULE_E_EXPORT_CONFLICT,export conflict
+MODULE_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+MODULE_E_GENERIC_BOUND_FAILED,generic bound failed
+MODULE_E_IMPORT_CYCLE,import cycle
+MODULE_E_IMPORT_NOT_FOUND,import not found
+MODULE_E_INVALID_ATTRIBUTE,invalid attribute
+MODULE_E_INVALID_BORROW,invalid borrow
+MODULE_E_INVALID_CALL,invalid call
+MODULE_E_INVALID_CAST,invalid cast
+MODULE_E_INVALID_DECLARATION,invalid declaration
+MODULE_E_INVALID_DEREF,invalid deref
+MODULE_E_INVALID_EXPRESSION,invalid expression
+MODULE_E_INVALID_INDEX,invalid index
+MODULE_E_INVALID_LITERAL,invalid literal
+MODULE_E_INVALID_MODIFIER,invalid modifier
+MODULE_E_INVALID_MOVE,invalid move
+MODULE_E_INVALID_OPERATOR,invalid operator
+MODULE_E_INVALID_PATTERN,invalid pattern
+MODULE_E_INVALID_STATEMENT,invalid statement
+MODULE_E_LIFETIME_TOO_SHORT,lifetime too short
+MODULE_E_LINK_FAILED,link failed
+MODULE_E_MACRO_EXPANSION_FAILED,macro expansion failed
+MODULE_E_MACRO_NOT_FOUND,macro not found
+MODULE_E_MACRO_RECURSION,macro recursion
+MODULE_E_MISSING_BODY,missing body
+MODULE_E_MISSING_RETURN,missing return
+MODULE_E_MUTABILITY_CONFLICT,mutability conflict
+MODULE_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+MODULE_E_PRIVATE_SYMBOL,private symbol
+MODULE_E_RUNTIME_PANIC,runtime panic
+MODULE_E_TRAIT_AMBIGUOUS,trait ambiguous
+MODULE_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+MODULE_E_UNBALANCED_DELIMITER,unbalanced delimiter
+MODULE_E_UNEXPECTED_TOKEN,unexpected token
+MODULE_E_UNKNOWN_MEMBER,unknown member
+MODULE_E_UNKNOWN_MODULE,unknown module
+MODULE_E_UNKNOWN_NAME,unknown name
+MODULE_E_UNKNOWN_TYPE,unknown type
+MODULE_E_UNREACHABLE_PATTERN,unreachable pattern
+MODULE_E_UNSUPPORTED_TARGET,unsupported target
+MODULE_E_USE_AFTER_DROP,use after drop
+MODULE_E_USE_AFTER_MOVE,use after move
+MODULE_E_USE_BEFORE_INIT,use before init
+NAME_E_ABI_MISMATCH,abi mismatch
+NAME_E_AMBIGUOUS_NAME,ambiguous name
+NAME_E_ARGUMENT_MISMATCH,argument mismatch
+NAME_E_ARITY_MISMATCH,arity mismatch
+NAME_E_ASSIGNMENT_MISMATCH,assignment mismatch
+NAME_E_BORROW_CONFLICT,borrow conflict
+NAME_E_BRANCH_MISMATCH,branch mismatch
+NAME_E_CONST_CYCLE,const cycle
+NAME_E_CONST_DIVISION_BY_ZERO,const division by zero
+NAME_E_CONST_OVERFLOW,const overflow
+NAME_E_CONST_REQUIRED,const required
+NAME_E_DANGLING_REFERENCE,dangling reference
+NAME_E_DOUBLE_DROP,double drop
+NAME_E_DUPLICATE_NAME,duplicate name
+NAME_E_EXPECTED_BLOCK,expected block
+NAME_E_EXPECTED_DELIMITER,expected delimiter
+NAME_E_EXPECTED_EXPRESSION,expected expression
+NAME_E_EXPECTED_IDENTIFIER,expected identifier
+NAME_E_EXPECTED_PATTERN,expected pattern
+NAME_E_EXPECTED_TYPE,expected type
+NAME_E_EXPORT_CONFLICT,export conflict
+NAME_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+NAME_E_GENERIC_BOUND_FAILED,generic bound failed
+NAME_E_IMPORT_CYCLE,import cycle
+NAME_E_IMPORT_NOT_FOUND,import not found
+NAME_E_INVALID_ATTRIBUTE,invalid attribute
+NAME_E_INVALID_BORROW,invalid borrow
+NAME_E_INVALID_CALL,invalid call
+NAME_E_INVALID_CAST,invalid cast
+NAME_E_INVALID_DECLARATION,invalid declaration
+NAME_E_INVALID_DEREF,invalid deref
+NAME_E_INVALID_EXPRESSION,invalid expression
+NAME_E_INVALID_INDEX,invalid index
+NAME_E_INVALID_LITERAL,invalid literal
+NAME_E_INVALID_MODIFIER,invalid modifier
+NAME_E_INVALID_MOVE,invalid move
+NAME_E_INVALID_OPERATOR,invalid operator
+NAME_E_INVALID_PATTERN,invalid pattern
+NAME_E_INVALID_STATEMENT,invalid statement
+NAME_E_LIFETIME_TOO_SHORT,lifetime too short
+NAME_E_LINK_FAILED,link failed
+NAME_E_MACRO_EXPANSION_FAILED,macro expansion failed
+NAME_E_MACRO_NOT_FOUND,macro not found
+NAME_E_MACRO_RECURSION,macro recursion
+NAME_E_MISSING_BODY,missing body
+NAME_E_MISSING_RETURN,missing return
+NAME_E_MUTABILITY_CONFLICT,mutability conflict
+NAME_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+NAME_E_PRIVATE_SYMBOL,private symbol
+NAME_E_RUNTIME_PANIC,runtime panic
+NAME_E_TRAIT_AMBIGUOUS,trait ambiguous
+NAME_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+NAME_E_UNBALANCED_DELIMITER,unbalanced delimiter
+NAME_E_UNEXPECTED_TOKEN,unexpected token
+NAME_E_UNKNOWN_MEMBER,unknown member
+NAME_E_UNKNOWN_MODULE,unknown module
+NAME_E_UNKNOWN_NAME,unknown name
+NAME_E_UNKNOWN_TYPE,unknown type
+NAME_E_UNREACHABLE_PATTERN,unreachable pattern
+NAME_E_UNSUPPORTED_TARGET,unsupported target
+NAME_E_USE_AFTER_DROP,use after drop
+NAME_E_USE_AFTER_MOVE,use after move
+NAME_E_USE_BEFORE_INIT,use before init
+OWNERSHIP_E_ABI_MISMATCH,abi mismatch
+OWNERSHIP_E_AMBIGUOUS_NAME,ambiguous name
+OWNERSHIP_E_ARGUMENT_MISMATCH,argument mismatch
+OWNERSHIP_E_ARITY_MISMATCH,arity mismatch
+OWNERSHIP_E_ASSIGNMENT_MISMATCH,assignment mismatch
+OWNERSHIP_E_BORROW_CONFLICT,borrow conflict
+OWNERSHIP_E_BRANCH_MISMATCH,branch mismatch
+OWNERSHIP_E_CONST_CYCLE,const cycle
+OWNERSHIP_E_CONST_DIVISION_BY_ZERO,const division by zero
+OWNERSHIP_E_CONST_OVERFLOW,const overflow
+OWNERSHIP_E_CONST_REQUIRED,const required
+OWNERSHIP_E_DANGLING_REFERENCE,dangling reference
+OWNERSHIP_E_DOUBLE_DROP,double drop
+OWNERSHIP_E_DUPLICATE_NAME,duplicate name
+OWNERSHIP_E_EXPECTED_BLOCK,expected block
+OWNERSHIP_E_EXPECTED_DELIMITER,expected delimiter
+OWNERSHIP_E_EXPECTED_EXPRESSION,expected expression
+OWNERSHIP_E_EXPECTED_IDENTIFIER,expected identifier
+OWNERSHIP_E_EXPECTED_PATTERN,expected pattern
+OWNERSHIP_E_EXPECTED_TYPE,expected type
+OWNERSHIP_E_EXPORT_CONFLICT,export conflict
+OWNERSHIP_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+OWNERSHIP_E_GENERIC_BOUND_FAILED,generic bound failed
+OWNERSHIP_E_IMPORT_CYCLE,import cycle
+OWNERSHIP_E_IMPORT_NOT_FOUND,import not found
+OWNERSHIP_E_INVALID_ATTRIBUTE,invalid attribute
+OWNERSHIP_E_INVALID_BORROW,invalid borrow
+OWNERSHIP_E_INVALID_CALL,invalid call
+OWNERSHIP_E_INVALID_CAST,invalid cast
+OWNERSHIP_E_INVALID_DECLARATION,invalid declaration
+OWNERSHIP_E_INVALID_DEREF,invalid deref
+OWNERSHIP_E_INVALID_EXPRESSION,invalid expression
+OWNERSHIP_E_INVALID_INDEX,invalid index
+OWNERSHIP_E_INVALID_LITERAL,invalid literal
+OWNERSHIP_E_INVALID_MODIFIER,invalid modifier
+OWNERSHIP_E_INVALID_MOVE,invalid move
+OWNERSHIP_E_INVALID_OPERATOR,invalid operator
+OWNERSHIP_E_INVALID_PATTERN,invalid pattern
+OWNERSHIP_E_INVALID_STATEMENT,invalid statement
+OWNERSHIP_E_LIFETIME_TOO_SHORT,lifetime too short
+OWNERSHIP_E_LINK_FAILED,link failed
+OWNERSHIP_E_MACRO_EXPANSION_FAILED,macro expansion failed
+OWNERSHIP_E_MACRO_NOT_FOUND,macro not found
+OWNERSHIP_E_MACRO_RECURSION,macro recursion
+OWNERSHIP_E_MISSING_BODY,missing body
+OWNERSHIP_E_MISSING_RETURN,missing return
+OWNERSHIP_E_MUTABILITY_CONFLICT,mutability conflict
+OWNERSHIP_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+OWNERSHIP_E_PRIVATE_SYMBOL,private symbol
+OWNERSHIP_E_RUNTIME_PANIC,runtime panic
+OWNERSHIP_E_TRAIT_AMBIGUOUS,trait ambiguous
+OWNERSHIP_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+OWNERSHIP_E_UNBALANCED_DELIMITER,unbalanced delimiter
+OWNERSHIP_E_UNEXPECTED_TOKEN,unexpected token
+OWNERSHIP_E_UNKNOWN_MEMBER,unknown member
+OWNERSHIP_E_UNKNOWN_MODULE,unknown module
+OWNERSHIP_E_UNKNOWN_NAME,unknown name
+OWNERSHIP_E_UNKNOWN_TYPE,unknown type
+OWNERSHIP_E_UNREACHABLE_PATTERN,unreachable pattern
+OWNERSHIP_E_UNSUPPORTED_TARGET,unsupported target
+OWNERSHIP_E_USE_AFTER_DROP,use after drop
+OWNERSHIP_E_USE_AFTER_MOVE,use after move
+OWNERSHIP_E_USE_BEFORE_INIT,use before init
+P0001,unexpected top-level token
+P000_UNBALANCED,unclosed block
+PARSE_EXPECTED_BLOCK,parse expected block
+PARSE_EXPECTED_EXPR,parse expected expr
+PARSE_EXPECTED_IDENTIFIER,parse expected identifier
+PARSE_EXPECTED_PATTERN,parse expected pattern
+PARSE_EXPECTED_TYPE,parse expected type
+PARSE_E_EXPECTED_TOKEN,expected token
+PARSE_E_UNEXPECTED_TOKEN,unexpected token
+PATTR003,pattr003
+PLOOP,parser made no progress
+PPRIMARY999,unexpected expression token
+PSTMT007,expected assignment operator
+RUNTIME_E_ABI_MISMATCH,abi mismatch
+RUNTIME_E_AMBIGUOUS_NAME,ambiguous name
+RUNTIME_E_ARGUMENT_MISMATCH,argument mismatch
+RUNTIME_E_ARITY_MISMATCH,arity mismatch
+RUNTIME_E_ASSERT_FAILED,assert failed
+RUNTIME_E_ASSIGNMENT_MISMATCH,assignment mismatch
+RUNTIME_E_BORROW_CONFLICT,borrow conflict
+RUNTIME_E_BOUNDS_CHECK,bounds check
+RUNTIME_E_BRANCH_MISMATCH,branch mismatch
+RUNTIME_E_CONST_CYCLE,const cycle
+RUNTIME_E_CONST_DIVISION_BY_ZERO,const division by zero
+RUNTIME_E_CONST_OVERFLOW,const overflow
+RUNTIME_E_CONST_REQUIRED,const required
+RUNTIME_E_DANGLING_REFERENCE,dangling reference
+RUNTIME_E_DIVISION_BY_ZERO,division by zero
+RUNTIME_E_DOUBLE_DROP,double drop
+RUNTIME_E_DUPLICATE_NAME,duplicate name
+RUNTIME_E_EXPECTED_BLOCK,expected block
+RUNTIME_E_EXPECTED_DELIMITER,expected delimiter
+RUNTIME_E_EXPECTED_EXPRESSION,expected expression
+RUNTIME_E_EXPECTED_IDENTIFIER,expected identifier
+RUNTIME_E_EXPECTED_PATTERN,expected pattern
+RUNTIME_E_EXPECTED_TYPE,expected type
+RUNTIME_E_EXPORT_CONFLICT,export conflict
+RUNTIME_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+RUNTIME_E_GENERIC_BOUND_FAILED,generic bound failed
+RUNTIME_E_IMPORT_CYCLE,import cycle
+RUNTIME_E_IMPORT_NOT_FOUND,import not found
+RUNTIME_E_INVALID_ATTRIBUTE,invalid attribute
+RUNTIME_E_INVALID_BORROW,invalid borrow
+RUNTIME_E_INVALID_CALL,invalid call
+RUNTIME_E_INVALID_CAST,invalid cast
+RUNTIME_E_INVALID_DECLARATION,invalid declaration
+RUNTIME_E_INVALID_DEREF,invalid deref
+RUNTIME_E_INVALID_EXPRESSION,invalid expression
+RUNTIME_E_INVALID_INDEX,invalid index
+RUNTIME_E_INVALID_LITERAL,invalid literal
+RUNTIME_E_INVALID_MODIFIER,invalid modifier
+RUNTIME_E_INVALID_MOVE,invalid move
+RUNTIME_E_INVALID_OPERATOR,invalid operator
+RUNTIME_E_INVALID_PATTERN,invalid pattern
+RUNTIME_E_INVALID_STATEMENT,invalid statement
+RUNTIME_E_LIFETIME_TOO_SHORT,lifetime too short
+RUNTIME_E_LINK_FAILED,link failed
+RUNTIME_E_MACRO_EXPANSION_FAILED,macro expansion failed
+RUNTIME_E_MACRO_NOT_FOUND,macro not found
+RUNTIME_E_MACRO_RECURSION,macro recursion
+RUNTIME_E_MISSING_BODY,missing body
+RUNTIME_E_MISSING_RETURN,missing return
+RUNTIME_E_MUTABILITY_CONFLICT,mutability conflict
+RUNTIME_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+RUNTIME_E_NULL_DEREF,null deref
+RUNTIME_E_OUT_OF_MEMORY,out of memory
+RUNTIME_E_PANIC,panic
+RUNTIME_E_PRIVATE_SYMBOL,private symbol
+RUNTIME_E_RUNTIME_PANIC,runtime panic
+RUNTIME_E_STACK_OVERFLOW,stack overflow
+RUNTIME_E_TRAIT_AMBIGUOUS,trait ambiguous
+RUNTIME_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+RUNTIME_E_UNBALANCED_DELIMITER,unbalanced delimiter
+RUNTIME_E_UNEXPECTED_TOKEN,unexpected token
+RUNTIME_E_UNKNOWN_MEMBER,unknown member
+RUNTIME_E_UNKNOWN_MODULE,unknown module
+RUNTIME_E_UNKNOWN_NAME,unknown name
+RUNTIME_E_UNKNOWN_TYPE,unknown type
+RUNTIME_E_UNREACHABLE_PATTERN,unreachable pattern
+RUNTIME_E_UNSUPPORTED_TARGET,unsupported target
+RUNTIME_E_USE_AFTER_DROP,use after drop
+RUNTIME_E_USE_AFTER_MOVE,use after move
+RUNTIME_E_USE_BEFORE_INIT,use before init
+SEMA_E_DUPLICATE_BINDING,duplicate binding
+SEMA_E_DUPLICATE_ITEM,duplicate item
+SEMA_E_DUPLICATE_SYMBOL,duplicate symbol
+SEMA_E_INTERNAL,internal
+SEMA_E_INVALID_ASSIGN_TARGET,invalid assign target
+SEMA_E_INVALID_ATTRIBUTE,invalid attribute
+SEMA_E_INVALID_CONTROL_FLOW,invalid control flow
+SEMA_E_INVALID_EXPORT,invalid export
+SEMA_E_INVALID_HIR,invalid hir
+SEMA_E_INVALID_IMPORT,invalid import
+SEMA_E_INVALID_MODULE,invalid module
+SEMA_E_INVALID_VISIBILITY,invalid visibility
+SEMA_E_MISSING_BINDING,missing binding
+SEMA_E_UNDECLARED_TARGET,undeclared target
+SEMA_E_UNKNOWN_SYMBOL,unknown symbol
+SYNTAX_E_ABI_MISMATCH,abi mismatch
+SYNTAX_E_AMBIGUOUS_NAME,ambiguous name
+SYNTAX_E_ARGUMENT_MISMATCH,argument mismatch
+SYNTAX_E_ARITY_MISMATCH,arity mismatch
+SYNTAX_E_ASSIGNMENT_MISMATCH,assignment mismatch
+SYNTAX_E_BORROW_CONFLICT,borrow conflict
+SYNTAX_E_BRANCH_MISMATCH,branch mismatch
+SYNTAX_E_CONST_CYCLE,const cycle
+SYNTAX_E_CONST_DIVISION_BY_ZERO,const division by zero
+SYNTAX_E_CONST_OVERFLOW,const overflow
+SYNTAX_E_CONST_REQUIRED,const required
+SYNTAX_E_DANGLING_REFERENCE,dangling reference
+SYNTAX_E_DOUBLE_DROP,double drop
+SYNTAX_E_DUPLICATE_NAME,duplicate name
+SYNTAX_E_EXPECTED_BLOCK,expected block
+SYNTAX_E_EXPECTED_DELIMITER,expected delimiter
+SYNTAX_E_EXPECTED_EXPRESSION,expected expression
+SYNTAX_E_EXPECTED_IDENTIFIER,expected identifier
+SYNTAX_E_EXPECTED_PATTERN,expected pattern
+SYNTAX_E_EXPECTED_TYPE,expected type
+SYNTAX_E_EXPORT_CONFLICT,export conflict
+SYNTAX_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+SYNTAX_E_GENERIC_BOUND_FAILED,generic bound failed
+SYNTAX_E_IMPORT_CYCLE,import cycle
+SYNTAX_E_IMPORT_NOT_FOUND,import not found
+SYNTAX_E_INVALID_ATTRIBUTE,invalid attribute
+SYNTAX_E_INVALID_BORROW,invalid borrow
+SYNTAX_E_INVALID_CALL,invalid call
+SYNTAX_E_INVALID_CAST,invalid cast
+SYNTAX_E_INVALID_DECLARATION,invalid declaration
+SYNTAX_E_INVALID_DEREF,invalid deref
+SYNTAX_E_INVALID_EXPRESSION,invalid expression
+SYNTAX_E_INVALID_INDEX,invalid index
+SYNTAX_E_INVALID_LITERAL,invalid literal
+SYNTAX_E_INVALID_MODIFIER,invalid modifier
+SYNTAX_E_INVALID_MOVE,invalid move
+SYNTAX_E_INVALID_OPERATOR,invalid operator
+SYNTAX_E_INVALID_PATTERN,invalid pattern
+SYNTAX_E_INVALID_STATEMENT,invalid statement
+SYNTAX_E_LIFETIME_TOO_SHORT,lifetime too short
+SYNTAX_E_LINK_FAILED,link failed
+SYNTAX_E_MACRO_EXPANSION_FAILED,macro expansion failed
+SYNTAX_E_MACRO_NOT_FOUND,macro not found
+SYNTAX_E_MACRO_RECURSION,macro recursion
+SYNTAX_E_MISSING_BODY,missing body
+SYNTAX_E_MISSING_RETURN,missing return
+SYNTAX_E_MUTABILITY_CONFLICT,mutability conflict
+SYNTAX_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+SYNTAX_E_PRIVATE_SYMBOL,private symbol
+SYNTAX_E_RUNTIME_PANIC,runtime panic
+SYNTAX_E_TRAIT_AMBIGUOUS,trait ambiguous
+SYNTAX_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+SYNTAX_E_UNBALANCED_DELIMITER,unbalanced delimiter
+SYNTAX_E_UNEXPECTED_TOKEN,unexpected token
+SYNTAX_E_UNKNOWN_MEMBER,unknown member
+SYNTAX_E_UNKNOWN_MODULE,unknown module
+SYNTAX_E_UNKNOWN_NAME,unknown name
+SYNTAX_E_UNKNOWN_TYPE,unknown type
+SYNTAX_E_UNREACHABLE_PATTERN,unreachable pattern
+SYNTAX_E_UNSUPPORTED_TARGET,unsupported target
+SYNTAX_E_USE_AFTER_DROP,use after drop
+SYNTAX_E_USE_AFTER_MOVE,use after move
+SYNTAX_E_USE_BEFORE_INIT,use before init
+TRAIT_E_ABI_MISMATCH,abi mismatch
+TRAIT_E_AMBIGUOUS_NAME,ambiguous name
+TRAIT_E_ARGUMENT_MISMATCH,argument mismatch
+TRAIT_E_ARITY_MISMATCH,arity mismatch
+TRAIT_E_ASSIGNMENT_MISMATCH,assignment mismatch
+TRAIT_E_BORROW_CONFLICT,borrow conflict
+TRAIT_E_BRANCH_MISMATCH,branch mismatch
+TRAIT_E_CONST_CYCLE,const cycle
+TRAIT_E_CONST_DIVISION_BY_ZERO,const division by zero
+TRAIT_E_CONST_OVERFLOW,const overflow
+TRAIT_E_CONST_REQUIRED,const required
+TRAIT_E_DANGLING_REFERENCE,dangling reference
+TRAIT_E_DOUBLE_DROP,double drop
+TRAIT_E_DUPLICATE_NAME,duplicate name
+TRAIT_E_EXPECTED_BLOCK,expected block
+TRAIT_E_EXPECTED_DELIMITER,expected delimiter
+TRAIT_E_EXPECTED_EXPRESSION,expected expression
+TRAIT_E_EXPECTED_IDENTIFIER,expected identifier
+TRAIT_E_EXPECTED_PATTERN,expected pattern
+TRAIT_E_EXPECTED_TYPE,expected type
+TRAIT_E_EXPORT_CONFLICT,export conflict
+TRAIT_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+TRAIT_E_GENERIC_BOUND_FAILED,generic bound failed
+TRAIT_E_IMPORT_CYCLE,import cycle
+TRAIT_E_IMPORT_NOT_FOUND,import not found
+TRAIT_E_INVALID_ATTRIBUTE,invalid attribute
+TRAIT_E_INVALID_BORROW,invalid borrow
+TRAIT_E_INVALID_CALL,invalid call
+TRAIT_E_INVALID_CAST,invalid cast
+TRAIT_E_INVALID_DECLARATION,invalid declaration
+TRAIT_E_INVALID_DEREF,invalid deref
+TRAIT_E_INVALID_EXPRESSION,invalid expression
+TRAIT_E_INVALID_INDEX,invalid index
+TRAIT_E_INVALID_LITERAL,invalid literal
+TRAIT_E_INVALID_MODIFIER,invalid modifier
+TRAIT_E_INVALID_MOVE,invalid move
+TRAIT_E_INVALID_OPERATOR,invalid operator
+TRAIT_E_INVALID_PATTERN,invalid pattern
+TRAIT_E_INVALID_STATEMENT,invalid statement
+TRAIT_E_LIFETIME_TOO_SHORT,lifetime too short
+TRAIT_E_LINK_FAILED,link failed
+TRAIT_E_MACRO_EXPANSION_FAILED,macro expansion failed
+TRAIT_E_MACRO_NOT_FOUND,macro not found
+TRAIT_E_MACRO_RECURSION,macro recursion
+TRAIT_E_MISSING_BODY,missing body
+TRAIT_E_MISSING_RETURN,missing return
+TRAIT_E_MUTABILITY_CONFLICT,mutability conflict
+TRAIT_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+TRAIT_E_PRIVATE_SYMBOL,private symbol
+TRAIT_E_RUNTIME_PANIC,runtime panic
+TRAIT_E_TRAIT_AMBIGUOUS,trait ambiguous
+TRAIT_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+TRAIT_E_UNBALANCED_DELIMITER,unbalanced delimiter
+TRAIT_E_UNEXPECTED_TOKEN,unexpected token
+TRAIT_E_UNKNOWN_MEMBER,unknown member
+TRAIT_E_UNKNOWN_MODULE,unknown module
+TRAIT_E_UNKNOWN_NAME,unknown name
+TRAIT_E_UNKNOWN_TYPE,unknown type
+TRAIT_E_UNREACHABLE_PATTERN,unreachable pattern
+TRAIT_E_UNSUPPORTED_TARGET,unsupported target
+TRAIT_E_USE_AFTER_DROP,use after drop
+TRAIT_E_USE_AFTER_MOVE,use after move
+TRAIT_E_USE_BEFORE_INIT,use before init
+TYPE0001,type0001
+TYPE0002,type0002
+TYPE0003,type0003
+TYPE0004,type0004
+TYPE0005,type0005
+TYPE0006,type0006
+TYPE0007,type0007
+TYPE0008,type0008
+TYPE0009,type0009
+TYPE0010,type0010
+TYPE9999,type9999
+TYPECK_E_ARGUMENT_MISMATCH,call argument type mismatch
+TYPECK_E_ASSIGN_MISMATCH,assignment type mismatch
+TYPECK_E_BINARY_MISMATCH,binary mismatch
+TYPECK_E_CALL_ARITY,wrong number of call arguments
+TYPECK_E_COMPARE_MISMATCH,compare mismatch
+TYPECK_E_CONDITION_TYPE,condition type
+TYPECK_E_IF_BRANCH_MISMATCH,if branch mismatch
+TYPECK_E_INDEX_TYPE,index type
+TYPECK_E_INTERNAL,internal
+TYPECK_E_INVALID_CALL_TARGET,invalid call target
+TYPECK_E_INVALID_CAST,invalid cast
+TYPECK_E_INVALID_DEREF,invalid deref
+TYPECK_E_INVALID_EXPR,invalid expr
+TYPECK_E_INVALID_HIR,invalid hir
+TYPECK_E_INVALID_INDEX_TARGET,invalid index target
+TYPECK_E_MALFORMED_BINARY,malformed binary
+TYPECK_E_MALFORMED_BORROW,malformed borrow
+TYPECK_E_MALFORMED_CAST,malformed cast
+TYPECK_E_MALFORMED_IF,malformed if
+TYPECK_E_MALFORMED_INDEX,malformed index
+TYPECK_E_MALFORMED_MEMBER,malformed member
+TYPECK_E_MALFORMED_UNARY,malformed unary
+TYPECK_E_MATCH_NON_EXHAUSTIVE,match non exhaustive
+TYPECK_E_UNARY_MISMATCH,unary mismatch
+TYPECK_E_UNKNOWN_ITEM,unknown item
+TYPECK_E_UNKNOWN_MEMBER,unknown member
+TYPECK_E_UNKNOWN_NAME,unknown name
+TYPECK_E_UNKNOWN_TYPE,unknown type
+TYPECK_E_USE_AFTER_MOVE,use after move
+TYPECK_E_USE_BEFORE_INIT,use before init
+TYPECK_W_UNRESOLVED_NAME,unresolved name
+TYPE_E_ABI_MISMATCH,abi mismatch
+TYPE_E_AMBIGUOUS_NAME,ambiguous name
+TYPE_E_ARGUMENT_MISMATCH,argument mismatch
+TYPE_E_ARITY_MISMATCH,arity mismatch
+TYPE_E_ASSIGNMENT_MISMATCH,assignment mismatch
+TYPE_E_BORROW_CONFLICT,borrow conflict
+TYPE_E_BRANCH_MISMATCH,branch mismatch
+TYPE_E_CONST_CYCLE,const cycle
+TYPE_E_CONST_DIVISION_BY_ZERO,const division by zero
+TYPE_E_CONST_OVERFLOW,const overflow
+TYPE_E_CONST_REQUIRED,const required
+TYPE_E_DANGLING_REFERENCE,dangling reference
+TYPE_E_DOUBLE_DROP,double drop
+TYPE_E_DUPLICATE_NAME,duplicate name
+TYPE_E_EXPECTED_BLOCK,expected block
+TYPE_E_EXPECTED_DELIMITER,expected delimiter
+TYPE_E_EXPECTED_EXPRESSION,expected expression
+TYPE_E_EXPECTED_IDENTIFIER,expected identifier
+TYPE_E_EXPECTED_PATTERN,expected pattern
+TYPE_E_EXPECTED_TYPE,expected type
+TYPE_E_EXPORT_CONFLICT,export conflict
+TYPE_E_GENERIC_ARGUMENT_MISSING,generic argument missing
+TYPE_E_GENERIC_BOUND_FAILED,generic bound failed
+TYPE_E_IMPORT_CYCLE,import cycle
+TYPE_E_IMPORT_NOT_FOUND,import not found
+TYPE_E_INVALID_ATTRIBUTE,invalid attribute
+TYPE_E_INVALID_BORROW,invalid borrow
+TYPE_E_INVALID_CALL,invalid call
+TYPE_E_INVALID_CAST,invalid cast
+TYPE_E_INVALID_DECLARATION,invalid declaration
+TYPE_E_INVALID_DEREF,invalid deref
+TYPE_E_INVALID_EXPRESSION,invalid expression
+TYPE_E_INVALID_INDEX,invalid index
+TYPE_E_INVALID_LITERAL,invalid literal
+TYPE_E_INVALID_MODIFIER,invalid modifier
+TYPE_E_INVALID_MOVE,invalid move
+TYPE_E_INVALID_OPERATOR,invalid operator
+TYPE_E_INVALID_PATTERN,invalid pattern
+TYPE_E_INVALID_STATEMENT,invalid statement
+TYPE_E_LIFETIME_TOO_SHORT,lifetime too short
+TYPE_E_LINK_FAILED,link failed
+TYPE_E_MACRO_EXPANSION_FAILED,macro expansion failed
+TYPE_E_MACRO_NOT_FOUND,macro not found
+TYPE_E_MACRO_RECURSION,macro recursion
+TYPE_E_MISSING_BODY,missing body
+TYPE_E_MISSING_RETURN,missing return
+TYPE_E_MUTABILITY_CONFLICT,mutability conflict
+TYPE_E_NON_EXHAUSTIVE_MATCH,non exhaustive match
+TYPE_E_PRIVATE_SYMBOL,private symbol
+TYPE_E_RUNTIME_PANIC,runtime panic
+TYPE_E_TRAIT_AMBIGUOUS,trait ambiguous
+TYPE_E_TRAIT_NOT_IMPLEMENTED,trait not implemented
+TYPE_E_UNBALANCED_DELIMITER,unbalanced delimiter
+TYPE_E_UNEXPECTED_TOKEN,unexpected token
+TYPE_E_UNKNOWN_MEMBER,unknown member
+TYPE_E_UNKNOWN_MODULE,unknown module
+TYPE_E_UNKNOWN_NAME,unknown name
+TYPE_E_UNKNOWN_TYPE,unknown type
+TYPE_E_UNREACHABLE_PATTERN,unreachable pattern
+TYPE_E_UNSUPPORTED_TARGET,unsupported target
+TYPE_E_USE_AFTER_DROP,use after drop
+TYPE_E_USE_AFTER_MOVE,use after move
+TYPE_E_USE_BEFORE_INIT,use before init
+ambiguous_import_path,ambiguous import path
+duplicate_entry_name,duplicate entry name
+duplicate_import_binding,duplicate import binding
+duplicate_local_declaration_name,duplicate local declaration name
+duplicate_pattern_binding,duplicate pattern binding
+duplicate_share_declaration,duplicate share declaration
+duplicate_symbol_in_share_list,duplicate symbol in share list
+entry_module_path_must_be_canonical,entry module path must be canonical
+expected,expected '}'
+expected_case_or_otherwise_in_match,expected 'case' or 'otherwise' in match
+expected_end,expected 'end'
+expected_expression,expected expression
+expected_identifier,expected identifier
+expected_pattern,expected pattern
+expected_proc_after_attribute,expected proc after attribute
+expected_top_level_declaration,expected top-level declaration
+expected_type,expected type
+experimental_module_import_denied,experimental module import denied
+expression_is_not_callable,expression is not callable
+extern_proc_cannot_have_a_body,extern proc cannot have a body
+forbidden_expression_syntax_in_strict_core_mode,forbidden expression syntax in strict-core mode
+forbidden_statement_syntax_in_strict_core_mode,forbidden statement syntax in strict-core mode
+forbidden_top_level_syntax_in_strict_core_mode,forbidden top-level syntax in strict-core mode
+generic_type_requires_at_least_one_argument,generic type requires at least one argument
+generic_type_requires_at_least_one_type_argument,generic type requires at least one type argument
+import_binding_conflicts_with_local_declaration,import binding conflicts with local declaration
+internal_module_import_denied,internal module import denied
+invalid_cast_between_signed_and_unsigned_values,invalid cast between signed and unsigned values
+invoke_has_no_callee,invoke has no callee
+legacy_import_path_is_deprecated,legacy import path is deprecated
+module_alias_member_not_exported,module alias member not exported
+proc_may_exit_without_returning_a_value,proc may exit without returning a value
+proc_requires_a_body_unless_marked_extern,proc requires a body unless marked #[extern]
+qualified_type_member_not_found,qualified type member not found
+re_export_symbol_conflict,re-export symbol conflict
+select_branch_must_be_a_when_statement,select branch must be a when statement
+select_requires_at_least_one_when_branch,select requires at least one when branch
+share_references_unknown_symbol,share references unknown symbol
+stdlib_module_denied_by_active_stdlib_profile,stdlib module denied by active stdlib profile
+stdlib_module_not_found,stdlib module not found
+strict_imports_forbids_non_canonical_import_paths,strict-imports forbids non-canonical import paths
+strict_imports_forbids_unused_import_aliases,strict-imports forbids unused import aliases
+strict_imports_requires_explicit_alias,strict-imports requires explicit alias
+strict_modules_forbids_glob_imports,strict-modules forbids glob imports
+symbol_not_exported_by_module,symbol not exported by module
+type_alias_requires_a_target_type,type alias requires a target type
+unexpected_hir_decl_kind,unexpected HIR decl kind
+unexpected_hir_expr_kind,unexpected HIR expr kind
+unexpected_hir_pattern_kind,unexpected HIR pattern kind
+unexpected_hir_stmt_kind,unexpected HIR stmt kind
+unexpected_hir_type_kind,unexpected HIR type kind
+unknown_generic_base_type,unknown generic base type
+unknown_identifier,unknown identifier
+unknown_type_did_you_mean_a_built_in_like_int_i32_i64_i128_u32_u64_u128_bool_string,unknown type (did you mean a built-in like int/i32/i64/i128/u32/u64/u128/bool/string?)
+unsupported_expression_in_hir,unsupported expression in HIR
+unsupported_pattern_in_hir,unsupported pattern in HIR
+unsupported_statement_in_hir,unsupported statement in HIR
+unsupported_type,unsupported type


### PR DESCRIPTION
Exports English diagnostics messages to pkgout/diagnostics_for_translation.csv for translators. This PR contains a single CSV file with keys and English source texts. Please use it to produce translations for locales; after translations are ready we can update locales/*/diagnostics.ftl accordingly.